### PR TITLE
fix alti for dji and fc whitout baro

### DIFF
--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -100,10 +100,10 @@ if (sensors(SENSOR_GPS) && STATE(GPS_FIX)) {
 
     if (haveGpsAlt && haveBaroAlt) {
         estimatedAltitude = gpsAlt * gpsTrust + baroAlt * (1 - gpsTrust);
-    }    else if (haveBaroAlt) {
-          estimatedAltitude = baroAlt;
-      }else if (haveGpsAlt) {
+    }else if (haveGpsAlt) {
         estimatedAltitude = gpsAlt;
+    }else if (haveBaroAlt) {
+          estimatedAltitude = baroAlt;
     }
 
 

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -931,7 +931,7 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
         break;
 
     case MSP_ALTITUDE:
-#if defined(USE_BARO) || defined(USE_RANGEFINDER)
+#if defined(USE_BARO) || defined(USE_RANGEFINDER) || defined(USE_GPS)
         sbufWriteU32(dst, getEstimatedAltitude());
 #else
         sbufWriteU32(dst, 0);
@@ -1983,7 +1983,7 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src)
             currentPidProfile->dFilter[YAW].Wc = sbufReadU8(src);
             gyroConfigMutable()->dyn_notch_q_factor = sbufReadU16(src);
             gyroConfigMutable()->dyn_notch_min_hz = sbufReadU16(src);
-            
+
         }
 
         // reinitialize the gyro filters with the new values


### PR DESCRIPTION
revert an old change that was incorrect in position.c 

and dji is getting from msp_altitude the getestimatedalt only for USE_BARO or USE_RANGEFINDER 
i added USE_GPS so it is enable for all fc without BARO using GPS 