### PR TITLE
Use v2font msp 1.44+ [skip ci]

### DIFF
--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -82,7 +82,7 @@
 
 // Map mode
 #define SYM_HOME       0x05
-#define SYM_AIRCRAFT   0x2A
+#define SYM_AIRCRAFT   0x40 //old school dungeon crawler @self
 #define SYM_RANGE_100  0x21
 #define SYM_RANGE_500  0x22
 #define SYM_RANGE_2500 0x23
@@ -225,6 +225,8 @@
 
 //Misc
 #define SYM_COLON 0x3A
+#define SYM_EXCL  0x21
+#define SYM_QUES  0x3F
 // Not available: #define SYM_ZERO_HALF_TRAILING_DOT 0xC0
 // Not available: #define SYM_ZERO_HALF_LEADING_DOT 0xD0
 #define SYM_ROLL  0x14

--- a/src/main/drivers/max7456_symbols.h
+++ b/src/main/drivers/max7456_symbols.h
@@ -81,8 +81,8 @@
 // Not available: #define SYM_CELLF      0xC3
 
 // Map mode
-#define SYM_HOME       0x04
-#define SYM_AIRCRAFT   0x05
+#define SYM_HOME       0x05
+#define SYM_AIRCRAFT   0x2A
 #define SYM_RANGE_100  0x21
 #define SYM_RANGE_500  0x22
 #define SYM_RANGE_2500 0x23
@@ -90,16 +90,19 @@
 #define SYM_DIRECTION  0x72
 
 // GPS Coordinates and Altitude
-// Not available: #define SYM_LAT 0xCA
-// Not available: #define SYM_LON 0xCB
-// Not available: #define SYM_ALT 0xCC
+#define SYM_LAT    0x89
+#define SYM_LON    0x98
+#define SYM_ALT    0x7F
+#define SYM_HOMEFLAG   0x11
+//#define SYM_TOTAL_DIST 0x71
+#define SYM_SPEED      0x70
 
 // GPS Mode and Autopilot
 // Not available: #define SYM_3DFIX     0xDF
 // Not available: #define SYM_HOLD      0xEF
 // Not available: #define SYM_G_HOME    0xFF
-#define SYM_GHOME     0x9D
-#define SYM_GHOME1    0x9E
+//#define SYM_GHOME     0x9D
+//#define SYM_GHOME1    0x9E
 // Not available: #define SYM_GHOLD     0xCD
 // Not available: #define SYM_GHOLD1    0xCE
 // Not available: #define SYM_GMISSION  0xB5
@@ -127,20 +130,20 @@
 // Not available: #define SYM_MAG11   0xB6
 
 // AH Center screen Graphics
-#define SYM_AH_CENTER_LINE        0x26
-#define SYM_AH_CENTER_LINE_RIGHT  0x27
-#define SYM_AH_CENTER             0x7E
-#define SYM_AH_RIGHT              0x02
-#define SYM_AH_LEFT               0x03
-#define SYM_AH_DECORATION_UP      0xC9
-#define SYM_AH_DECORATION_DOWN    0xCF
+#define SYM_AH_CENTER_LINE          0x72
+#define SYM_AH_CENTER               0x73
+#define SYM_AH_CENTER_LINE_RIGHT    0x74
+#define SYM_AH_RIGHT                0x02
+#define SYM_AH_LEFT                 0x03
+#define SYM_AH_DECORATION           0x13
 
 // AH Bars
 #define SYM_AH_BAR9_0 0x80
 
 // Temperature
-#define SYM_TEMP_F 0x0D
-#define SYM_TEMP_C 0x0E
+#define SYM_TEMP_F      0x0D
+#define SYM_TEMP_C      0x0E
+#define SYM_TEMPERATURE 0x7A
 
 // Batt evolution
 #define SYM_BATT_FULL   0x90
@@ -163,17 +166,19 @@
 
 // Unit Icon´s (Metric)
 #define SYM_MS          0x9F
-// Not available: #define SYM_KMH         0xA5
+#define SYM_KMH         0x9E
 // Not available: #define SYM_ALTM        0xA7
 // Not available: #define SYM_DISTHOME_M  0xBB
 #define SYM_M           0x0C
+#define SYM_KM          0x7D
 
 // Unit Icon´s (Imperial)
 #define SYM_FTS         0x99
-// Not available: #define SYM_MPH         0xA6
+#define SYM_MPH         0x9D
 // Not available: #define SYM_ALTFT       0xA8
 // Not available: #define SYM_DISTHOME_FT 0xB9
 #define SYM_FT          0x0F
