### PR TITLE
Make battery voltage / current filter cutoffs configurable - Policy on Betaflight features

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -681,6 +681,8 @@ const clivalue_t valueTable[] = {
     { "use_cbat_alerts",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, useConsumptionAlerts) },
     { "cbat_alert_percent",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, consumptionWarningPercentage) },
     { "vbat_cutoff_percent",        VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, lvcPercentage) },
+    { "vbat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatLpfPeriod) },
+    { "ibat_lpf_period",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, ibatLpfPeriod) },
 
 //  PG_VOLTAGE_SENSOR_ADC_CONFIG
     { "vbat_scale",                 VAR_UINT8  | MASTER_VALUE, .config.minmax = { VBAT_SCALE_MIN, VBAT_SCALE_MAX }, PG_VOLTAGE_SENSOR_ADC_CONFIG, offsetof(voltageSensorADCConfig_t, vbatscale) },

--- a/src/main/sensors/current.c
+++ b/src/main/sensors/current.c
@@ -23,6 +23,7 @@
 #include "string.h"
 
 #include "platform.h"
+
 #include "build/build_config.h"
 #include "build/debug.h"
 
@@ -34,11 +35,12 @@
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
-#include "config/config_reset.h"
 
 #include "sensors/adcinternal.h"
-#include "sensors/current.h"
+#include "sensors/battery.h"
 #include "sensors/esc_sensor.h"
+
+#include "current.h"
 
 const char * const currentMeterSourceNames[CURRENT_METER_COUNT] = {
     "NONE", "ADC", "VIRTUAL", "ESC", "MSP"
@@ -86,7 +88,6 @@ void currentMeterReset(currentMeter_t *meter)
 // ADC/Virtual shared
 //
 
-#define IBAT_LPF_FREQ  0.4f
 static biquadFilter_t adciBatFilter;
 
 #ifndef CURRENT_METER_SCALE_DEFAULT
@@ -140,7 +141,7 @@ currentMeterADCState_t currentMeterADCState;
 void currentMeterADCInit(void)
 {
     memset(&currentMeterADCState, 0, sizeof(currentMeterADCState_t));
-    biquadFilterInitLPF(&adciBatFilter, IBAT_LPF_FREQ, HZ_TO_INTERVAL_US(50));
+    biquadFilterInitLPF(&adciBatFilter, GET_BATTERY_LPF_FREQUENCY(batteryConfig()->ibatLpfPeriod), HZ_TO_INTERVAL_US(50));
 }
 
 void currentMeterADCRefresh(int32_t lastUpdateAt)

--- a/src/main/sensors/voltage.c
+++ b/src/main/sensors/voltage.c
@@ -26,19 +26,22 @@
 
 #include "build/build_config.h"
 
-#include "common/maths.h"
 #include "common/filter.h"
+#include "common/maths.h"
 #include "common/utils.h"
+
+#include "config/config_reset.h"
 
 #include "drivers/adc.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
-#include "config/config_reset.h"
 
 #include "sensors/adcinternal.h"
-#include "sensors/voltage.h"
+#include "sensors/battery.h"
 #include "sensors/esc_sensor.h"
+
+#include "voltage.h"
 
 const char * const voltageMeterSourceNames[VOLTAGE_METER_COUNT] = {
     "NONE", "ADC", "ESC"
@@ -191,7 +194,7 @@ void voltageMeterADCInit(void)
         voltageMeterADCState_t *state = &voltageMeterADCStates[i];
         memset(state, 0, sizeof(voltageMeterADCState_t));
 
-        biquadFilterInitLPF(&state->filter, VBAT_LPF_FREQ, HZ_TO_INTERVAL_US(50));
+        biquadFilterInitLPF(&state->filter, GET_BATTERY_LPF_FREQUENCY(batteryConfig()->vbatLpfPeriod), HZ_TO_INTERVAL_US(50));
     }
 }
 
@@ -215,7 +218,7 @@ void voltageMeterESCInit(void)
 {
 #ifdef USE_ESC_SENSOR
     memset(&voltageMeterESCState, 0, sizeof(voltageMeterESCState_t));
-    biquadFilterInitLPF(&voltageMeterESCState.filter, VBAT_LPF_FREQ, HZ_TO_INTERVAL_US(50));
+    biquadFilterInitLPF(&voltageMeterESCState.filter, GET_BATTERY_LPF_FREQUENCY(batteryConfig()->vbatLpfPeriod), HZ_TO_INTERVAL_US(50));
 #endif
 }
 

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -67,8 +67,6 @@ typedef enum {
 #define VBAT_MULTIPLIER_MIN 1
 #define VBAT_MULTIPLIER_MAX 255
 
-#define VBAT_LPF_FREQ  0.1f
-
 #ifndef MAX_VOLTAGE_SENSOR_ADC
 #define MAX_VOLTAGE_SENSOR_ADC 1 // VBAT - some boards have external, 12V, 9V and 5V meters.
 #endif


### PR DESCRIPTION
I really like the way how betaflight 4.0 current and voltage are really "jumpy". On punchouts the displayed current value will be more close to the truth and during hangtime you can estimate your current battery voltage without sag.
In BF this was introduced in:
betaflight/betaflight#7447 +(betaflight/betaflight#7546)

However, I do not know how you handle porting Betaflight features into EmuFlight. 
- Will you copy features from BF one by one into EmuFlight when they are needed or wanted? (like this PR)
- Or will you some day rebase all the EmuFlight features on top of bf 4.x ?