### PR TITLE
fix filterGetNotchQ

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -97,10 +97,7 @@ FAST_CODE float slewFilterApply(slewFilter_t *filter, float input)
 // get notch filter Q given center frequency (f0) and lower cutoff frequency (f1)
 // Q = f0 / (f2 - f1) ; f2 = f0^2 / f1
 float filterGetNotchQ(float centerFreq, float cutoffFreq) {
-	(void) centerFreq;
-	(void) cutoffFreq;
-//    return centerFreq * cutoffFreq / (centerFreq * centerFreq - cutoffFreq * cutoffFreq);
-	return 0.707f; // Butterworth response
+    return centerFreq * cutoffFreq / (centerFreq * centerFreq - cutoffFreq * cutoffFreq);
 }
 
 /* sets up a biquad Filter */


### PR DESCRIPTION
For unknown reason `filterGetNotchQ` was returning a constant Q factor that:
* happily ignored notch filter cutoff frequency
* that was leading to a situation when cutoff (-dB) was approx. center/2 (always)
* phase delay was not constant but was growing  with center frequency as attenuated band was wider and wider