### PR TITLE
Fix turtle power

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -709,7 +709,7 @@ static void applyFlipOverAfterCrashModeToMotors(void)
                     motorOutput = disarmMotorOutput;
                 }
             }
-            motorOutput = MIN(1.0f, flipPower * motorOutput * mixerConfig()->crashflip_power_percent / 100.0f);
+            motorOutput = MIN(1.0f, flipPower * motorOutput * (mixerConfig()->crashflip_power_percent * 1.414f) / 100.0f);
             motorOutput = motorOutputMin + motorOutput * motorOutputRange;
 
             // Add a little bit to the motorOutputMin so props aren't spinning when sticks are centered


### PR DESCRIPTION
since changing turtle mode it appears that turtle mode has less power than it did before. This fixes that issue and restores the power that turtle mode should have. (this bug was found as more whoop pilots had issues in turtle mode)