### PR TITLE
crsf rssi

### DIFF
--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -490,40 +490,22 @@ static bool osdDrawSingleElement(uint8_t item)
     switch (item) {
     case OSD_RSSI_VALUE:
         {
-            if(crsfRssi)
-            {
-				          uint16_t osdLQ = CRSFgetLQ();
-                  uint8_t osdRfMode = CRSFgetRFMode();
-                  uint16_t osdSnR = CRSFgetSnR();
-                  uint8_t osdTXPower = CRSFgetTXPower();
-                  switch (osdRfMode) {
-                          case 0:
-                              uint16_t osdLQfinal = osdLQ;
-                              break;
-                          case 1:
-                              uint16_t osdLQfinal = osdLQ + 100;
-                              break;
-                          case 2:
-                              uint16_t osdLQfinal = osdLQ + 200;
-                              break;
-                      if (osdLQfinal >= 300)
-					                 osdLQfinal = 300;
+            if(crsfRssi){
+				uint16_t osdLQ = rxGetLinkQuality();
+				if (osdLQ >= 100)
+					osdLQ = 99;
+				uint8_t osdRfMode = rxGetRfMode();
+				tfp_sprintf(buff, "%c%1d:%2d", SYM_RSSI, osdRfMode, osdLQ);
+			} else {
+				uint16_t osdRssi = getRssi() * 100 / 1024; // change range
+				if (osdRssi >= 100)
+					osdRssi = 99;
 
-				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
-                  tfp_sprintf(buff, "%3d", osdTXPower);
-                  tfp_sprintf(buff, "%3d", osdSnR);
-            }
-            else
-            {
-				          uint16_t osdRssi = getRssi() * 100 / 1024; // change range
-				          if (osdRssi >= 100)
-					             osdRssi = 99;
-
-				          tfp_sprintf(buff, "%c%2d", SYM_RSSI, osdRssi);
-			      }
+				tfp_sprintf(buff, "%c%2d", SYM_RSSI, osdRssi);
+			}
             break;
         }
-
+	
     case OSD_MAIN_BATT_VOLTAGE:
         buff[0] = osdGetBatterySymbol(osdGetBatteryAverageCellVoltage());
         tfp_sprintf(buff + 1, "%2d.%1d%c", getBatteryVoltage() / 10, getBatteryVoltage() % 10, SYM_VOLT);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -494,28 +494,24 @@ static bool osdDrawSingleElement(uint8_t item)
             {
 				          uint16_t osdLQ = CRSFgetLQ();
                   uint8_t osdRfMode = CRSFgetRFMode();
-
-
-                  uint16_t osdLQfinal = 0;
-                  switch (osdRfMode)
-                  {
+                  uint16_t osdSnR = CRSFgetSnR();
+                  uint8_t osdTXPower = CRSFgetTXPower();
+                  switch (osdRfMode) {
                           case 0:
-                              osdLQfinal = osdLQ;
+                              uint16_t osdLQfinal = osdLQ;
                               break;
                           case 1:
-                              osdLQfinal = osdLQ + 100;
+                              uint16_t osdLQfinal = osdLQ + 100;
                               break;
                           case 2:
-                              osdLQfinal = osdLQ + 200;
+                              uint16_t osdLQfinal = osdLQ + 200;
                               break;
-                  }
-
-                  if (osdLQfinal >= 300)
-					             osdLQfinal = 300;
+                      if (osdLQfinal >= 300)
+					                 osdLQfinal = 300;
 
 				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
-
-
+                  tfp_sprintf(buff, "%3d", osdTXPower);
+                  tfp_sprintf(buff, "%3d", osdSnR);
             }
             else
             {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -490,22 +490,40 @@ static bool osdDrawSingleElement(uint8_t item)
     switch (item) {
     case OSD_RSSI_VALUE:
         {
-            if(crsfRssi){
-				uint16_t osdLQ = rxGetLinkQuality();
-				if (osdLQ >= 100)
-					osdLQ = 99;
-				uint8_t osdRfMode = rxGetRfMode();
-				tfp_sprintf(buff, "%c%1d:%2d", SYM_RSSI, osdRfMode, osdLQ);
-			} else {
-				uint16_t osdRssi = getRssi() * 100 / 1024; // change range
-				if (osdRssi >= 100)
-					osdRssi = 99;
+            if(crsfRssi)
+            {
+				          uint16_t osdLQ = CRSFgetLQ();
+                  uint8_t osdRfMode = CRSFgetRFMode();
+                  uint16_t osdSnR = CRSFgetSnR();
+                  uint8_t osdTXPower = CRSFgetTXPower();
+                  switch (osdRfMode) {
+                          case 0:
+                              uint16_t osdLQfinal = osdLQ;
+                              break;
+                          case 1:
+                              uint16_t osdLQfinal = osdLQ + 100;
+                              break;
+                          case 2:
+                              uint16_t osdLQfinal = osdLQ + 200;
+                              break;
+                      if (osdLQfinal >= 300)
+					                 osdLQfinal = 300;
 
-				tfp_sprintf(buff, "%c%2d", SYM_RSSI, osdRssi);
-			}
+				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
+                  tfp_sprintf(buff, "%3d", osdTXPower);
+                  tfp_sprintf(buff, "%3d", osdSnR);
+            }
+            else
+            {
+				          uint16_t osdRssi = getRssi() * 100 / 1024; // change range
+				          if (osdRssi >= 100)
+					             osdRssi = 99;
+
+				          tfp_sprintf(buff, "%c%2d", SYM_RSSI, osdRssi);
+			      }
             break;
         }
-	
+
     case OSD_MAIN_BATT_VOLTAGE:
         buff[0] = osdGetBatterySymbol(osdGetBatteryAverageCellVoltage());
         tfp_sprintf(buff + 1, "%2d.%1d%c", getBatteryVoltage() / 10, getBatteryVoltage() % 10, SYM_VOLT);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -494,24 +494,28 @@ static bool osdDrawSingleElement(uint8_t item)
             {
 				          uint16_t osdLQ = CRSFgetLQ();
                   uint8_t osdRfMode = CRSFgetRFMode();
-                  uint16_t osdSnR = CRSFgetSnR();
-                  uint8_t osdTXPower = CRSFgetTXPower();
-                  switch (osdRfMode) {
+
+
+                  uint16_t osdLQfinal = 0;
+                  switch (osdRfMode)
+                  {
                           case 0:
-                              uint16_t osdLQfinal = osdLQ;
+                              osdLQfinal = osdLQ;
                               break;
                           case 1:
-                              uint16_t osdLQfinal = osdLQ + 100;
+                              osdLQfinal = osdLQ + 100;
                               break;
                           case 2:
-                              uint16_t osdLQfinal = osdLQ + 200;
+                              osdLQfinal = osdLQ + 200;
                               break;
-                      if (osdLQfinal >= 300)
-					                 osdLQfinal = 300;
+                  }
+
+                  if (osdLQfinal >= 300)
+					             osdLQfinal = 300;
 
 				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
-                  tfp_sprintf(buff, "%3d", osdTXPower);
-                  tfp_sprintf(buff, "%3d", osdSnR);
+
+
             }
             else
             {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -211,3 +211,4 @@ bool osdStatGetState(uint8_t statIndex);
 void osdWarnSetState(uint8_t warningIndex, bool enabled);
 bool osdWarnGetState(uint8_t warningIndex);
 bool osdWarnDjiEnabled(void);
+void setCrsfRssi(bool b);

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -131,9 +131,10 @@ typedef struct crsfPayloadLinkstatistics_s {
 static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, timeUs_t currentTimeUs)
 {
     const crsfLinkStatistics_t stats = *statsPtr;
-    setLinkQualityDirect(stats.uplink_Link_quality);
-    rxSetRfMode(stats.rf_Mode);
-    
+    CRSFsetLQ(stats.uplink_Link_quality);
+    CRSFsetRFMode(stats.rf_Mode);
+    CRSFsetSnR(stats.downlink_SNR);
+    CRSFsetTXPower(stats.uplink_TX_Power);
 }
 
 STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -114,6 +114,28 @@ struct crsfPayloadRcChannelsPacked_s {
 
 typedef struct crsfPayloadRcChannelsPacked_s crsfPayloadRcChannelsPacked_t;
 
+
+typedef struct crsfPayloadLinkstatistics_s {
+    uint8_t uplink_RSSI_1;
+    uint8_t uplink_RSSI_2;
+    uint8_t uplink_Link_quality;
+    int8_t uplink_SNR;
+    uint8_t active_antenna;
+    uint8_t rf_Mode;
+    uint8_t uplink_TX_Power;
+    uint8_t downlink_RSSI;
+    uint8_t downlink_Link_quality;
+    int8_t downlink_SNR;
+} crsfLinkStatistics_t;
+
+static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, timeUs_t currentTimeUs)
+{
+    const crsfLinkStatistics_t stats = *statsPtr;
+    setLinkQualityDirect(stats.uplink_Link_quality);
+    rxSetRfMode(stats.rf_Mode);
+    
+}
+
 STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)
 {
     // CRC includes type and payload
@@ -179,6 +201,15 @@ STATIC_UNIT_TESTED void crsfDataReceive(uint16_t c, void *data)
                             break;
                         }
 #endif
+						case CRSF_FRAMETYPE_LINK_STATISTICS: {
+							 // if to FC and 10 bytes + CRSF_FRAME_ORIGIN_DEST_SIZE
+							 if ((crsfFrame.frame.deviceAddress == CRSF_ADDRESS_FLIGHT_CONTROLLER) &&
+								 (crsfFrame.frame.frameLength == CRSF_FRAME_ORIGIN_DEST_SIZE + CRSF_FRAME_LINK_STATISTICS_PAYLOAD_SIZE)) {
+								 const crsfLinkStatistics_t* statsFrame = (const crsfLinkStatistics_t*)&crsfFrame.frame.payload;
+								 handleCrsfLinkStatisticsFrame(statsFrame, currentTimeUs);
+							 }
+							break;
+						}
                         default:
                             break;
                     }

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -131,10 +131,9 @@ typedef struct crsfPayloadLinkstatistics_s {
 static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, timeUs_t currentTimeUs)
 {
     const crsfLinkStatistics_t stats = *statsPtr;
-    CRSFsetLQ(stats.uplink_Link_quality);
-    CRSFsetRFMode(stats.rf_Mode);
-    CRSFsetSnR(stats.downlink_SNR);
-    CRSFsetTXPower(stats.uplink_TX_Power);
+    setLinkQualityDirect(stats.uplink_Link_quality);
+    rxSetRfMode(stats.rf_Mode);
+    
 }
 
 STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -75,8 +75,10 @@ static uint16_t rssi = 0;                  // range: [0;1023]
 static timeUs_t lastMspRssiUpdateUs = 0;
 
 
-static uint16_t linkQuality = 0;
-static uint8_t rfMode = 0;
+static uint16_t crsflq = 0;
+static uint8_t crsfrfmode = 0;
+static uint16_t crsfsnr = 0;
+static uint8_t crsftxpower = 0;
 
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
@@ -703,24 +705,71 @@ uint8_t getRssiPercent(void)
     return scaleRange(getRssi(), 0, RSSI_MAX_VALUE, 0, 100);
 }
 
-void setLinkQualityDirect(uint16_t linkqualityValue)
+void CRSFsetLQ(uint16_t crsflqValue)
 {
-    linkQuality = linkqualityValue;
+    crsflq = crsflqValue; //linkQuality
 }
 
-void rxSetRfMode(uint8_t rfModeValue)
+void CRSFsetRFMode(uint8_t crsfrfValue)
 {
-    rfMode = rfModeValue;
+    crsfrfmode = crsfrfValue; //rfmode
 }
 
-uint16_t rxGetLinkQuality(void)
+void CRSFsetTXPower(uint8_t crsftxpValue)
 {
-    return linkQuality;
+    switch (crsftxpValue) {
+        case 0:
+            crsftxpower = 0;
+            break;
+        case 1:
+            crsftxpower = 10;
+            break;
+        case 2:
+            crsftxpower = 25;
+            break;
+        case 3:
+            crsftxpower = 100;
+            break;
+        case 4:
+            crsftxpower = 500;
+            break;
+        case 5:
+            crsftxpower = 1000;
+            break;
+        case 6:
+            crsftxpower = 2000;
+            break;
+        case 7:
+            crsftxpower = 250;
+            break;
+        default:
+            crsftxpower = 0;
+            break;
 }
 
-uint8_t rxGetRfMode(void)
+void CRSFsetSnR(uint16_t crsfsnrValue)
 {
-    return rfMode;
+    crsfsnr = crsfsnrValue;
+}
+
+uint16_t CRSFgetLQ(void)
+{
+    return crsflq;
+}
+
+uint8_t CRSFgetRFMode(void)
+{
+    return crsfrfmode;
+}
+
+uint16_t CRSFgetSnR(void)
+{
+    return crsfsnr;
+}
+
+uint8_t CRSFgetTXPower(void)
+{
+    return crsftxpower;
 }
 
 uint16_t rxGetRefreshRate(void)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -78,7 +78,7 @@ static timeUs_t lastMspRssiUpdateUs = 0;
 static uint16_t crsflq = 0;
 static uint8_t crsfrfmode = 0;
 static uint16_t crsfsnr = 0;
-static uint16_t crsftxpower = 0;
+static uint8_t crsftxpower = 0;
 
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
@@ -715,9 +715,36 @@ void CRSFsetRFMode(uint8_t crsfrfValue)
     crsfrfmode = crsfrfValue; //rfmode
 }
 
-void CRSFsetTXPower(uint16_t crsftxpValue)
+void CRSFsetTXPower(uint8_t crsftxpValue)
 {
-    crsftxpower=crsftxpValue;
+    switch (crsftxpValue) {
+        case 0:
+            crsftxpower = 0;
+            break;
+        case 1:
+            crsftxpower = 10;
+            break;
+        case 2:
+            crsftxpower = 25;
+            break;
+        case 3:
+            crsftxpower = 100;
+            break;
+        case 4:
+            crsftxpower = 500;
+            break;
+        case 5:
+            crsftxpower = 1000;
+            break;
+        case 6:
+            crsftxpower = 2000;
+            break;
+        case 7:
+            crsftxpower = 250;
+            break;
+        default:
+            crsftxpower = 0;
+            break;
 }
 
 void CRSFsetSnR(uint16_t crsfsnrValue)
@@ -740,7 +767,7 @@ uint16_t CRSFgetSnR(void)
     return crsfsnr;
 }
 
-uint16_t CRSFgetTXPower(void)
+uint8_t CRSFgetTXPower(void)
 {
     return crsftxpower;
 }

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -47,6 +47,7 @@
 #include "flight/failsafe.h"
 
 #include "io/serial.h"
+#include "io/osd.h"
 
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
@@ -72,6 +73,11 @@ const char rcChannelLetters[] = "AERT12345678abcdefgh";
 
 static uint16_t rssi = 0;                  // range: [0;1023]
 static timeUs_t lastMspRssiUpdateUs = 0;
+
+
+static uint16_t linkQuality = 0;
+static uint8_t rfMode = 0;
+
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
 
@@ -215,6 +221,7 @@ bool serialRxInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfig
 #ifdef USE_SERIALRX_CRSF
     case SERIALRX_CRSF:
         enabled = crsfRxInit(rxConfig, rxRuntimeConfig);
+		setCrsfRssi(true);
         break;
 #endif
 #ifdef USE_SERIALRX_TARGET_CUSTOM
@@ -694,6 +701,26 @@ uint16_t getRssi(void)
 uint8_t getRssiPercent(void)
 {
     return scaleRange(getRssi(), 0, RSSI_MAX_VALUE, 0, 100);
+}
+
+void setLinkQualityDirect(uint16_t linkqualityValue)
+{
+    linkQuality = linkqualityValue;
+}
+
+void rxSetRfMode(uint8_t rfModeValue)
+{
+    rfMode = rfModeValue;
+}
+
+uint16_t rxGetLinkQuality(void)
+{
+    return linkQuality;
+}
+
+uint8_t rxGetRfMode(void)
+{
+    return rfMode;
 }
 
 uint16_t rxGetRefreshRate(void)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -75,10 +75,8 @@ static uint16_t rssi = 0;                  // range: [0;1023]
 static timeUs_t lastMspRssiUpdateUs = 0;
 
 
-static uint16_t crsflq = 0;
-static uint8_t crsfrfmode = 0;
-static uint16_t crsfsnr = 0;
-static uint8_t crsftxpower = 0;
+static uint16_t linkQuality = 0;
+static uint8_t rfMode = 0;
 
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
@@ -705,71 +703,24 @@ uint8_t getRssiPercent(void)
     return scaleRange(getRssi(), 0, RSSI_MAX_VALUE, 0, 100);
 }
 
-void CRSFsetLQ(uint16_t crsflqValue)
+void setLinkQualityDirect(uint16_t linkqualityValue)
 {
-    crsflq = crsflqValue; //linkQuality
+    linkQuality = linkqualityValue;
 }
 
-void CRSFsetRFMode(uint8_t crsfrfValue)
+void rxSetRfMode(uint8_t rfModeValue)
 {
-    crsfrfmode = crsfrfValue; //rfmode
+    rfMode = rfModeValue;
 }
 
-void CRSFsetTXPower(uint8_t crsftxpValue)
+uint16_t rxGetLinkQuality(void)
 {
-    switch (crsftxpValue) {
-        case 0:
-            crsftxpower = 0;
-            break;
-        case 1:
-            crsftxpower = 10;
-            break;
-        case 2:
-            crsftxpower = 25;
-            break;
-        case 3:
-            crsftxpower = 100;
-            break;
-        case 4:
-            crsftxpower = 500;
-            break;
-        case 5:
-            crsftxpower = 1000;
-            break;
-        case 6:
-            crsftxpower = 2000;
-            break;
-        case 7:
-            crsftxpower = 250;
-            break;
-        default:
-            crsftxpower = 0;
-            break;
+    return linkQuality;
 }
 
-void CRSFsetSnR(uint16_t crsfsnrValue)
+uint8_t rxGetRfMode(void)
 {
-    crsfsnr = crsfsnrValue;
-}
-
-uint16_t CRSFgetLQ(void)
-{
-    return crsflq;
-}
-
-uint8_t CRSFgetRFMode(void)
-{
-    return crsfrfmode;
-}
-
-uint16_t CRSFgetSnR(void)
-{
-    return crsfsnr;
-}
-
-uint8_t CRSFgetTXPower(void)
-{
-    return crsftxpower;
+    return rfMode;
 }
 
 uint16_t rxGetRefreshRate(void)

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -78,7 +78,7 @@ static timeUs_t lastMspRssiUpdateUs = 0;
 static uint16_t crsflq = 0;
 static uint8_t crsfrfmode = 0;
 static uint16_t crsfsnr = 0;
-static uint8_t crsftxpower = 0;
+static uint16_t crsftxpower = 0;
 
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
@@ -715,36 +715,9 @@ void CRSFsetRFMode(uint8_t crsfrfValue)
     crsfrfmode = crsfrfValue; //rfmode
 }
 
-void CRSFsetTXPower(uint8_t crsftxpValue)
+void CRSFsetTXPower(uint16_t crsftxpValue)
 {
-    switch (crsftxpValue) {
-        case 0:
-            crsftxpower = 0;
-            break;
-        case 1:
-            crsftxpower = 10;
-            break;
-        case 2:
-            crsftxpower = 25;
-            break;
-        case 3:
-            crsftxpower = 100;
-            break;
-        case 4:
-            crsftxpower = 500;
-            break;
-        case 5:
-            crsftxpower = 1000;
-            break;
-        case 6:
-            crsftxpower = 2000;
-            break;
-        case 7:
-            crsftxpower = 250;
-            break;
-        default:
-            crsftxpower = 0;
-            break;
+    crsftxpower=crsftxpValue;
 }
 
 void CRSFsetSnR(uint16_t crsfsnrValue)
@@ -767,7 +740,7 @@ uint16_t CRSFgetSnR(void)
     return crsfsnr;
 }
 
-uint8_t CRSFgetTXPower(void)
+uint16_t CRSFgetTXPower(void)
 {
     return crsftxpower;
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -173,14 +173,9 @@ void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRange
 void suspendRxPwmPpmSignal(void);
 void resumeRxPwmPpmSignal(void);
 
-//set and get CRSF stats
-void CRSFsetLQ(uint16_t crsflqValue);
-void CRSFsetSnR(uint16_t crsfsnrValue);
-void CRSFsetRFMode(uint8_t crsfrfValue);
-void CRSFsetTXPower(uint8_t crsftxpValue);
-uint16_t CRSFgetLQ(void);
-uint8_t CRSFgetRFMode(void);
-uint16_t CRSFgetSnR(void);
-uint8_t CRSFgetTXPower(void);
+void setLinkQualityDirect(uint16_t linkqualityValue);
+void rxSetRfMode(uint8_t rfModeValue);
+uint16_t rxGetLinkQuality(void);
+uint8_t rxGetRfMode(void);
 
 uint16_t rxGetRefreshRate(void);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -173,4 +173,9 @@ void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRange
 void suspendRxPwmPpmSignal(void);
 void resumeRxPwmPpmSignal(void);
 
+void setLinkQualityDirect(uint16_t linkqualityValue);
+void rxSetRfMode(uint8_t rfModeValue);
+uint16_t rxGetLinkQuality(void);
+uint8_t rxGetRfMode(void);
+
 uint16_t rxGetRefreshRate(void);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -177,10 +177,10 @@ void resumeRxPwmPpmSignal(void);
 void CRSFsetLQ(uint16_t crsflqValue);
 void CRSFsetSnR(uint16_t crsfsnrValue);
 void CRSFsetRFMode(uint8_t crsfrfValue);
-void CRSFsetTXPower(uint16_t crsftxpValue);
+void CRSFsetTXPower(uint8_t crsftxpValue);
 uint16_t CRSFgetLQ(void);
 uint8_t CRSFgetRFMode(void);
 uint16_t CRSFgetSnR(void);
-uint16_t CRSFgetTXPower(void);
+uint8_t CRSFgetTXPower(void);
 
 uint16_t rxGetRefreshRate(void);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -177,10 +177,10 @@ void resumeRxPwmPpmSignal(void);
 void CRSFsetLQ(uint16_t crsflqValue);
 void CRSFsetSnR(uint16_t crsfsnrValue);
 void CRSFsetRFMode(uint8_t crsfrfValue);
-void CRSFsetTXPower(uint8_t crsftxpValue);
+void CRSFsetTXPower(uint16_t crsftxpValue);
 uint16_t CRSFgetLQ(void);
 uint8_t CRSFgetRFMode(void);
 uint16_t CRSFgetSnR(void);
-uint8_t CRSFgetTXPower(void);
+uint16_t CRSFgetTXPower(void);
 
 uint16_t rxGetRefreshRate(void);

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -173,9 +173,14 @@ void resetAllRxChannelRangeConfigurations(rxChannelRangeConfig_t *rxChannelRange
 void suspendRxPwmPpmSignal(void);
 void resumeRxPwmPpmSignal(void);
 
-void setLinkQualityDirect(uint16_t linkqualityValue);
-void rxSetRfMode(uint8_t rfModeValue);
-uint16_t rxGetLinkQuality(void);
-uint8_t rxGetRfMode(void);
+//set and get CRSF stats
+void CRSFsetLQ(uint16_t crsflqValue);
+void CRSFsetSnR(uint16_t crsfsnrValue);
+void CRSFsetRFMode(uint8_t crsfrfValue);
+void CRSFsetTXPower(uint8_t crsftxpValue);
+uint16_t CRSFgetLQ(void);
+uint8_t CRSFgetRFMode(void);
+uint16_t CRSFgetSnR(void);
+uint8_t CRSFgetTXPower(void);
 
 uint16_t rxGetRefreshRate(void);


### PR DESCRIPTION
When crsf is selected as the rx protocol to use, the osd rssi will now display rfmode and link quality data in place of rssi in the format of "SYM rfmode : lq" with rfmode being (2,1,0) for (150hz, 50hz,4hz) and lq being 0-99 scale.
