### PR TITLE
version bump 0.2.53

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -25,7 +25,7 @@
 #define FC_FIRMWARE_NAME            "EmuFlight"
 #define FC_VERSION_MAJOR            0  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            2  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      52 // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      53 // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 


### PR DESCRIPTION
* This is equivalent to Travis Build 747
* KakuteF7mini #219
* minor fix TmotorF4HD, adding target RACEPIT mini #217
* Flywoof405 #218
* informative .hex names #216
* 20200507 kalman covar without cross influence #213
* make the pid calculation nondynamic #212
* rename target NOX to NOXF4 #209
