### PR TITLE
Fix a bug in kalman.c?

### DIFF
--- a/src/main/common/kalman.c
+++ b/src/main/common/kalman.c
@@ -145,6 +145,11 @@ FAST_CODE float kalman_process(kalman_t* kalmanState, float input, float target)
 void FAST_CODE kalman_update(float* input, float* output)
 {
     update_kalman_covariance(input);
+
+    setPoint[X] = getSetpointRate(X);
+    setPoint[Y] = getSetpointRate(Y);
+    setPoint[Z] = getSetpointRate(Z);
+
     output[X] = kalman_process(&kalmanFilterStateRate[X], input[X], setPoint[X] );
     output[Y] = kalman_process(&kalmanFilterStateRate[Y], input[Y], setPoint[Y] );
     output[Z] = kalman_process(&kalmanFilterStateRate[Z], input[Z], setPoint[Z] );


### PR DESCRIPTION
@DzikuVx showed me a potential bug within the kalman.c code. Right now setpoint[axis] is called but never initialized or set to anything. It appears that it never updates nor does anything. This code should update it to properly store the correct setpoint with every kalman update. I'd like this to be looked into more though, because I have logged the kalman before and seen it do things, but now that I've looked at it again I am pretty sure that setpoint within kalman.c currently does nothing.

Thanks for pointing this out Pawel :)