### PR TITLE
Fix bug with logging.

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -876,6 +876,8 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
         }
 #endif // USE_YAW_SPIN_RECOVERY
 
+        previousPidSetpoint[axis] = currentPidSetpoint;
+
         // -----calculate error rate
         errorRate = currentPidSetpoint - gyro.gyroADCf[axis]; // r - y
 


### PR DESCRIPTION
previousPidSetpoint[axis] is used in blackbox logging to log your current setpoint. However when feedforward was removed this was also removed, and the unintended consequence was that logs of setpoint were no longer quite accurate. This should fix that and hopefully fix an issue with logging.

this is what we want to see 
![image](https://user-images.githubusercontent.com/46289813/80117218-2304aa00-8544-11ea-9e2b-7523f0322f36.png)

instead this is what we see 
![image](https://user-images.githubusercontent.com/46289813/80117243-2c8e1200-8544-11ea-81ff-7b4fda3b827f.png)

Rate Dynamics is not getting logged properly and is making the quad look sporadic in how it handles error. Looks actually very very bad. However if you look at pitch on the second image you can easily see that a lot of that pitch error comes from doing backflips while using rate dynamics.
