### PR TITLE
Travis upload to Bintray only for master and [Bb]uild*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,12 @@ deploy:
     file: bintray-conf.json
     skip_cleanup: true # do not delete what has just been built
     on:
-      all_branches: true
       #tags: true
+      branches:
+        only:
+          -master
+          -build*
+          -Build*
 
 after_deploy:
   - wget https://raw.githubusercontent.com/DiscordHooks/travis-ci-discord-webhook/master/send.sh


### PR DESCRIPTION
only deploy to Bintray for:
* `master`
* `build`*
* `Build`*
 where * represents wildcard filename
