### PR TITLE
gimbal mode `CINEMATIC` to hack around resource constraints when using `FEATURE_SERVO_TILT`

### DIFF
--- a/src/main/flight/servos.c
+++ b/src/main/flight/servos.c
@@ -504,7 +504,8 @@ static void servoTable(void)
                     break;
                 case GIMBAL_MODE_CINEMATIC:
                     // TODO: rework this crude hack
-                    servo[SERVO_GIMBAL_ROLL] = servo[SERVO_GIMBAL_PITCH] += (-(int32_t)servoParams(SERVO_GIMBAL_PITCH)->rate) * attitude.values.pitch / 50 + (int32_t)servoParams(SERVO_GIMBAL_ROLL)->rate * attitude.values.roll / 50;
+                    // just use roll axis for both servos
+                    servo[SERVO_GIMBAL_ROLL] = servo[SERVO_GIMBAL_PITCH] += (int32_t)servoParams(SERVO_GIMBAL_ROLL)->rate * attitude.values.roll / 50;
                     break;
                 default:
                     servo[SERVO_GIMBAL_PITCH] += (int32_t)servoParams(SERVO_GIMBAL_PITCH)->rate * attitude.values.pitch / 50;

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -186,7 +186,7 @@ static const char * const lookupTableGPSSBASMode[] = {
 
 #ifdef USE_SERVOS
 static const char * const lookupTableGimbalMode[] = {
-    "NORMAL", "MIXTILT"
+    "NORMAL", "MIXTILT", "CINEMATIC"
 };
 #endif
 

--- a/src/main/io/gimbal.h
+++ b/src/main/io/gimbal.h
@@ -24,10 +24,11 @@
 
 typedef enum {
     GIMBAL_MODE_NORMAL = 0,
-    GIMBAL_MODE_MIXTILT = 1
+    GIMBAL_MODE_MIXTILT = 1,
+    GIMBAL_MODE_CINEMATIC = 2
 } gimbalMode_e;
 
-#define GIMBAL_MODE_MAX (GIMBAL_MODE_MIXTILT)
+#define GIMBAL_MODE_MAX (GIMBAL_MODE_CINEMATIC)
 
 typedef struct gimbalConfig_s {
     uint8_t mode;


### PR DESCRIPTION
requested and tested by @B-nutze-RR 🚁 

in context of `FEATURE_SERVO_TILT` this hack adds another gimbal mode… which bascially does not what it is named like but copies the same value for the roll servo to the pitch servo.

it reduces the number of timers required by one, which allows to use one resource less, i.e. keep the buzzer working on `HELIOSPRING` but have one servo to stabilize camera on the roll axis.

this should possibly not be merged to mainline while at the same time it does not change anything if not enabled by `set gimbal_mode = CINEMATIC`.