### PR TITLE
CRSF LQ Proper [PR round 2!]

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -65,7 +65,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"RSSI / LQ",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
     {"CRSF TX POWER",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_TX], 0},
     {"CRSF SNR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_SNR], 0},
-    {"CRSF NOISE LVL",     OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_RSSI], 0},
+    {"CRSF RSSI",     OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_RSSI], 0},
     {"BATTERY VOLTAGE",    OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
     {"BATTERY USAGE",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_USAGE], 0},
     {"AVG CELL VOLTAGE",   OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], 0},

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -62,7 +62,10 @@ static long menuOsdActiveElemsOnExit(const OSD_Entry *self)
 OSD_Entry menuOsdActiveElemsEntries[] =
 {
     {"--- ACTIV ELEM ---", OME_Label,   NULL, NULL, 0},
-    {"RSSI",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
+    {"RSSI / LQ",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
+    {"CRSF TX POWER",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_TX], 0},
+    {"CRSF SNR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_SNR], 0},
+    {"CRSF NOISE LVL",     OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_RSSI], 0},
     {"BATTERY VOLTAGE",    OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
     {"BATTERY USAGE",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_USAGE], 0},
     {"AVG CELL VOLTAGE",   OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], 0},

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -983,6 +983,9 @@ const clivalue_t valueTable[] = {
 
     { "osd_vbat_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_VOLTAGE]) },
     { "osd_rssi_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RSSI_VALUE]) },
+    { "osd_crsf_tx_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_TX]) },
+    { "osd_crsf_snr_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_SNR]) },
+    { "osd_crsf_rssi_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_RSSI]) },
     { "osd_tim_1_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_1]) },
     { "osd_tim_2_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_2]) },
     { "osd_remaining_time_estimate_pos",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_REMAINING_TIME_ESTIMATE]) },

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1222,13 +1222,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10);
     osdConfig->timers[OSD_TIMER_2] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10);
 
-    if(crsfRssi)
-      {
-        osdConfig->lq_alarm = 70;
-        osdConfig->rssi_alarm = 0;
-      }
-    else
-        osdConfig->rssi_alarm = 20;
+    osdConfig->lq_alarm = 70;
+    osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm  = 2200;
     osdConfig->alt_alarm  = 100; // meters or feet depend on configuration
     osdConfig->esc_temp_alarm = ESC_TEMP_ALARM_OFF; // off by default

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -498,7 +498,6 @@ static bool osdDrawSingleElement(uint8_t item)
             {
 				          uint16_t osdLQ = CRSFgetLQ();
                   uint8_t osdRfMode = CRSFgetRFMode();
-                  uint16_t osdLQfinal = 0;
                   switch (osdRfMode)
                   {
                           case 2:
@@ -579,7 +578,7 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
       }
 
-      case OSD_CRSF_RSSI: //crsf noise level
+      case OSD_CRSF_RSSI: //crsf rssi
       {
         uint8_t osdcrsfrssi = CRSFgetRSSI();
         tfp_sprintf(buff, "-%2dDBM" , osdcrsfrssi );

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -95,6 +95,10 @@ typedef enum {
     OSD_ADJUSTMENT_RANGE,
     OSD_CORE_TEMPERATURE,
     OSD_G_FORCE,
+    OSD_CRSF_SNR,
+    OSD_CRSF_TX,
+    OSD_CRSF_RSSI,
+
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -181,8 +185,10 @@ typedef struct osdConfig_s {
     uint16_t alt_alarm;
     uint16_t lq_alarm;
     uint8_t rssi_alarm;
-    uint16_t distance_alarm;
+uint16_t distance_alarm;
+
     osd_unit_e units;
+
     uint16_t timers[OSD_TIMER_COUNT];
     uint16_t enabledWarnings;
 

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -135,7 +135,17 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
     CRSFsetRFMode(stats.rf_Mode);
     CRSFsetSnR(stats.downlink_SNR);
     CRSFsetTXPower(stats.uplink_TX_Power);
+    if(stats.uplink_RSSI_1 == 0)
+    CRSFsetRSSI(stats.uplink_RSSI_2);
+    else if(stats.uplink_RSSI_2 == 0)
+    CRSFsetRSSI(stats.uplink_RSSI_1);
+    else
+    {
+      uint8_t rssimin=MIN(stats.uplink_RSSI_1, stats.uplink_RSSI_2) *-1;
+      CRSFsetRSSI(rssimin);
+    }
 }
+
 
 STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)
 {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -78,6 +78,7 @@ static uint16_t crsflq = 0;
 static uint8_t crsfrfmode = 0;
 static uint16_t crsfsnr = 0;
 static uint16_t crsftxpower = 0;
+static uint16_t crsfrssi = 0;
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
 
@@ -715,7 +716,7 @@ void CRSFsetRFMode(uint8_t crsfrfValue)
 
 void CRSFsetTXPower(uint16_t crsftxpValue)
 {
-    crsftxpower=crsftxpValue;
+    crsftxpower = crsftxpValue;
 }
 
 void CRSFsetSnR(uint16_t crsfsnrValue)
@@ -723,6 +724,15 @@ void CRSFsetSnR(uint16_t crsfsnrValue)
     crsfsnr = crsfsnrValue;
 }
 
+void CRSFsetRSSI(uint8_t crsfrssiValue)
+{
+  crsfrssi = crsfrssiValue;
+}
+
+uint8_t CRSFgetRSSI(void)
+{
+    return crsfrssi;
+}
 uint16_t CRSFgetLQ(void)
 {
     return crsflq;
@@ -733,7 +743,7 @@ uint8_t CRSFgetRFMode(void)
     return crsfrfmode;
 }
 
-uint16_t CRSFgetSnR(void)
+uint8_t CRSFgetSnR(void)
 {
     return crsfsnr;
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -176,11 +176,13 @@ void resumeRxPwmPpmSignal(void);
 //set and get CRSF stats
 void CRSFsetLQ(uint16_t crsflqValue);
 void CRSFsetSnR(uint16_t crsfsnrValue);
+void CRSFsetRSSI(uint8_t crsfrssiValue);
 void CRSFsetRFMode(uint8_t crsfrfValue);
 void CRSFsetTXPower(uint16_t crsftxpValue);
+uint8_t CRSFgetRSSI(void);
 uint16_t CRSFgetLQ(void);
 uint8_t CRSFgetRFMode(void);
-uint16_t CRSFgetSnR(void);
+uint8_t CRSFgetSnR(void);
 uint16_t CRSFgetTXPower(void);
 
 uint16_t rxGetRefreshRate(void);


### PR DESCRIPTION
* Show CRSF LQ mode 1 as 0-99, mode 2 as 0-300
* add dB and SNR
* configurable blink threshold `osd_lq_alarm`

finallized CRSF OSD elements..
tested LQ properly switching
added noise level
added signal to noise ratio
added Tx Power

LQ test = https://youtu.be/CDPf6unYv24
snr/noise/tx elements =https://youtu.be/CVroHVWUAcQ