### PR TITLE
github workflow update test 02

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ jobs:
   build:
     strategy:
       max-parallel: 1
+    timeout-minutes: 480  #default 360
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -12,7 +13,7 @@ jobs:
         release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
     - uses: actions/setup-python@v1
     - name: Make
-      run: make all
+      run: make all -j2 --keep-going
     - name: Upload
       uses: actions/upload-artifact@v2-preview
       with:


### PR DESCRIPTION
* test time-out
* -j2
* --keep-going     #i know bad practice, but github workflow acting differently than travis-ci, and thusly blocking merge-ability

