### PR TITLE
Update version.h for the release of 0.3.0

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -24,8 +24,8 @@
 
 #define FC_FIRMWARE_NAME            "EmuFlight"
 #define FC_VERSION_MAJOR            0  // increment when a major release is made (big new feature, etc)
-#define FC_VERSION_MINOR            2  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      52 // increment when a bug is fixed
+#define FC_VERSION_MINOR            3  // increment when a minor release is made (small new feature, change etc)
+#define FC_VERSION_PATCH_LEVEL      0  // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 


### PR DESCRIPTION
The Hex code is ready, Keep this branch so that we have a version of the 0.3.0 code that is easy to find. Will be useful for adding new targets and for keeping a history. 

This code just pushes the version numbering to 0.3.0