### PR TITLE
Remove GA Filter

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -431,9 +431,6 @@ static uint16_t gyroConfig_gyro_lowpass_hz_yaw;
 static uint16_t gyroConfig_gyro_lowpass2_hz_roll;
 static uint16_t gyroConfig_gyro_lowpass2_hz_pitch;
 static uint16_t gyroConfig_gyro_lowpass2_hz_yaw;
-static uint8_t  gyroConfig_gyro_average_roll;
-static uint8_t  gyroConfig_gyro_average_pitch;
-static uint8_t  gyroConfig_gyro_average_yaw;
 static uint16_t gyroConfig_gyro_soft_notch_hz_1;
 static uint16_t gyroConfig_gyro_soft_notch_cutoff_1;
 static uint16_t gyroConfig_gyro_soft_notch_hz_2;
@@ -454,9 +451,6 @@ static long cmsx_menuGyro_onEnter(void)
     gyroConfig_gyro_lowpass2_hz_roll =  gyroConfig()->gyro_lowpass2_hz[ROLL];
     gyroConfig_gyro_lowpass2_hz_pitch =  gyroConfig()->gyro_lowpass2_hz[PITCH];
     gyroConfig_gyro_lowpass2_hz_yaw =  gyroConfig()->gyro_lowpass2_hz[YAW];
-    gyroConfig_gyro_average_roll = gyroConfig()->averagedGyro[ROLL];
-    gyroConfig_gyro_average_pitch = gyroConfig()->averagedGyro[PITCH];
-    gyroConfig_gyro_average_yaw = gyroConfig()->averagedGyro[YAW];
     gyroConfig_gyro_soft_notch_hz_1 = gyroConfig()->gyro_soft_notch_hz_1;
     gyroConfig_gyro_soft_notch_cutoff_1 = gyroConfig()->gyro_soft_notch_cutoff_1;
     gyroConfig_gyro_soft_notch_hz_2 = gyroConfig()->gyro_soft_notch_hz_2;
@@ -482,9 +476,6 @@ static long cmsx_menuGyro_onExit(const OSD_Entry *self)
     gyroConfigMutable()->gyro_lowpass2_hz[ROLL] =  gyroConfig_gyro_lowpass2_hz_roll;
     gyroConfigMutable()->gyro_lowpass2_hz[PITCH] =  gyroConfig_gyro_lowpass2_hz_pitch;
     gyroConfigMutable()->gyro_lowpass2_hz[YAW] =  gyroConfig_gyro_lowpass2_hz_pitch;
-    gyroConfigMutable()->averagedGyro[ROLL] = gyroConfig_gyro_average_roll;
-    gyroConfigMutable()->averagedGyro[PITCH] = gyroConfig_gyro_average_pitch;
-    gyroConfigMutable()->averagedGyro[YAW] = gyroConfig_gyro_average_yaw;
     gyroConfigMutable()->gyro_soft_notch_hz_1 = gyroConfig_gyro_soft_notch_hz_1;
     gyroConfigMutable()->gyro_soft_notch_cutoff_1 = gyroConfig_gyro_soft_notch_cutoff_1;
     gyroConfigMutable()->gyro_soft_notch_hz_2 = gyroConfig_gyro_soft_notch_hz_2;
@@ -512,9 +503,6 @@ static OSD_Entry cmsx_menuFilterGlobalEntries[] =
     { "GYRO LPF2 PITCH",  OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_lowpass2_hz_pitch,  0, 16000, 1 }, 0 },
     { "GYRO LPF2 YAW",    OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_lowpass2_hz_yaw,  0, 16000, 1 }, 0 },
 #endif
-    { "GYRO AVG ROLL",  OME_UINT8,  NULL, &(OSD_UINT8_t)  { &gyroConfig_gyro_average_roll,        0, 10, 1 }, 0 },
-    { "GYRO AVG PITCH", OME_UINT8,  NULL, &(OSD_UINT8_t)  { &gyroConfig_gyro_average_pitch,        0, 10, 1 }, 0 },
-    { "GYRO AVG YAW",   OME_UINT8,  NULL, &(OSD_UINT8_t)  { &gyroConfig_gyro_average_yaw,        0, 10, 1 }, 0 },
     { "GYRO NF1",       OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_soft_notch_hz_1,     0, 500, 1 }, 0 },
     { "GYRO NF1C",      OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_soft_notch_cutoff_1, 0, 500, 1 }, 0 },
     { "GYRO NF2",       OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_soft_notch_hz_2,     0, 500, 1 }, 0 },

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -1330,9 +1330,9 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         sbufWriteU8(dst, currentPidProfile->dFilter[ROLL].Wc);
         sbufWriteU8(dst, currentPidProfile->dFilter[PITCH].Wc);
         sbufWriteU8(dst, currentPidProfile->dFilter[YAW].Wc);
-        sbufWriteU8(dst, gyroConfig()->averagedGyro[ROLL]);
-        sbufWriteU8(dst, gyroConfig()->averagedGyro[PITCH]);
-        sbufWriteU8(dst, gyroConfig()->averagedGyro[YAW]);
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
+        sbufWriteU8(dst, 0);
 
 
         break;
@@ -1968,9 +1968,9 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             currentPidProfile->dFilter[ROLL].Wc = sbufReadU8(src);
             currentPidProfile->dFilter[PITCH].Wc = sbufReadU8(src);
             currentPidProfile->dFilter[YAW].Wc = sbufReadU8(src);
