### PR TITLE
branchname in .hex filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ BUILDNO := $(TRAVIS_BUILD_NUMBER)
 endif
 
 REVISION := $(shell git log -1 --format="%h")
+# use branchname in .hex files, insure no spaces, truncate to 30 chars max
+BRANCHNAME := $(shell git rev-parse --abbrev-ref HEAD | sed -e 's/^[[:space:]]*//' | cut -c 1-30)
 
 FC_VER_MAJOR := $(shell grep " FC_VERSION_MAJOR" src/main/build/version.h | awk '{print $$3}' )
 FC_VER_MINOR := $(shell grep " FC_VERSION_MINOR" src/main/build/version.h | awk '{print $$3}' )
@@ -285,9 +287,9 @@ CPPCHECK        = cppcheck $(CSOURCES) --enable=all --platform=unix64 \
                   -I/usr/include -I/usr/include/linux
 
 ifneq ($(BUILDNO),local)
-TARGET_BASENAME = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET)_Build_$(BUILDNO)_$(REVISION)
+TARGET_BASENAME = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET)_Build_$(BUILDNO)_$(REVISION)_Branch_$(BRANCHNAME)
 else
-TARGET_BASENAME = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET)_Build_$(REVISION)
+TARGET_BASENAME = $(BIN_DIR)/$(FORKNAME)_$(FC_VER)_$(TARGET)_Build_$(REVISION)_Branch_$(BRANCHNAME)
 endif
 
 #


### PR DESCRIPTION
* as per discussion with @Quick-Flash 
* examples:
`EmuFlight_0.2.53_STRIXF10_Build_758995213_Branch_20200513_branchname_in_hex.hex`
if master, would be: `EmuFlight_0.2.53_STRIXF10_Build_758995213_Branch_master.hex`
& of course, when on travis, the travis number will be included: `EmuFlight_0.2.53_STRIXF10_Build_999_758995213_Branch_master.hex`
* it will use the branchname, but truncate to 30 characters if too long