### PR TITLE
update to smart smoothing

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -135,8 +135,8 @@ void resetPidProfile(pidProfile_t *pidProfile)
                  },
 
                  .dFilter = {
-                     [PID_ROLL] = {2, 100, 250, 5},  // wc, dtermlpf, dtermlpf2, smartSmoothing
-                     [PID_PITCH] = {2, 100, 250, 5}, // wc, dtermlpf, dtermlpf2, smartSmoothing
+                     [PID_ROLL] = {2, 100, 250, 0},  // wc, dtermlpf, dtermlpf2, smartSmoothing
+                     [PID_PITCH] = {2, 100, 250, 0}, // wc, dtermlpf, dtermlpf2, smartSmoothing
                      [PID_YAW] = {0, 100, 250, 0},    // wc, dtermlpf, dtermlpf2, smartSmoothing
                  },
 
@@ -1055,7 +1055,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
 
             if (smart_dterm_smoothing[axis] > 0)
             {
-                dDeltaMultiplier = constrainf(fabsf(dDelta + previousdDelta[axis]) / (2 * smart_dterm_smoothing[axis]), 0.5f, 1.0f);
+                dDeltaMultiplier = constrainf(fabsf((dDelta + previousdDelta[axis]) / (4 * smart_dterm_smoothing[axis])) + 0.5, 0.5f, 1.0f); //smooth transition from 0.5-1.0f for the multiplier.
                 dDelta = dDelta * dDeltaMultiplier;
                 previousdDelta[axis] = dDelta;
                 DEBUG_SET(DEBUG_SMART_SMOOTHING, axis, dDeltaMultiplier * 1000.0f);


### PR DESCRIPTION
This code makes smart smoothing smoother. It makes the transition multiplier that smart smoothing applies to the dterm more smooth. Before it would go from a multiplier of .5 to greater very very quickly. This change will make the transition from .5 multiplier to a multiplier of 1 far smoother.

This PR also takes the default smart smoothing and sets it to 0.