+#define SYM_MILES       0x7E
 
 // Voltage and amperage
 #define SYM_VOLT  0x06
@@ -183,7 +188,7 @@
 
 // Flying Mode
 // Not available: #define SYM_ACRO      0xAE
-#define SYM_ACROGY    0x98
+//#define SYM_ACROGY    0x98
 // Not available: #define SYM_ACRO1     0xAF
 // Not available: #define SYM_STABLE    0xAC
 // Not available: #define SYM_STABLE1   0xAD
@@ -193,34 +198,37 @@
 // Not available: #define SYM_PASS1     0xAB
 // Not available: #define SYM_AIR       0xEA
 // Not available: #define SYM_AIR1      0xEB
-#define SYM_PLUS      0x89
+#define SYM_PLUS      0x2B
 
 // Note, these change with scrolling enabled (scrolling is TODO)
 //#define SYM_AH_DECORATION_LEFT 0x13
 //#define SYM_AH_DECORATION_RIGHT 0x13
-#define SYM_AH_DECORATION 0x13
+//#define SYM_AH_DECORATION 0x13
 
 // Time
 #define SYM_ON_M  0x9B
 #define SYM_FLY_M 0x9C
-#define SYM_ON_H  0x70
-#define SYM_FLY_H 0x71
+//#define SYM_ON_H  0x70
+//#define SYM_FLY_H 0x71
 // Not available: #define SYM_CLOCK 0xBC
 
 // Throttle Position (%)
 #define SYM_THR   0x04
-#define SYM_THR1  0x05
+#define SYM_THR1  0x04
 
 // RSSI
 #define SYM_RSSI 0x01
+#define LINK_QUALITY 0x7B
 
-// Menu cursor
+// Menu cursor //0x03
 #define SYM_CURSOR SYM_AH_LEFT
 
 //Misc
-#define SYM_COLON 0x2D
+#define SYM_COLON 0x3A
 // Not available: #define SYM_ZERO_HALF_TRAILING_DOT 0xC0
 // Not available: #define SYM_ZERO_HALF_LEADING_DOT 0xD0
+#define SYM_ROLL  0x14
+#define SYM_PITCH 0x15
 
 //sport
 // Not available: #define SYM_MIN 0xB3

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -991,7 +991,7 @@ static bool osdDrawSingleElement(uint8_t item)
 #ifdef USE_ESC_SENSOR
     case OSD_ESC_TMP:
         if (feature(FEATURE_ESC_SENSOR)) {
-            tfp_sprintf(buff, "%3d%c", osdConvertTemperatureToSelectedUnit(escDataCombined->temperature), osdGetTemperatureSymbolForSelectedUnit());
+            tfp_sprintf(buff, "%c%3d%c", SYM_TEMPERATURE, osdConvertTemperatureToSelectedUnit(escDataCombined->temperature), osdGetTemperatureSymbolForSelectedUnit());
         }
         break;
 
@@ -1018,7 +1018,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
 #ifdef USE_ADC_INTERNAL
     case OSD_CORE_TEMPERATURE:
-        tfp_sprintf(buff, "%3d%c", osdConvertTemperatureToSelectedUnit(getCoreTemperatureCelsius()), osdGetTemperatureSymbolForSelectedUnit());
+        tfp_sprintf(buff, "%c%3d%c", SYM_TEMPERATURE, osdConvertTemperatureToSelectedUnit(getCoreTemperatureCelsius()), osdGetTemperatureSymbolForSelectedUnit());
         break;
 #endif
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -522,7 +522,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
         } else {
             // We use this symbol when we don't have a FIX
-            buff[0] = SYM_COLON;
+            buff[0] = SYM_QUES;
         }
 
         buff[1] = 0;
