### PR TITLE
fix ./make/tools.mk for windows

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -28,7 +28,7 @@ ifdef MACOSX
 endif
 
 ifdef WINDOWS
-  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip.bz2
+  ARM_SDK_URL  := $(ARM_SDK_URL_BASE)-win32.zip
 endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))


### PR DESCRIPTION
windows arm_sdk download was wrongly named with .bz2 extension, changed to .zip