### PR TITLE
thrust linearization

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -271,10 +271,11 @@ static OSD_Entry cmsx_menuRateProfileEntries[] =
     { "TPA RATE D",  OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &rateProfile.dynThrD,              0,  250,  1, 10}, 0 },
     { "TPA BREAKPOINT",   OME_UINT16, NULL, &(OSD_UINT16_t){ &rateProfile.tpa_breakpoint,  1000, 2000, 10}, 0 },
 
-    { "VBAT COMP TYPE",  OME_TAB,   NULL, &(OSD_TAB_t)    { &rateProfile.vbat_comp_type, VBAT_COMP_TYPE_COUNT - 1, cms_throttleVbatCompTypeLabels}, 0 },
-    { "VBAT COMP REF",   OME_UINT8, NULL, &(OSD_UINT8_t)  { &rateProfile.vbat_comp_ref, VBAT_CELL_VOTAGE_RANGE_MIN, VBAT_CELL_VOTAGE_RANGE_MAX,  1}, 0 },
-    { "VBAT COMP THR %", OME_UINT8, NULL, &(OSD_UINT8_t)  { &rateProfile.vbat_comp_throttle_level, 0,  100,  1}, 0 },
-    { "VBAT COMP PID %", OME_UINT8, NULL, &(OSD_UINT8_t)  { &rateProfile.vbat_comp_pid_level, 0,  100,  1}, 0 },
+    { "VBAT COMP TYPE", OME_TAB,   NULL, &(OSD_TAB_t)   { &rateProfile.vbat_comp_type, VBAT_COMP_TYPE_COUNT - 1, cms_throttleVbatCompTypeLabels}, 0 },
+    { "VBAT COMP REF",  OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.vbat_comp_ref, VBAT_CELL_VOTAGE_RANGE_MIN, VBAT_CELL_VOTAGE_RANGE_MAX,  1}, 0 },
+
+    { "THRUST LINEAR",  OME_UINT8, NULL, &(OSD_UINT8_t) { &rateProfile.thrust_linearization_level, 0,  100,  1}, 0 },
+    { "TROTTLE LINEAR", OME_TAB,   NULL, &(OSD_TAB_t)   { &rateProfile.throttle_linearization, 1, cms_offOnLabels }, 0 },
 
     { "SAVE&EXIT",   OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT_SAVE, 0},
     { "BACK", OME_Back, NULL, NULL, 0 },

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -62,8 +62,8 @@ void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
             .throttle_limit_percent = 100,
             .vbat_comp_type = VBAT_COMP_TYPE_OFF,
             .vbat_comp_ref = 37,
-            .vbat_comp_throttle_level = 75,
-            .vbat_comp_pid_level = 75,
+            .thrust_linearization_level = 0,
+            .throttle_linearization = 0
         );
     }
 }

--- a/src/main/fc/controlrate_profile.h
+++ b/src/main/fc/controlrate_profile.h
@@ -60,8 +60,8 @@ typedef struct controlRateConfig_s {
     uint8_t throttle_limit_percent;         // Sets the maximum pilot commanded throttle limit
     uint8_t vbat_comp_type;                 // Sets the type of battery compensation: off, boost, limit or both
     uint8_t vbat_comp_ref;                  // Sets the voltage reference to calculate the battery compensation
-    uint8_t vbat_comp_throttle_level;       // Sets the level of throttle battery compensation
-    uint8_t vbat_comp_pid_level;            // Sets the level of PID battery compensation
+    uint8_t thrust_linearization_level;     // Sets the level of thrust linearization
+    uint8_t throttle_linearization;         // Tells whether the linearization has to be applied also to the throttle or not
 } controlRateConfig_t;
 
 PG_DECLARE_ARRAY(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -551,8 +551,6 @@ static float calcHorizonLevelStrength(void)
     return constrainf(horizonLevelStrength, 0, 1);
 }
 
-#define SIGN(x) ((x > 0.0f) - (x < 0.0f))
-
 static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPitchTrims_t *angleTrim, float currentPidSetpoint, const float deltaT)
 {
     // calculate error angle and limit the angle to the max inclination
@@ -852,11 +850,6 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
         setPointDAttenuation[axis] = 1 + (getRcDeflectionAbs(axis) * (setPointDTransition[axis] - 1));
     }
 
-    //vbat pid compensation on just the p term :) thanks NFE
-    float vbatCompensationFactor = calculateVbatCompensation(currentControlRateProfile->vbat_comp_type, currentControlRateProfile->vbat_comp_ref);
-
-    vbatCompensationFactor = scaleRangef(currentControlRateProfile->vbat_comp_pid_level, 0.0f, 100.0f, 1.0f, vbatCompensationFactor);
-
     // gradually scale back integration when above windup point
     const float dynCi = constrainf((1.1f - getMotorMixRange()) * ITermWindupPointInv, 0.1f, 1.0f) * itermAccelerator * deltaT;
     float errorRate;
@@ -1027,7 +1020,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 #endif
 
         // -----calculate P component and add Dynamic Part based on stick input
