### PR TITLE
debug for smart smoothing

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -77,4 +77,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "ANTI_GRAVITY",
     "IMU",
     "KALMAN",
+    "SMART_SMOOTHING",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -95,6 +95,7 @@ typedef enum {
     DEBUG_ANTI_GRAVITY,
     DEBUG_IMU,
     DEBUG_KALMAN,
+    DEBUG_SMART_SMOOTHING,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/common/kalman.c
+++ b/src/main/common/kalman.c
@@ -128,8 +128,6 @@ FAST_CODE float kalman_process(kalman_t* kalmanState, float input, float target)
     kalmanState->e = fabsf(1.0f - (((targetAbs + 1.0f) * errorMultiplier) / fabsf(kalmanState->lastX)));
   }
 
-  //kalmanState->e = ABS((target - input) * 3) + ABS(input/4);
-
   //prediction update
   kalmanState->p = kalmanState->p + (kalmanState->q * kalmanState->e);
 

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1074,6 +1074,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
                 dDeltaMultiplier = constrainf(fabsf(dDelta + previousdDelta[axis]) / (2 * smart_dterm_smoothing[axis]), 0.0f, 1.0f);
                 dDelta = dDelta * dDeltaMultiplier;
                 previousdDelta[axis] = dDelta;
+                DEBUG_SET(DEBUG_SMART_SMOOTHING, axis, dDeltaMultiplier * 1000.0f);
             }
             // Divide rate change by dT to get differential (ie dr/dt).
             // dT is fixed and calculated from the target PID loop time


### PR DESCRIPTION
adds a debug that shows what the dterm is multiplied by. It shows it multiplied by 1000 though, so if smart smoothing shrinks your dterm by half it will show 500. If it leaves the dterm untouched it will show 1000. Just a way to make this easier to see in a bbl.

this should make it easier to see what the debug mode is doing to help us better understand it and see how to tune it.