### PR TITLE
USE_PEGASUS_UI

### DIFF
--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -154,6 +154,7 @@
 #endif
 
 #if (FLASH_SIZE > 128)
+#define USE_PEGASUS_UI
 #define USE_SERIALRX_SUMH       // Graupner legacy protocol
 #define USE_CAMERA_CONTROL
 #define USE_CMS


### PR DESCRIPTION
Define USE_PEGASUS_UI in order to help with further gui development. It adds a cli command that dumps every single setting on your quad. The command is config and it lists every single configurable setting for your drone. Hoping that it can help manage some of the MSP complexity that plagues us.
