### PR TITLE
remove lagging average filter from code

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -204,11 +204,3 @@ FAST_CODE float biquadFilterApply(biquadFilter_t *filter, float input)
     filter->x2 = filter->b2 * input - filter->a2 * result;
     return result;
 }
-
-void laggedMovingAverageInit(laggedMovingAverage_t *filter, uint16_t windowSize, float *buf)
-{
-    filter->movingWindowIndex = 0;
-    filter->windowSize = windowSize;
-    filter->buf = buf;
-    filter->primed = false;
-}

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -41,14 +41,6 @@ typedef struct biquadFilter_s {
     float x1, x2, y1, y2;
 } biquadFilter_t;
 
-typedef struct laggedMovingAverage_s {
-    uint16_t movingWindowIndex;
-    uint16_t windowSize;
-    float movingSum;
-    float *buf;
-    bool primed;
-} laggedMovingAverage_t;
-
 typedef enum {
     FILTER_PT1 = 0,
     FILTER_BIQUAD,


### PR DESCRIPTION
Remove the lagging average filter which is no longer used.

This filter has not been used for quite a long time as far as I am aware. No need to keep bloat in the code.