### PR TITLE
iDecayV2

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -180,7 +180,7 @@ static OSD_Entry cmsx_menuPidAdvancedEntries[] =
     { "BOOST LIMIT YAW",   OME_UINT8, NULL, &(OSD_UINT8_t){ &errorBoostLimitYaw,       0,  250,  1}, 0 },
 
     { "I DECAY",           OME_UINT8, NULL, &(OSD_UINT8_t){ &i_decay,                  1, 10, 1 }, 0 },
-    { "I_DECAY_CUTOFF", OME_UINT8, NULL, &(OSD_UINT8_t){ &i_decay_cutoff,  1, 250, 1 }, 0 },
+    { "I DECAY CUTOFF",    OME_UINT8, NULL, &(OSD_UINT8_t){ &i_decay_cutoff,           1, 250, 1 }, 0 },
 
     { "SAVE&EXIT",         OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT_SAVE, 0},
     { "BACK",              OME_Back, NULL, NULL, 0 },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -62,6 +62,7 @@ static uint8_t pidProfileIndex;
 static char pidProfileIndexString[] = " p";
 static uint8_t feathered_pids;
 static uint8_t i_decay;
+static uint8_t i_decay_cutoff;
 static uint16_t errorBoost;
 static uint8_t errorBoostLimit;
 static uint16_t errorBoostYaw;
@@ -132,6 +133,7 @@ static long cmsx_PidRead(void)
     const pidProfile_t *pidProfile = pidProfiles(pidProfileIndex);
     feathered_pids = pidProfile->feathered_pids;
     i_decay = pidProfile->i_decay;
+    i_decay = pidProfile->i_decay_cutoff;
     errorBoost = pidProfile->errorBoost;
     errorBoostLimit = pidProfile->errorBoostLimit;
     errorBoostYaw = pidProfile->errorBoostYaw;
@@ -169,6 +171,7 @@ static long cmsx_PidWriteback(const OSD_Entry *self)
     pidProfile->errorBoostYaw = errorBoostYaw;
     pidProfile->errorBoostLimitYaw = errorBoostLimitYaw;
     pidProfile->i_decay = i_decay;
+    pidProfile->i_decay_cutoff = i_decay_cutoff;
     pidInitConfig(currentPidProfile);
 
     return 0;
@@ -197,7 +200,9 @@ static OSD_Entry cmsx_menuPidEntries[] =
     { "EMU BOOST YAW", OME_UINT16, NULL, &(OSD_UINT16_t){ &errorBoostYaw,        0,  1000,  5}, 0 },
     { "BOOST LIMIT YAW", OME_UINT8, NULL, &(OSD_UINT8_t){ &errorBoostLimitYaw,   0,  250,  1}, 0 },
 
-    { "I_DECAY", OME_UINT8, NULL, &(OSD_UINT8_t){ &i_decay,  1, 10, 1 }, 0 },
+    { "I_DECAY", OME_UINT8, NULL, &(OSD_UINT8_t){ &i_decay,  1, 50, 1 }, 0 },
+    { "I_DECAY_CUTOFF", OME_UINT8, NULL, &(OSD_UINT8_t){ &i_decay_cutoff,  1, 250, 1 }, 0 },
+
     { "SAVE&EXIT",   OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT_SAVE, 0},
     { "BACK", OME_Back, NULL, NULL, 0 },
     { NULL, OME_END, NULL, NULL, 0 }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -102,6 +102,7 @@ typedef struct pidProfile_s {
     // EmuFlight PID controller parameters
     uint8_t feathered_pids;                 // determine how feathered your pids are
     uint8_t i_decay;						            // i-term decay (increases how quickly iterm shrinks in value)
+    uint8_t i_decay_cutoff;                 // iterm values above which i_decay has full effect
     uint16_t errorBoost;                    // the weight of the setpoint boost
     uint16_t errorBoostYaw;                 // the weight of the setpoint boost for yaw
     uint8_t errorBoostLimit;                // percentage of the error that the emu boost can boost

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -864,8 +864,9 @@ const clivalue_t valueTable[] = {
     { "throttle_boost_cutoff",      VAR_UINT8 | PROFILE_VALUE,  .config.minmax = { 5, 50 }, PG_PID_PROFILE, offsetof(pidProfile_t, throttle_boost_cutoff) },
 #endif
 
-    { "feathered_pids",             VAR_UINT8  | PROFILE_VALUE,  .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, feathered_pids) },
-    { "i_decay",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 10 },  PG_PID_PROFILE, offsetof(pidProfile_t, i_decay) },
+    { "feathered_pids",             VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, feathered_pids) },
+    { "i_decay",                    VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 50 },  PG_PID_PROFILE, offsetof(pidProfile_t, i_decay) },
+    { "i_decay_cutoff",             VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 1, 250 },  PG_PID_PROFILE, offsetof(pidProfile_t, i_decay_cutoff) },
     { "emu_boost",                  VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, errorBoost) },
     { "emu_boost_yaw",              VAR_UINT16 | PROFILE_VALUE, .config.minmax = { 0, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, errorBoostYaw) },
     { "emu_boost_limit",            VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 250 }, PG_PID_PROFILE, offsetof(pidProfile_t, errorBoostLimit) },


### PR DESCRIPTION
Replaces the current iDecay. Just changes the strength of idecay as iterm approaches 0. Removes some bobbles and other issues that iDecay seem to present. This can be made almost the same as iDecay if the cutoff is set to 1. Tester reports are that this is much better.