### PR TITLE
Drop gyroanalyse quality factor

### DIFF
--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -538,7 +538,6 @@ const clivalue_t valueTable[] = {
     { "gyro_to_use",                VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_to_use) },
 #endif
 #if defined(USE_GYRO_DATA_ANALYSE)
-    { "dyn_notch_quality",          VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 70 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_quality) },
     { "dyn_notch_width_percent",    VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 99 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, dyn_notch_width_percent) },
 #endif
 

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -208,7 +208,7 @@ static void gyroInitLowpassFilterLpf(gyroSensor_t *gyroSensor, int slot, int typ
 #define GYRO_OVERFLOW_TRIGGER_THRESHOLD 31980  // 97.5% full scale (1950dps for 2000dps gyro)
 #define GYRO_OVERFLOW_RESET_THRESHOLD 30340    // 92.5% full scale (1850dps for 2000dps gyro)
 
-PG_REGISTER_WITH_RESET_TEMPLATE(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 4);
+PG_REGISTER_WITH_RESET_TEMPLATE(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 6);
 
 #ifndef GYRO_CONFIG_USE_GYRO_DEFAULT
 #define GYRO_CONFIG_USE_GYRO_DEFAULT GYRO_CONFIG_USE_GYRO_1
@@ -240,7 +240,6 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
     .checkOverflow = GYRO_OVERFLOW_CHECK_ALL_AXES,
     .yaw_spin_recovery = true,
     .yaw_spin_threshold = 1950,
-    .dyn_notch_quality = 70,
     .dyn_notch_width_percent = 25,
     .imuf_mode = GTBCM_GYRO_ACC_FILTER_F,
     .imuf_rate = IMUF_RATE_16K,
@@ -287,7 +286,6 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
     .gyro_offset_yaw = 0,
     .yaw_spin_recovery = true,
     .yaw_spin_threshold = 1950,
-    .dyn_notch_quality = 70,
     .dyn_notch_width_percent = 50,
 );
 #endif //USE_GYRO_IMUF9001

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -109,7 +109,6 @@ typedef struct gyroConfig_s {
     int16_t  yaw_spin_threshold;
 
     uint16_t gyroCalibrationDuration;  // Gyro calibration duration in 1/100 second
-    uint8_t dyn_notch_quality; // bandpass quality factor, 100 for steep sided bandpass
     uint8_t dyn_notch_width_percent;
 #if defined(USE_GYRO_IMUF9001)
     uint16_t imuf_mode;

--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -62,8 +62,6 @@
 #define DYN_NOTCH_CALC_TICKS      (XYZ_AXIS_COUNT * 4)
 
 static uint16_t FAST_RAM_ZERO_INIT fftSamplingRateHz;
-// centre frequency of bandpass that constrains input to FFT
-static uint16_t FAST_RAM_ZERO_INIT fftBpfHz;
 // Hz per bin
 static float FAST_RAM_ZERO_INIT    fftResolution;
 // maximum notch centre frequency limited by Nyquist
@@ -90,7 +88,6 @@ void gyroDataAnalyseInit(uint32_t targetLooptimeUs)
     // otherwise we need to calculate a FFT sample frequency to ensure we get 3 samples (gyro loops < 4K)
     fftSamplingRateHz = MIN((gyroLoopRateHz / 3), FFT_SAMPLING_RATE_HZ);
 
-    fftBpfHz = fftSamplingRateHz / 4;
     fftResolution = (float)fftSamplingRateHz / FFT_WINDOW_SIZE;
     dynNotchMaxCentreHz = fftSamplingRateHz / 2;
 
@@ -124,7 +121,6 @@ void gyroDataAnalyseStateInit(gyroAnalyseState_t *state, uint32_t targetLooptime
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         // any init value
         state->centerFreq[axis] = 200;
-        biquadFilterInit(&state->gyroBandpassFilter[axis], fftBpfHz, 1000000 / fftSamplingRateHz, 0.01f * gyroConfig()->dyn_notch_quality, FILTER_BPF);
         biquadFilterInitLPF(&state->detectedFrequencyFilter[axis], DYN_NOTCH_SMOOTH_FREQ_HZ, looptime);
     }
 }
@@ -152,7 +148,6 @@ void gyroDataAnalyse(gyroAnalyseState_t *state, biquadFilter_t *notchFilterDyn)
         // calculate mean value of accumulated samples
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
             float sample = state->oversampledGyroAccumulator[axis] * state->maxSampleCountRcp;
-            sample = biquadFilterApply(&state->gyroBandpassFilter[axis], sample);
 
             state->downsampledGyroData[axis][state->circularBufferIdx] = sample;
             if (axis == 0) {

--- a/src/main/sensors/gyroanalyse.h
+++ b/src/main/sensors/gyroanalyse.h
@@ -35,9 +35,6 @@ typedef struct gyroAnalyseState_s {
     float maxSampleCountRcp;
     float oversampledGyroAccumulator[XYZ_AXIS_COUNT];
 
-    // filter for downsampled accumulated gyro
-    biquadFilter_t gyroBandpassFilter[XYZ_AXIS_COUNT];
-
     // downsampled gyro data circular buffer for frequency analysis
     uint8_t circularBufferIdx;
     float downsampledGyroData[XYZ_AXIS_COUNT][FFT_WINDOW_SIZE];


### PR DESCRIPTION
Gyroanalyse quality factor (?) seemed to work with a very peculiar way:
* it was setting a BPF and center on `fftSamplingRate / 4`
* default Q factor of `0.7` was setting cutoff at approx half of this frequency. Lowering to somewhere recommended `0.1` was setting to approx. 10% of it

As a result:
* gyroanalyse was preferring frequencies closer to `fftSamplingRate / 4` more than any other frequencies
* peak detection was not constant among frequency range
* tuning of this factor was bound to fftFrequency that is not visible to the user and not even directly dependent on looptime frequency
* in general, hard to use, complicated, with questionable gain and apparently useless on a longer run

This PR is an addition to #110 