-        pidData[axis].P = (pidCoefficient[axis].Kp * (boostedErrorRate + errorRate)) * vbatCompensationFactor;
+        pidData[axis].P = (pidCoefficient[axis].Kp * (boostedErrorRate + errorRate));
 
         /*
          * Process Iterm with I-decay function

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -44,6 +44,8 @@
 // This value gives the same "feel" as the previous Kd default of 26 (26 * DTERM_SCALE)
 #define FEEDFORWARD_SCALE 0.013754f
 
+#define SIGN(x) ((x > 0.0f) - (x < 0.0f))
+
 typedef enum {
     PID_ROLL,
     PID_PITCH,

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -976,9 +976,9 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
 
         sbufWriteU8(dst, currentControlRateProfile->vbat_comp_type);
         sbufWriteU8(dst, currentControlRateProfile->vbat_comp_ref);
-        sbufWriteU8(dst, currentControlRateProfile->vbat_comp_throttle_level);
-        sbufWriteU8(dst, currentControlRateProfile->vbat_comp_pid_level);
 
+        sbufWriteU8(dst, currentControlRateProfile->thrust_linearization_level);
+        sbufWriteU8(dst, currentControlRateProfile->throttle_linearization);
         break;
 
     case MSP_EMUF:
@@ -1773,8 +1773,8 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             if (sbufBytesRemaining(src) >= 4) {
                 currentControlRateProfile->vbat_comp_type = sbufReadU8(src);
                 currentControlRateProfile->vbat_comp_ref = sbufReadU8(src);
-                currentControlRateProfile->vbat_comp_throttle_level = sbufReadU8(src);
-                currentControlRateProfile->vbat_comp_pid_level = sbufReadU8(src);
+                currentControlRateProfile->thrust_linearization_level = sbufReadU8(src);
+                currentControlRateProfile->throttle_linearization = sbufReadU8(src);
             }
             initRcProcessing();
         } else {

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -762,10 +762,11 @@ const clivalue_t valueTable[] = {
     { "throttle_limit_type",        VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_THROTTLE_LIMIT_TYPE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, throttle_limit_type) },
     { "throttle_limit_percent",     VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 25, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, throttle_limit_percent) },
 
-    { "vbat_comp_type",             VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_VBAT_COMP_TYPE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_type) },
-    { "vbat_comp_ref"         ,     VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { VBAT_CELL_VOTAGE_RANGE_MIN, VBAT_CELL_VOTAGE_RANGE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_ref) },
-    { "vbat_comp_throttle_level",   VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_throttle_level) },
-    { "vbat_comp_pid_level",        VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_pid_level) },
+    { "vbat_comp_type", VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_VBAT_COMP_TYPE }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_type) },
+    { "vbat_comp_ref",  VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { VBAT_CELL_VOTAGE_RANGE_MIN, VBAT_CELL_VOTAGE_RANGE_MAX }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, vbat_comp_ref) },
+
+    { "thrust_linearization_level", VAR_UINT8  | PROFILE_RATE_VALUE, .config.minmax = { 0, 100 }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, thrust_linearization_level) },
+    { "throttle_linearization",     VAR_UINT8  | PROFILE_RATE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_CONTROL_RATE_PROFILES, offsetof(controlRateConfig_t, throttle_linearization) },
 
 // PG_SERIAL_CONFIG
     { "reboot_character",           VAR_UINT8  | MASTER_VALUE, .config.minmax = { 48, 126 }, PG_SERIAL_CONFIG, offsetof(serialConfig_t, reboot_character) },

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -458,15 +458,14 @@ void batteryUpdateCurrentMeter(timeUs_t currentTimeUs)
     }
 }
 
-float calculateVbatCompensation(uint8_t vbatCompType, uint8_t vbatCompRef)
+float calculateVbatCompensationFactor()
 {
     float factor =  1.0f;
-    if (vbatCompType != VBAT_COMP_TYPE_OFF && batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && batteryCellCount > 0) {
+    if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE && batteryCellCount > 0) {
         float vbat = (float) voltageMeter.filtered / batteryCellCount;
         if (vbat) {
-            factor = vbatCompRef / vbat;
-            factor *= factor;
-            switch (vbatCompType) {
+            factor = currentControlRateProfile->vbat_comp_ref / vbat;
+            switch (currentControlRateProfile->vbat_comp_type) {
                 case VBAT_COMP_TYPE_BOOST:
                     factor = MAX(factor, 1.0f);
                     break;

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -97,7 +97,7 @@ void batteryUpdateAlarms(void);
 
 struct rxConfig_s;
 
-float calculateVbatCompensation(uint8_t vbatCompType, uint8_t vbatCompRef);
+float calculateVbatCompensationFactor();
 uint8_t calculateBatteryPercentageRemaining(void);
 bool isBatteryVoltageConfigured(void);
 uint16_t getBatteryVoltage(void);


### PR DESCRIPTION
Resuming a PR I screwed-up with (git rebasing gone wrong).

This PR is intended to port thrust linearization to EmuFlight. Something like betaflight/betaflight#7304, using a different, simpler, formula to compensate thrust non-linearity.

Thrust/RPM relationship is similar to a quadratic curve, but not exactly equal. A configurable mix with a linear relationship (no compensation) is used to find the exact compensation for a given quad.

Efficient quads (motor, propellers etc) will have a thrust_linearization_level close to 100, whereas a less efficient one will have a lower level, something like 65.

throttle_linearization is a boolean parameter that tells if the throttle feel has to be "linear" or de-compensated to match the old fashioned square root feel (default value).

I found the linear throttle feel to be great, since it helps to maintain a mure constant fly height. But since the throttle hovering level will be a little higher (e.g. from 33 to 50), I suggest to use a custom three points curve on the transmitter: (-100, -100), (-33, -70), (100, 100), but I'm thinking to add this type of curve directly on EmuFlight, letting the user choose the type of curve to apply to the throttle.

I tested linearization in this way:
- set idle throttle to 0%
- put my quad uside-down on a balance in acro mode, using a support to hold it firmly
- zeroed the balance
- took note of the thrust (in grams) generated at various throttle level

         STOCK     LINEAR THRUST
20%       6                   16
40%     19                   30
60%     32                   45
80%     56                   61