@@ -535,7 +535,7 @@ static bool osdDrawSingleElement(uint8_t item)
             tfp_sprintf(buff, "%d%c", distance, osdGetMetersToSelectedUnitSymbol());
         } else {
             // We use this symbol when we don't have a FIX
-            buff[0] = SYM_COLON;
+            buff[0] = SYM_QUES;
             // overwrite any previous distance with blanks
             memset(buff + 1, SYM_BLANK, 6);
             buff[7] = '\0';
@@ -563,7 +563,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 osdFormatAltitudeString(buff, getEstimatedAltitude());
             } else {
                 // We use this symbol when we don't have a valid measure
-                buff[0] = SYM_COLON;
+                buff[0] = SYM_QUES;
                 // overwrite any previous altitude with blanks
                 memset(buff + 1, SYM_BLANK, 6);
                 buff[7] = '\0';
@@ -980,7 +980,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 tfp_sprintf(buff, "%c%01d.%01d", directionSymbol, abs(verticalSpeed / 100), abs((verticalSpeed % 100) / 10));
             } else {
                 // We use this symbol when we don't have a valid measure
-                buff[0] = SYM_COLON;
+                buff[0] = SYM_QUES;
                 // overwrite any previous vertical speed with blanks
                 memset(buff + 1, SYM_BLANK, 6);
                 buff[7] = '\0';

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -266,9 +266,9 @@ static char osdGetTemperatureSymbolForSelectedUnit(void)
 {
     switch (osdConfig()->units) {
     case OSD_UNIT_IMPERIAL:
-        return 'F';
+        return SYM_TEMP_F;
     default:
-        return 'C';
+        return SYM_TEMP_C;
     }
 }
 #endif
@@ -277,7 +277,7 @@ static void osdFormatAltitudeString(char * buff, int altitude)
 {
     const int alt = osdGetMetersToSelectedUnit(altitude) / 10;
 
-    tfp_sprintf(buff, "%5d %c", alt, osdGetMetersToSelectedUnitSymbol());
+    tfp_sprintf(buff, "%c%5d %c", SYM_ALT, alt, osdGetMetersToSelectedUnitSymbol());
     buff[5] = buff[4];
     buff[4] = '.';
 }
@@ -495,22 +495,20 @@ static bool osdDrawSingleElement(uint8_t item)
         // FIXME ideally we want to use SYM_KMH symbol but it's not in the font any more, so we use K (M for MPH)
         switch (osdConfig()->units) {
         case OSD_UNIT_IMPERIAL:
-            tfp_sprintf(buff, "%3dM", CM_S_TO_MPH(gpsSol.groundSpeed));
+            tfp_sprintf(buff, "%c%3d%c", SYM_SPEED, CM_S_TO_MPH(gpsSol.groundSpeed), SYM_MPH);
             break;
         default:
-            tfp_sprintf(buff, "%3dK", CM_S_TO_KM_H(gpsSol.groundSpeed));
+            tfp_sprintf(buff, "%c%3d%c", SYM_SPEED, CM_S_TO_KM_H(gpsSol.groundSpeed), SYM_KMH);
             break;
         }
         break;
 
     case OSD_GPS_LAT:
-        // The SYM_LAT symbol in the actual font contains only blank, so we use the SYM_ARROW_NORTH
-        osdFormatCoordinate(buff, SYM_ARROW_NORTH, gpsSol.llh.lat);
+        osdFormatCoordinate(buff, SYM_LAT, gpsSol.llh.lat);
         break;
 
     case OSD_GPS_LON:
-        // The SYM_LON symbol in the actual font contains only blank, so we use the SYM_ARROW_EAST
-        osdFormatCoordinate(buff, SYM_ARROW_EAST, gpsSol.llh.lon);
+        osdFormatCoordinate(buff, SYM_LON, gpsSol.llh.lon);
         break;
 
     case OSD_HOME_DIR:
@@ -519,8 +517,7 @@ static bool osdDrawSingleElement(uint8_t item)
                 const int h = GPS_directionToHome - DECIDEGREES_TO_DEGREES(attitude.values.yaw);
                 buff[0] = osdGetDirectionSymbolFromHeading(h);
             } else {
-                // We don't have a HOME symbol in the font, by now we use this
-                buff[0] = SYM_THR1;
+                buff[0] = SYM_HOMEFLAG;
             }
 
         } else {
@@ -919,8 +916,10 @@ static bool osdDrawSingleElement(uint8_t item)
     case OSD_PITCH_ANGLE:
     case OSD_ROLL_ANGLE:
         {
+            const char symbol = (item == OSD_PITCH_ANGLE) ? SYM_PITCH : SYM_ROLL ;
             const int angle = (item == OSD_PITCH_ANGLE) ? attitude.values.pitch : attitude.values.roll;
-            tfp_sprintf(buff, "%c%02d.%01d", angle < 0 ? '-' : ' ', abs(angle / 10), abs(angle % 10));
+            //tfp_sprintf(buff, "%c", symbol);
+            tfp_sprintf(buff, "%c%c%02d.%01d", symbol, angle < 0 ? '-' : ' ', abs(angle / 10), abs(angle % 10));
             break;
         }
 


### PR DESCRIPTION
Requires v2 fonts uploaded to flight controller.  GUI will trigger v2 font usage with msp 1.44+
Not only fixes crosshair, but also includes some GPS, temperature, and imperial/metric character fixes.