### PR TITLE
reapply betaflight -- ignore failsafe packets in rx_spi_frskyx #7345

### DIFF
--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -200,9 +200,9 @@ static bool tuneRx(uint8_t *packet)
             if (packet[ccLen - 1] & 0x80) {
                 if (packet[2] == 0x01) {
                     uint8_t Lqi = packet[ccLen - 1] & 0x7F;
-                    if (Lqi < 50) {
+                    // higher lqi represent better link quality
+                    if (Lqi > 50) {
                         rxFrSkySpiConfigMutable()->bindOffset = bindOffset;
-
                         return true;
                     }
                 }

--- a/src/main/rx/cc2500_frsky_x.c
+++ b/src/main/rx/cc2500_frsky_x.c
@@ -273,6 +273,10 @@ static void frSkyXTelemetryWriteFrame(const smartPortPayload_t *payload)
 void frSkyXSetRcData(uint16_t *rcData, const uint8_t *packet)
 {
     uint16_t c[8];
+    // ignore failsafe packet
+    if (packet[7] != 0) {
+        return;
+    }
     c[0] = (uint16_t)((packet[10] << 8) & 0xF00) | packet[9];
     c[1] = (uint16_t)((packet[11] << 4) & 0xFF0) | (packet[10] >> 4);
     c[2] = (uint16_t)((packet[13] << 8) & 0xF00) | packet[12];


### PR DESCRIPTION
I'm hoping this fixes d16 mode on the EMAX "d8-compatible" tinyhawk. (works in emuflight 4, but not in emuflight 3 or betaflight)

----- 

Original fix into betaflight here -- https://github.com/betaflight/betaflight/pull/7345/

Original merge into emuflight here -- https://github.com/emuflight/EmuFlight/commit/c3521db8f13896b9e1c599439ed42e05ef089b25#diff-8d164ba28d885dd7f800306523978b00

It appears to have been (accidentally?) undone in a subsequent commit here -- https://github.com/emuflight/EmuFlight/commit/089283648cae4cc5dab1294590c649e260ccb5d8#diff-8d164ba28d885dd7f800306523978b00

So this MR simply re-does the original fix over the top of EF's latest master.