### PR TITLE
Fix dyn notch and static notch for helio

### DIFF
--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -70,10 +70,9 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor)
         GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_FILTERED, axis, lrintf(gyroADCf));
 #else //USE_GYRO_IMUF9001
         gyroADCf = kalman_update(gyroADCf, axis);
-        gyroSensor->gyroDev.gyroADCf[axis] = gyroADCf;
-
         // DEBUG_GYRO_FILTERED records the scaled, filtered, after all software filtering has been applied.
         GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_FILTERED, axis, lrintf(gyroSensor->gyroDev.gyroADCf[axis]));
 #endif //USE_GYRO_IMUF9001
+        gyroSensor->gyroDev.gyroADCf[axis] = gyroADCf;
     }
 }

--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -35,8 +35,10 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor)
         GYRO_FILTER_DEBUG_SET(DEBUG_GYRO_SCALED, axis, lrintf(gyroADCf));
 
         // apply static notch filters and software lowpass filters
+#ifndef USE_GYRO_IMUF9001 //Not apply software lowpass filter for Helio
         gyroADCf = gyroSensor->lowpass2FilterApplyFn((filter_t *)&gyroSensor->lowpass2Filter[axis], gyroADCf);
         gyroADCf = gyroSensor->lowpassFilterApplyFn((filter_t *)&gyroSensor->lowpassFilter[axis], gyroADCf);
+#endif
         gyroADCf = gyroSensor->notchFilter1ApplyFn((filter_t *)&gyroSensor->notchFilter1[axis], gyroADCf);
         gyroADCf = gyroSensor->notchFilter2ApplyFn((filter_t *)&gyroSensor->notchFilter2[axis], gyroADCf);
 


### PR DESCRIPTION
* Remove software lowpass filter for Helio since it is prefiltered with gyro lpf on IMUF side. No need to apply in double.
* Fix non-Applied dynamic_filter for helio.