### PR TITLE
github actions workflow for Draft Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,3 @@
-name: Build EmuFlight
-
 on:
   push:
     tags:
@@ -7,7 +5,11 @@ on:
   pull_request:
     branches:
     - '*'
+  # repository_dispatch is a newer github-actions feature that will allow building from triggers other than code merge/PR
+  repository_dispatch:
+    types: [build]
 
+name: Build EmuFlight
 jobs:
   build:
     timeout-minutes: 75
@@ -17,6 +19,8 @@ jobs:
         targets: [targets-group-1, targets-group-2, targets-group-rest]
     runs-on: ubuntu-latest
     steps:
+
+    # curl, by default, may timeout easily
     - name: curl fix
       run: function curl () { command curl --connect-timeout 30 --retry 10 "$@" ; }
 
@@ -24,16 +28,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - name: Get pull request number
-      id: get_pullno
-      run: echo ::set-env name=PULL_NUMBER::$(echo "$GITHUB_REF" | awk -F / '{print $3}')
-      if: startsWith(github.ref, 'refs/pull/')
-
-    - name: Get revision tag
-      id: get_revtag
-      run: echo "::set-output name=REVISION_TAG::${GITHUB_REF/refs\/tags\//}"
-      if: startsWith(github.ref, 'refs/tags/')
 
     - name: Take the trash out
       run: |
@@ -43,6 +37,7 @@ jobs:
         docker rmi -f $(docker image ls -aq)
         sync
         df -h
+      continue-on-error: true
 
     - name: Setup Python
       uses: actions/setup-python@v1
@@ -56,24 +51,64 @@ jobs:
       id: get_version
       run: echo "::set-output name=VERSION::$(make version)"
 
+    # for Makefile interaction
+    - name: Get GitHub Build Number (ENV)
+      id: get_buildno
+      run: echo ::set-env name=GITHUBBUILDNUMBER::${{ github.run_number }}
+      continue-on-error: true
+
+    - name: Get pull request number
+      id: get_pullno
+      run: echo ::set-env name=PULL_NUMBER::$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+      if: startsWith(github.ref, 'refs/pull/')
+
+    - name: Get revision tag
+      id: get_revtag
+      run: echo "::set-output name=REVISION_TAG::${GITHUB_REF/refs\/tags\//}"
+      if: startsWith(github.ref, 'refs/tags/')
+
+    # for debugging
+    - name: Show Variables
+      id: show_vars
+      run: |
+        echo "Build: ${{ github.run_number }}"
+        echo "Firmware ${{ steps.get_version.outputs.VERSION }}"
+        echo "Commit: ${{ github.sha }}"
+        echo "tag: ${{ steps.get_revtag.outputs.REVISION_TAG}}"
+      continue-on-error: true
+
     - name: Compile Code
       run: |
         make ${{ matrix.targets }}
 
-    - name: Store Artifacts
-      uses: actions/upload-artifact@v2-preview
+    # Upload the Builds to ZIP file with existing SHA in .hex names
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
       with:
         name: EmuFlight-${{ steps.get_version.outputs.VERSION }}-${{ github.run_number }}
         path: obj/*.hex
-      continue-on-error: true
 
-    - name: Release Binaries
+    # Rename .hex for Releases
+    - name: Rename Artifacts
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        sudo apt -y install rename
+        cd obj
+        rename 's/_Build_.*/.hex/' *.hex
+
+    - name: Draft Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: EmuFlight-${{ steps.get_version.outputs.VERSION }}
-        prerelease: true
-        draft: true
         files: obj/*.hex
+        draft: true
+        prerelease: true
+        tag_name: ${{ github.run_number }}   # use the build Number, but we manually change to version so that it creates a version-tag on release
+        name:  DRAFT / EmuFlight ${{ steps.get_version.outputs.VERSION }} / GitHub Build ${{ github.run_number }}
+        body: |
+          # EmuFlight ${{ steps.get_version.outputs.VERSION }}
+          ## BuildTag: ${{ steps.get_revtag.outputs.REVISION_TAG}}
+          ## Commit: ${{ github.sha }}
+          ## Changes in this Release:
       env:
-        GITHUB_TOKEN: ${{ secrets.release_token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ include $(ROOT)/make/targets.mk
 BUILDNO := local
 
 # github actions build
-ifneq ($(BUILD_NUMBER),)
-BUILDNO := $(BUILD_NUMBER)
+ifneq ($(GITHUBBUILDNUMBER),)
+BUILDNO := $(GITHUBBUILDNUMBER)
 endif
 
 # travis build


### PR DESCRIPTION
* Builds for PR tests as usual.
* Creates Draft-Release for tags, and uploads *.hex Assets
* We can manually delete Drafts as necessary
* For actual releases, we modify the Release-Notes and the tag to an `X.Y.Z` version

Easy to build master or any branch with something like:
(where `buildTag` is somewhat descriptive because it twill be used for draft notes and bintray)
```
git checkout [BRANCH]
git tag buildTag
git push [upstream|origin] buildTag
git tag --delete buildTag
git push --delete [upstream|origin] buildTag
```