### PR TITLE
upgrade toolchain to '2020-q2-update'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       uses: actions/setup-python@v1
 
     - name: Setup Toolchain
-      uses: fiam/arm-none-eabi-gcc@v1
+      uses: fiam/arm-none-eabi-gcc@v1.0.2
       with:
         release: '9-2020-q2' # The arm-none-eabi-gcc release to use.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build EmuFlight
+
 
 on:
   push:
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Toolchain
       uses: fiam/arm-none-eabi-gcc@v1
       with:
-        release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+        release: '9-2020-q2-update' # The arm-none-eabi-gcc release to use.
 
     - name: Get code version
       id: get_version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Setup Toolchain
       uses: fiam/arm-none-eabi-gcc@v1
       with:
-        release: '9-2020-q2-update' # The arm-none-eabi-gcc release to use.
+        release: '9-2020-q2' # The arm-none-eabi-gcc release to use.
 
     - name: Get code version
       id: get_version

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -16,7 +16,11 @@ arm_sdk_version:
 ## arm_sdk_install   : Install Arm SDK
 .NOTPARALLEL .PHONY: arm_sdk_install
 
-ARM_SDK_URL_BASE  := https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major
+# source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
+ARM_SDK_URL_BASE  := https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update
+
+# Set up ARM (STM32) SDK
+ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-9-2020-q2-update
 
 # source: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 ifdef LINUX
@@ -33,14 +37,11 @@ endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
 
-# Set up ARM (STM32) SDK
-ARM_SDK_DIR ?= $(TOOLS_DIR)/gcc-arm-none-eabi-9-2019-q4-major
-
 # add toolchain binaries to PATH
 export PATH := $(ARM_SDK_DIR)/bin:$(PATH)
 
 # Checked below, Should match the output of $(shell arm-none-eabi-gcc -dumpversion)
-GCC_REQUIRED_VERSION ?= 9.2.1
+GCC_REQUIRED_VERSION ?= 9.3.1
 
 SDK_INSTALL_MARKER := $(ARM_SDK_DIR)/bin/arm-none-eabi-gcc-$(GCC_REQUIRED_VERSION)
 


### PR DESCRIPTION
minor bump. compiles fine for me.

```
Release notes for
****************************************************
GNU Arm Embedded Toolchain 2020-q2-update
****************************************************

This release includes bare metal pre-built binaries for AArch32 EABI targets,
which can be hosted on:
* Windows 10 or later on 32/64-bit architecture
* Linux
  - on AArch64 (RHEL 7, Ubuntu 14.04 or later)
  - on x86_64 (RHEL 7, Ubuntu 16.04 or later)
* Mac OS X 10.14 or later on 64-bit architecture

For Windows, the binaries are provided with an installer and as a zip file.
For Linux, the binaries are provided as tarball files.
For Mac OS X, the binaries are provided as tarball and pkg files.

The release also contains source code package (together with build scripts and
instructions to setup the build environment), which is composed of:

  * gcc : refs/vendors/ARM/heads/arm-9-branch
    git://gcc.gnu.org/git/gcc.git commit 13861a80750d118fbdca6006ab175903bacbb7ec

  * binutils : binutils-2_34-branch
    git://sourceware.org/git/binutils-gdb.git commit f75c52135257ea05da151a508d99fbaee1bb9dc1

  * newlib and newlib-nano : newlib-3.3.0
    git://sourceware.org/git/newlib-cygwin.git commit 6d79e0a58866548f435527798fbd4a6849d05bc7

  * gdb : gdb-8.3-branch
    git://sourceware.org/git/binutils-gdb.git commit fc94da0a253e925166bbb1a429c190200dc5778d

Note that some or all of the following prerequisites are downloaded when
building from source:

  * EnvVarUpdate NSIS script :
    http://nsis.sourceforge.net/mediawiki/images/a/ad/EnvVarUpdate.7z

  * expat 2.1.1 :
    https://downloads.sourceforge.net/project/expat/expat/2.1.1/expat-2.1.1.tar.bz2

  * gmp 6.1.0 :
    https://gmplib.org/download/gmp/gmp-6.1.0.tar.bz2

  * isl 0.18 :
    http://isl.gforge.inria.fr/isl-0.18.tar.xz

  * libelf 0.8.13 :
    https://fossies.org/linux/misc/old/libelf-0.8.13.tar.gz

  * libiconv 1.15 :
    https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.15.tar.gz

  * mpc 1.0.3 :
    ftp://ftp.gnu.org/gnu/mpc/mpc-1.0.3.tar.gz

  * mpfr 3.1.4 :
    http://www.mpfr.org/mpfr-3.1.4/mpfr-3.1.4.tar.bz2

  * python 2.7.7 :
    https://www.python.org/ftp/python/2.7.7/python-2.7.7.msi

  * zlib 1.2.8 :
    http://www.zlib.net/fossils/zlib-1.2.8.tar.gz

Features:
* All GCC 9.3.1 features, plus latest mainline features

Tests:
* Targets:
  + Variety of Cortex-M0/M0+/M3/M4/M7/A9 boards
  + Qemu
  + Arm Fast Models

Notable changes in 2020-q2-update release:
* Bumped binutils to version 2.34.

* Bumped newlib to version 3.3.0.

* Fixed https://bugs.launchpad.net/gcc-arm-embedded/+bug/1848002
  Parallel builds fail on Windows due to bug in MinGW-w64 used to build binutils.

* Fixed https://community.arm.com/developer/tools-software/tools/f/arm-compilers-forum/46294/macos-objdump-reading-section-bss-failed-because-memory-exhausted
  objdump: Reading section .bss failed because: memory exhausted.

* Fixed https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93188
  Fix rmprofile multilibs when architecture includes +mp or +sec.

* Fixed https://bugs.launchpad.net/gcc-arm-embedded/+bug/1415310
  Extend the --skip_steps to enable skipping the target library strip step.

* Additional v7-a multilib directories:
    thumb/v7-a+fp/softfp
    thumb/v7-a+fp/hard
    thumb/v7-a+simd/softfp
    thumb/v7-a+simd/hard
    thumb/v7-a/nofp

* Additional v7ve multilib directories:
    thumb/v7ve+simd/softfp
    thumb/v7ve+simd/hard

* Additional v8-a multilib directories:
    thumb/v8-a/nofp
    thumb/v8-a+simd/softfp
    thumb/v8-a+simd/hard

Known issues:
* Doing IPA on CMSE generates a linker error:
The linker will error out when resulting object file contains a symbol for
the clone function with the __acle_se prefix that has a non-local binding.
  Issue occurs when compiling binaries for M-profile Secure Extensions where
the compiler may decide to clone a function with the cmse_nonsecure_entry
attribute.
  Although cloning nonsecure entry functions is legal, as long as the clone
is only used inside the secure application, the clone function itself should
not be seen as a secure entry point and so it should not have the __acle_se
prefix.
  A possible work around for this is to add a 'noclone' attribute to
functions with the 'cmse_nonsecure_entry'. This will prevent GCC from cloning
such functions.
```