### PR TITLE
reduce build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 75
     strategy:
       max-parallel: 3
       matrix:


### PR DESCRIPTION
* 6 hour timeout too long for failure; 1hr 15min should be appropriate (75 minutes)
* jobs usually take about 45min currently for 155 targets