-            gyroConfigMutable()->averagedGyro[ROLL] = sbufReadU8(src);
-            gyroConfigMutable()->averagedGyro[PITCH] = sbufReadU8(src);
-            gyroConfigMutable()->averagedGyro[YAW] = sbufReadU8(src);
+            sbufReadU8(src);
+            sbufReadU8(src);
+            sbufReadU8(src);
 
         }
 
@@ -1996,10 +1996,10 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
         gyroConfigMutable()->imuf_yaw_q = sbufReadU16(src);
         gyroConfigMutable()->imuf_w = sbufReadU16(src);
 #ifdef USE_GYRO_IMUF9001
-        gyroConfigMutable()->imuf_roll_lpf_cutoff_hz = sbufReadU16(src);
-        gyroConfigMutable()->imuf_pitch_lpf_cutoff_hz = sbufReadU16(src);
-        gyroConfigMutable()->imuf_yaw_lpf_cutoff_hz = sbufReadU16(src);
-        gyroConfigMutable()->imuf_acc_lpf_cutoff_hz = sbufReadU16(src);
+        sbufReadU16(src);
+        sbufReadU16(src);
+        sbufReadU16(src);
+        sbufReadU16(src);
 #endif
         break;
 //#endif

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -522,9 +522,7 @@ const clivalue_t valueTable[] = {
     { "imuf_w",                     VAR_UINT16 | MASTER_VALUE, .config.minmax = { 3, 512   }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_w) },
     { "imuf_sharpness",             VAR_UINT16 | MASTER_VALUE, .config.minmax = { 1, 5000  }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, imuf_sharpness) },
 #endif
-    { "gyro_average_roll",          VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10    }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, averagedGyro[ROLL]) },
-    { "gyro_average_pitch",         VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10    }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, averagedGyro[PITCH]) },
-    { "gyro_average_yaw",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 10    }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, averagedGyro[YAW]) },
+
 #ifdef USE_GYRO_OVERFLOW_CHECK
     { "gyro_overflow_detect",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_OVERFLOW_CHECK }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, checkOverflow) },
 #endif

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -125,10 +125,6 @@ static FAST_RAM_ZERO_INIT float gyroPrevious[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT timeUs_t accumulatedMeasurementTimeUs;
 static FAST_RAM_ZERO_INIT timeUs_t accumulationLastTimeSampledUs;
 
-static FAST_RAM_ZERO_INIT float averagedGyroData[XYZ_AXIS_COUNT][AVERAGED_GYRO_DATA_BUFFER_SIZE];
-static FAST_RAM_ZERO_INIT float averagedGyroDataSum[XYZ_AXIS_COUNT];
-static FAST_RAM_ZERO_INIT uint8_t averagedGyroDataPointer[XYZ_AXIS_COUNT];
-
 float FAST_RAM_ZERO_INIT vGyroStdDevModulus;
 
 
@@ -258,9 +254,6 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
    	.imuf_acc_lpf_cutoff_hz = IMUF_DEFAULT_ACC_LPF_HZ,
     .imuf_sharpness = 1000,
     .gyro_offset_yaw = 0,
-    .averagedGyro[ROLL] = 0,
-    .averagedGyro[PITCH] = 0,
-    .averagedGyro[YAW] = 0,
 );
 #else //USE_GYRO_IMUF9001
 PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
@@ -296,9 +289,6 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
     .yaw_spin_threshold = 1950,
     .dyn_notch_quality = 70,
     .dyn_notch_width_percent = 50,
-    .averagedGyro[ROLL] = 0,
-    .averagedGyro[PITCH] = 0,
-    .averagedGyro[YAW] = 0,
 );
 #endif //USE_GYRO_IMUF9001
 

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -65,8 +65,6 @@ typedef enum {
 #define GYRO_CONFIG_USE_GYRO_2      1
 #define GYRO_CONFIG_USE_GYRO_BOTH   2
 
-#define AVERAGED_GYRO_DATA_BUFFER_SIZE 10
-
 typedef enum {
     FILTER_LOWPASS = 0,
     FILTER_LOWPASS2
@@ -126,8 +124,6 @@ typedef struct gyroConfig_s {
     uint16_t imuf_yaw_q;
     uint16_t imuf_w;
     uint16_t imuf_sharpness;
-
-    uint8_t averagedGyro[XYZ_AXIS_COUNT];
 } gyroConfig_t;
 
 PG_DECLARE(gyroConfig_t, gyroConfig);

--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -39,19 +39,6 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor)
         gyroADCf = gyroSensor->notchFilter1ApplyFn((filter_t *)&gyroSensor->notchFilter1[axis], gyroADCf);
         gyroADCf = gyroSensor->notchFilter2ApplyFn((filter_t *)&gyroSensor->notchFilter2[axis], gyroADCf);
 
-        if (gyroConfig()->averagedGyro[axis] > 1)
-        {
-          averagedGyroData[axis][averagedGyroDataPointer[axis]++] = gyroADCf;
-          averagedGyroDataSum[axis] += gyroADCf;
-
-          if (averagedGyroDataPointer[axis] == gyroConfig()->averagedGyro[axis]){
-          averagedGyroDataPointer[axis] = 0;
-          }
-
-          gyroADCf = (float)averagedGyroDataSum[axis] / (float)gyroConfig()->averagedGyro[axis];
-          averagedGyroDataSum[axis] -= averagedGyroData[axis][averagedGyroDataPointer[axis]];
-        }
-
 #ifdef USE_GYRO_DATA_ANALYSE
         if (isDynamicFilterActive()) {
             if (axis == X) {


### PR DESCRIPTION
The GA or gyro average filter was adopted from the old RaceFlightOne code and has not shown itself to be useful. So this filter is being removed in light of simplification and progression. Should make configurator changes easier as well.