### PR TITLE
CRSF LQ OSD Style options

### DIFF
--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -65,7 +65,7 @@ OSD_Entry menuOsdActiveElemsEntries[] =
     {"RSSI / LQ",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
     {"CRSF TX POWER",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_TX], 0},
     {"CRSF SNR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_SNR], 0},
-    {"CRSF NOISE LVL",     OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_RSSI], 0},
+    {"CRSF RSSI",     OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_RSSI], 0},
     {"BATTERY VOLTAGE",    OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
     {"BATTERY USAGE",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_USAGE], 0},
     {"AVG CELL VOLTAGE",   OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], 0},

--- a/src/main/cms/cms_menu_osd.c
+++ b/src/main/cms/cms_menu_osd.c
@@ -62,7 +62,10 @@ static long menuOsdActiveElemsOnExit(const OSD_Entry *self)
 OSD_Entry menuOsdActiveElemsEntries[] =
 {
     {"--- ACTIV ELEM ---", OME_Label,   NULL, NULL, 0},
-    {"RSSI",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
+    {"RSSI / LQ",               OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_RSSI_VALUE], 0},
+    {"CRSF TX POWER",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_TX], 0},
+    {"CRSF SNR",           OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_SNR], 0},
+    {"CRSF NOISE LVL",     OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_CRSF_RSSI], 0},
     {"BATTERY VOLTAGE",    OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_VOLTAGE], 0},
     {"BATTERY USAGE",      OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_MAIN_BATT_USAGE], 0},
     {"AVG CELL VOLTAGE",   OME_VISIBLE, NULL, &osdConfig_item_pos[OSD_AVG_CELL_VOLTAGE], 0},

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -146,7 +146,7 @@ static const char * const lookupTableUnit[] = {
     "IMPERIAL", "METRIC"
 };
 
-static const char * const lookupTableFormat[] = {
+static const char * const lookupTableCrsfformat[] = {
     "TBS", "MODE", "FREQ"
 };
 
@@ -376,7 +376,7 @@ static const char * const lookupTableRcSmoothingDerivativeType[] = {
 const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOffOn),
     LOOKUP_TABLE_ENTRY(lookupTableUnit),
-    LOOKUP_TABLE_ENTRY(lookupTableFormat),
+    LOOKUP_TABLE_ENTRY(lookupTableCrsfformat),
     LOOKUP_TABLE_ENTRY(lookupTableAlignment),
 #ifdef USE_GPS
     LOOKUP_TABLE_ENTRY(lookupTableGPSProvider),
@@ -968,7 +968,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",              VAR_UINT16  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRSFFORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -146,6 +146,10 @@ static const char * const lookupTableUnit[] = {
     "IMPERIAL", "METRIC"
 };
 
+static const char * const lookupTableCrsfFormat[] = {
+    "TBS", "MODE", "FREQ"
+};
+
 static const char * const lookupTableAlignment[] = {
     "DEFAULT",
     "CW0",
@@ -372,6 +376,7 @@ static const char * const lookupTableRcSmoothingDerivativeType[] = {
 const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOffOn),
     LOOKUP_TABLE_ENTRY(lookupTableUnit),
+    LOOKUP_TABLE_ENTRY(lookupTableCrsfFormat),
     LOOKUP_TABLE_ENTRY(lookupTableAlignment),
 #ifdef USE_GPS
     LOOKUP_TABLE_ENTRY(lookupTableGPSProvider),
@@ -963,7 +968,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 3 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",              VAR_UINT16  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRSF_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -302,8 +302,8 @@ static const char * const lookupTableMax7456Clock[] = {
 };
 #endif
 
-static const char * const lookupTableLqFormat[] = {
-    "300", "MODE", "FREQ"
+static const char * const lookupTableCrsfLqFormat[] = {
+    "300", "MODE", "EMU"
 };
 
 #ifdef USE_GYRO_OVERFLOW_CHECK
@@ -413,7 +413,7 @@ const lookupTableEntry_t lookupTables[] = {
 #if defined(USE_GYRO_IMUF9001)
     LOOKUP_TABLE_ENTRY(lookupTableImufRate),
 #endif
-    LOOKUP_TABLE_ENTRY(lookupTableLqFormat),
+    LOOKUP_TABLE_ENTRY(lookupTableCrsfLqFormat),
     LOOKUP_TABLE_ENTRY(debugModeNames),
     LOOKUP_TABLE_ENTRY(lookupTablePwmProtocol),
     LOOKUP_TABLE_ENTRY(lookupTableRcInterpolation),
@@ -968,7 +968,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_LQ_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE,| MODE_LOOKUP, .config.lookup = { TABLE_CRSF_LQ_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -963,6 +963,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
+    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 3 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -983,6 +983,9 @@ const clivalue_t valueTable[] = {
 
     { "osd_vbat_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_MAIN_BATT_VOLTAGE]) },
     { "osd_rssi_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_RSSI_VALUE]) },
+    { "osd_crsf_tx_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_TX]) },
+    { "osd_crsf_snr_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_SNR]) },
+    { "osd_crsf_rssi_pos",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_CRSF_RSSI]) },
     { "osd_tim_1_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_1]) },
     { "osd_tim_2_pos",              VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_ITEM_TIMER_2]) },
     { "osd_remaining_time_estimate_pos",        VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, OSD_POSCFG_MAX }, PG_OSD_CONFIG, offsetof(osdConfig_t, item_pos[OSD_REMAINING_TIME_ESTIMATE]) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -146,7 +146,7 @@ static const char * const lookupTableUnit[] = {
     "IMPERIAL", "METRIC"
 };
 
-static const char * const lookupTableCrsfFormat[] = {
+static const char * const lookupTableFormat[] = {
     "TBS", "MODE", "FREQ"
 };
 
@@ -376,7 +376,7 @@ static const char * const lookupTableRcSmoothingDerivativeType[] = {
 const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOffOn),
     LOOKUP_TABLE_ENTRY(lookupTableUnit),
-    LOOKUP_TABLE_ENTRY(lookupTableCrsfFormat),
+    LOOKUP_TABLE_ENTRY(lookupTableFormat),
     LOOKUP_TABLE_ENTRY(lookupTableAlignment),
 #ifdef USE_GPS
     LOOKUP_TABLE_ENTRY(lookupTableGPSProvider),
@@ -968,7 +968,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",              VAR_UINT16  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_CRSF_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",              VAR_UINT16  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -302,8 +302,8 @@ static const char * const lookupTableMax7456Clock[] = {
 };
 #endif
 
-static const char * const lookupTableCrsfLqFormat[] = {
-    "300", "MODE", "EMU"
+static const char * const lookupTableLqFormat[] = {
+    "300", "MODE", "FREQ"
 };
 
 #ifdef USE_GYRO_OVERFLOW_CHECK
@@ -413,7 +413,7 @@ const lookupTableEntry_t lookupTables[] = {
 #if defined(USE_GYRO_IMUF9001)
     LOOKUP_TABLE_ENTRY(lookupTableImufRate),
 #endif
-    LOOKUP_TABLE_ENTRY(lookupTableCrsfLqFormat),
+    LOOKUP_TABLE_ENTRY(lookupTableLqFormat),
     LOOKUP_TABLE_ENTRY(debugModeNames),
     LOOKUP_TABLE_ENTRY(lookupTablePwmProtocol),
     LOOKUP_TABLE_ENTRY(lookupTableRcInterpolation),
@@ -968,7 +968,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE,| MODE_LOOKUP, .config.lookup = { TABLE_CRSF_LQ_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",              VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_LQ_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -302,10 +302,6 @@ static const char * const lookupTableMax7456Clock[] = {
 };
 #endif
 
-static const char * const lookupTableCrsfLqFormat[] = {
-    "300", "MODE", "EMU"
-};
-
 #ifdef USE_GYRO_OVERFLOW_CHECK
 static const char * const lookupTableGyroOverflowCheck[] = {
     "OFF", "YAW", "ALL"
@@ -413,7 +409,6 @@ const lookupTableEntry_t lookupTables[] = {
 #if defined(USE_GYRO_IMUF9001)
     LOOKUP_TABLE_ENTRY(lookupTableImufRate),
 #endif
-    LOOKUP_TABLE_ENTRY(lookupTableCrsfLqFormat),
     LOOKUP_TABLE_ENTRY(debugModeNames),
     LOOKUP_TABLE_ENTRY(lookupTablePwmProtocol),
     LOOKUP_TABLE_ENTRY(lookupTableRcInterpolation),
@@ -968,7 +963,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE,| MODE_LOOKUP, .config.lookup = { TABLE_CRSF_LQ_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 3 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -963,7 +963,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-
+    { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },
     { "osd_alt_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 10000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, alt_alarm) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -302,6 +302,10 @@ static const char * const lookupTableMax7456Clock[] = {
 };
 #endif
 
+static const char * const lookupTableCrsfLqFormat[] = {
+    "300", "MODE", "EMU"
+};
+
 #ifdef USE_GYRO_OVERFLOW_CHECK
 static const char * const lookupTableGyroOverflowCheck[] = {
     "OFF", "YAW", "ALL"
@@ -409,6 +413,7 @@ const lookupTableEntry_t lookupTables[] = {
 #if defined(USE_GYRO_IMUF9001)
     LOOKUP_TABLE_ENTRY(lookupTableImufRate),
 #endif
+    LOOKUP_TABLE_ENTRY(lookupTableCrsfLqFormat),
     LOOKUP_TABLE_ENTRY(debugModeNames),
     LOOKUP_TABLE_ENTRY(lookupTablePwmProtocol),
     LOOKUP_TABLE_ENTRY(lookupTableRcInterpolation),
@@ -963,7 +968,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "osd_warn_rc_smoothing",      VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_RC_SMOOTHING,     PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
     { "osd_warn_dji",               VAR_UINT16  | MASTER_VALUE | MODE_BITSET, .config.bitpos = OSD_WARNING_DJI,              PG_OSD_CONFIG, offsetof(osdConfig_t, enabledWarnings)},
-    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE, .config.minmax = { 1, 3 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
+    { "osd_lq_format",               VAR_UINT8  | MASTER_VALUE,| MODE_LOOKUP, .config.lookup = { TABLE_CRSF_LQ_FORMAT }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_format) },
     { "osd_lq_alarm",               VAR_UINT16  | MASTER_VALUE, .config.minmax = { 0, 300 }, PG_OSD_CONFIG, offsetof(osdConfig_t, lq_alarm) },
     { "osd_rssi_alarm",             VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 100 }, PG_OSD_CONFIG, offsetof(osdConfig_t, rssi_alarm) },
     { "osd_cap_alarm",              VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 20000 }, PG_OSD_CONFIG, offsetof(osdConfig_t, cap_alarm) },

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -28,7 +28,7 @@
 typedef enum {
     TABLE_OFF_ON = 0,
     TABLE_UNIT,
-    TABLE_FORMAT,
+    TABLE_CRSFFORMAT,
     TABLE_ALIGNMENT,
 #ifdef USE_GPS
     TABLE_GPS_PROVIDER,

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -80,6 +80,7 @@ typedef enum {
 #ifdef USE_MAX7456
     TABLE_MAX7456_CLOCK,
 #endif
+  TABLE_LQ_FORMAT,
 #ifdef USE_RANGEFINDER
     TABLE_RANGEFINDER_HARDWARE,
 #endif

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -80,7 +80,6 @@ typedef enum {
 #ifdef USE_MAX7456
     TABLE_MAX7456_CLOCK,
 #endif
-  TABLE_LQ_FORMAT,
 #ifdef USE_RANGEFINDER
     TABLE_RANGEFINDER_HARDWARE,
 #endif

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -28,6 +28,7 @@
 typedef enum {
     TABLE_OFF_ON = 0,
     TABLE_UNIT,
+    TABLE_CRSF_FORMAT,
     TABLE_ALIGNMENT,
 #ifdef USE_GPS
     TABLE_GPS_PROVIDER,

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -28,7 +28,7 @@
 typedef enum {
     TABLE_OFF_ON = 0,
     TABLE_UNIT,
-    TABLE_CRSF_FORMAT,
+    TABLE_FORMAT,
     TABLE_ALIGNMENT,
 #ifdef USE_GPS
     TABLE_GPS_PROVIDER,

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1222,13 +1222,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10);
     osdConfig->timers[OSD_TIMER_2] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10);
 
-    if(crsfRssi)
-      {
-        osdConfig->lq_alarm = 70;
-        osdConfig->rssi_alarm = 0;
-      }
-    else
-        osdConfig->rssi_alarm = 20;
+    osdConfig->lq_alarm = 70;
+    osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm  = 2200;
     osdConfig->alt_alarm  = 100; // meters or feet depend on configuration
     osdConfig->esc_temp_alarm = ESC_TEMP_ALARM_OFF; // off by default

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -498,7 +498,6 @@ static bool osdDrawSingleElement(uint8_t item)
             {
 				          uint16_t osdLQ = CRSFgetLQ();
                   uint8_t osdRfMode = CRSFgetRFMode();
-                  uint16_t osdLQfinal = 0;
                   switch (osdRfMode)
                   {
                           case 2:
@@ -579,7 +578,7 @@ static bool osdDrawSingleElement(uint8_t item)
         break;
       }
 
-      case OSD_CRSF_RSSI: //crsf noise level
+      case OSD_CRSF_RSSI: //crsf rssi
       {
         uint8_t osdcrsfrssi = CRSFgetRSSI();
         tfp_sprintf(buff, "-%2dDBM" , osdcrsfrssi );

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -498,24 +498,51 @@ static bool osdDrawSingleElement(uint8_t item)
             {
 				          uint16_t osdLQ = CRSFgetLQ();
                   uint8_t osdRfMode = CRSFgetRFMode();
-                  switch (osdRfMode)
+
+                switch (osdConfig()->lq_format)
                   {
-                          case 2:
+                  case 3:
+                    switch (osdRfMode)
+                    {
+                            case 2:
                               osdLQfinal = osdLQ * 3;
                               if (osdLQfinal<200)
                                 osdLQfinal=200;
                               break;
-                          default:
-                            osdLQfinal = osdLQ;
-                            break;
+                            default:
+                              osdLQfinal = osdLQ;
+                              break;
+                        }
+                    if (osdLQfinal >= 300)
+                      osdLQfinal = 300;
+
+  				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
+                    break;
+
+                  case 2:
+                    if (osdLQ >=100)
+                      osdLQ = 100;
+                    tfp_sprintf(buff, "%1d:%d", osdRfMode, osdLQ);
+                    break;
+
+                  case 1:
+                    switch(osdRfMode)
+                      {
+                        case 0:
+                          osdRfMode = 4;
+                          break;
+                        case 1:
+                          osdRfMode = 50;
+                          break;
+                        case 2:
+                          osdRfMode = 150;
+                          break;
+                      }
+                    tfp_sprintf(buff, "%3dHZ:%d", osdRfMode, osdLQ);
+                    break;
+
+
                   }
-
-                  if (osdLQfinal >= 300)
-					             osdLQfinal = 300;
-
-				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
-
-
             }
             else
             {
@@ -1220,7 +1247,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 
     osdConfig->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10);
     osdConfig->timers[OSD_TIMER_2] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10);
-
+    osdConfig->lq_format = 3;
     osdConfig->lq_alarm = 70;
     osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm  = 2200;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1209,10 +1209,8 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
     osdConfig->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10);
     osdConfig->timers[OSD_TIMER_2] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10);
 
-    if(crsfRssi)
-        osdConfig->rssi_alarm = 170;
-    else
-        osdConfig->rssi_alarm = 20;
+    osdConfig->lq_alarm = 170;
+    osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm  = 2200;
     osdConfig->alt_alarm  = 100; // meters or feet depend on configuration
     osdConfig->esc_temp_alarm = ESC_TEMP_ALARM_OFF; // off by default
@@ -1309,7 +1307,7 @@ void osdUpdateAlarms(void)
                   break;
       }
 
-      if (osdLQfinal <= 170)  //CRSF RSSI_alarm = set to 160 (Mode1 : 60)
+      if (osdLQfinal <= osdConfig()->lq_alarm)  //CRSF RSSI_alarm = set to 170 (Mode1 : 60)
         SET_BLINK(OSD_RSSI_VALUE);
       else
         CLR_BLINK(OSD_RSSI_VALUE);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -504,7 +504,7 @@ static bool osdDrawSingleElement(uint8_t item)
                   case 3:
                     switch (osdRfMode)
                     {
-                            case 300:
+                            case 2:
                               osdLQfinal = osdLQ * 3;
                               if (osdLQfinal<200)
                                 osdLQfinal=200;
@@ -519,13 +519,13 @@ static bool osdDrawSingleElement(uint8_t item)
   				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
                     break;
 
-                  case MODE:
+                  case 2:
                     if (osdLQ >=100)
                       osdLQ = 100;
-                    tfp_sprintf(buff, "%1-d:%+d", osdRfMode, osdLQ);
+                    tfp_sprintf(buff, "%1d:%d", osdRfMode, osdLQ);
                     break;
 
-                  case FREQ:
+                  case 1:
                     switch(osdRfMode)
                       {
                         case 0:
@@ -538,7 +538,7 @@ static bool osdDrawSingleElement(uint8_t item)
                           osdRfMode = 150;
                           break;
                       }
-                    tfp_sprintf(buff, "%3+dHZ:%+d", osdRfMode, osdLQ);
+                    tfp_sprintf(buff, "%3dHZ:%d", osdRfMode, osdLQ);
                     break;
 
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -498,7 +498,7 @@ static bool osdDrawSingleElement(uint8_t item)
             {
 				          uint16_t osdLQ = CRSFgetLQ();
                   uint8_t osdRfMode = CRSFgetRFMode();
-
+                  osdLQfinal = osdLQ;
                 switch (osdConfig()->lq_format)
                   {
 
@@ -523,14 +523,12 @@ static bool osdDrawSingleElement(uint8_t item)
 
 
                   case MODE:
-                    osdLQfinal = osdLQ;
-                    if (osdLQ >=100)
+                      if (osdLQ >=100)
                       osdLQfinal = 100;
                     tfp_sprintf(buff, "%1d:%d", osdRfMode, osdLQfinal);
                     break;
 
                   case FREQ:
-                    osdLQfinal = osdLQ;
                     switch(osdRfMode)
                       {
                         case 0:
@@ -1252,7 +1250,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 
     osdConfig->timers[OSD_TIMER_1] = OSD_TIMER(OSD_TIMER_SRC_ON, OSD_TIMER_PREC_SECOND, 10);
     osdConfig->timers[OSD_TIMER_2] = OSD_TIMER(OSD_TIMER_SRC_TOTAL_ARMED, OSD_TIMER_PREC_SECOND, 10);
-    osdConfig->lq_format = 3;
+    osdConfig->lq_format = TBS;
     osdConfig->lq_alarm = 70;
     osdConfig->rssi_alarm = 20;
     osdConfig->cap_alarm  = 2200;

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -501,10 +501,10 @@ static bool osdDrawSingleElement(uint8_t item)
 
                 switch (osdConfig()->lq_format)
                   {
-                  case 0:
+                  case 3:
                     switch (osdRfMode)
                     {
-                            case 2:
+                            case 300:
                               osdLQfinal = osdLQ * 3;
                               if (osdLQfinal<200)
                                 osdLQfinal=200;
@@ -519,13 +519,13 @@ static bool osdDrawSingleElement(uint8_t item)
   				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
                     break;
 
-                  case 1:
+                  case MODE:
                     if (osdLQ >=100)
                       osdLQ = 100;
                     tfp_sprintf(buff, "%1-d:%+d", osdRfMode, osdLQ);
                     break;
 
-                  case 2:
+                  case FREQ:
                     switch(osdRfMode)
                       {
                         case 0:

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -504,7 +504,7 @@ static bool osdDrawSingleElement(uint8_t item)
                   case 3:
                     switch (osdRfMode)
                     {
-                            case 2:
+                            case 300:
                               osdLQfinal = osdLQ * 3;
                               if (osdLQfinal<200)
                                 osdLQfinal=200;
@@ -519,13 +519,13 @@ static bool osdDrawSingleElement(uint8_t item)
   				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
                     break;
 
-                  case 2:
+                  case MODE:
                     if (osdLQ >=100)
                       osdLQ = 100;
-                    tfp_sprintf(buff, "%1d:%d", osdRfMode, osdLQ);
+                    tfp_sprintf(buff, "%1-d:%+d", osdRfMode, osdLQ);
                     break;
 
-                  case 1:
+                  case FREQ:
                     switch(osdRfMode)
                       {
                         case 0:
@@ -538,7 +538,7 @@ static bool osdDrawSingleElement(uint8_t item)
                           osdRfMode = 150;
                           break;
                       }
-                    tfp_sprintf(buff, "%3dHZ:%d", osdRfMode, osdLQ);
+                    tfp_sprintf(buff, "%3+dHZ:%+d", osdRfMode, osdLQ);
                     break;
 
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -501,7 +501,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
                 switch (osdConfig()->lq_format)
                   {
-                  case 3:
+                  case TBS:
                     switch (osdRfMode)
                     {
                             case 2:
@@ -519,13 +519,15 @@ static bool osdDrawSingleElement(uint8_t item)
   				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
                     break;
 
-                  case 2:
+                  case MODE:
+                    osdLQfinal = osdLQ;
                     if (osdLQ >=100)
-                      osdLQ = 100;
-                    tfp_sprintf(buff, "%1d:%d", osdRfMode, osdLQ);
+                      osdLQfinal = 100;
+                    tfp_sprintf(buff, "%1d:%d", osdRfMode, osdLQfinal);
                     break;
 
-                  case 1:
+                  case FREQ:
+                    osdLQfinal = osdLQ;
                     switch(osdRfMode)
                       {
                         case 0:
@@ -538,7 +540,7 @@ static bool osdDrawSingleElement(uint8_t item)
                           osdRfMode = 150;
                           break;
                       }
-                    tfp_sprintf(buff, "%3dHZ:%d", osdRfMode, osdLQ);
+                    tfp_sprintf(buff, "%3dHZ:%d", osdRfMode, osdLQfinal);
                     break;
 
 

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -501,10 +501,10 @@ static bool osdDrawSingleElement(uint8_t item)
 
                 switch (osdConfig()->lq_format)
                   {
-                  case 3:
+                  case 0:
                     switch (osdRfMode)
                     {
-                            case 300:
+                            case 2:
                               osdLQfinal = osdLQ * 3;
                               if (osdLQfinal<200)
                                 osdLQfinal=200;
@@ -519,13 +519,13 @@ static bool osdDrawSingleElement(uint8_t item)
   				          tfp_sprintf(buff, "%c%3d", LINK_QUALITY, osdLQfinal);
                     break;
 
-                  case MODE:
+                  case 1:
                     if (osdLQ >=100)
                       osdLQ = 100;
                     tfp_sprintf(buff, "%1-d:%+d", osdRfMode, osdLQ);
                     break;
 
-                  case FREQ:
+                  case 2:
                     switch(osdRfMode)
                       {
                         case 0:

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -95,6 +95,10 @@ typedef enum {
     OSD_ADJUSTMENT_RANGE,
     OSD_CORE_TEMPERATURE,
     OSD_G_FORCE,
+    OSD_CRSF_SNR,
+    OSD_CRSF_TX,
+    OSD_CRSF_RSSI,
+
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
@@ -181,8 +185,10 @@ typedef struct osdConfig_s {
     uint16_t alt_alarm;
     uint16_t lq_alarm;
     uint8_t rssi_alarm;
-    uint16_t distance_alarm;
+uint16_t distance_alarm;
+
     osd_unit_e units;
+
     uint16_t timers[OSD_TIMER_COUNT];
     uint16_t enabledWarnings;
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -183,9 +183,10 @@ typedef struct osdConfig_s {
     // Alarms
     uint16_t cap_alarm;
     uint16_t alt_alarm;
+    uint8_t lq_format;
     uint16_t lq_alarm;
     uint8_t rssi_alarm;
-uint16_t distance_alarm;
+    uint16_t distance_alarm;
 
     osd_unit_e units;
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -102,6 +102,12 @@ typedef enum {
     OSD_ITEM_COUNT // MUST BE LAST
 } osd_items_e;
 
+typedef enum {
+    TBS = 0,
+    MODE,
+    FREQ
+} crsfformat;
+
 // *** IMPORTANT ***
 // The order of the OSD stats enumeration *must* match the order they're displayed on-screen
 // This is because the fields are presented in the configurator in the order of the enumeration

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -179,11 +179,10 @@ typedef struct osdConfig_s {
     // Alarms
     uint16_t cap_alarm;
     uint16_t alt_alarm;
+    uint16_t lq_alarm;
     uint8_t rssi_alarm;
-uint16_t distance_alarm;
-
+    uint16_t distance_alarm;
     osd_unit_e units;
-
     uint16_t timers[OSD_TIMER_COUNT];
     uint16_t enabledWarnings;
 

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -106,7 +106,7 @@ typedef enum {
     TBS = 0,
     MODE,
     FREQ
-} crsfformat;
+} crsfformat_e;
 
 // *** IMPORTANT ***
 // The order of the OSD stats enumeration *must* match the order they're displayed on-screen
@@ -177,10 +177,10 @@ typedef enum {
 } osdWarningsFlags_e;
 
 typedef enum {
-    LQ_FORMAT_300,
-    LQ_FORMAT_MODE,
-    LQ_FORMAT_FREQ,
-    LQ_FORMAT_COUNT
+    OSD_LQ_FORMAT_300 = 0,
+    OSD_LQ_FORMAT_MODE,
+    OSD_LQ_FORMAT_FREQ,
+    OSD_LQ_FORMAT_COUNT
 } lq_format_e;
 
 // Make sure the number of warnings do not exceed the available 16bit storage
@@ -196,7 +196,7 @@ typedef struct osdConfig_s {
     // Alarms
     uint16_t cap_alarm;
     uint16_t alt_alarm;
-    uint8_t lq_format;
+    crsfformat_e lq_format;
     uint16_t lq_alarm;
     uint8_t rssi_alarm;
     uint16_t distance_alarm;

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -103,7 +103,7 @@ typedef enum {
 } osd_items_e;
 
 typedef enum {
-    TBS = 0,
+    TBS,
     MODE,
     FREQ
 } crsfformat_e;
@@ -176,12 +176,6 @@ typedef enum {
     OSD_WARNING_COUNT // MUST BE LAST
 } osdWarningsFlags_e;
 
-typedef enum {
-    OSD_LQ_FORMAT_300 = 0,
-    OSD_LQ_FORMAT_MODE,
-    OSD_LQ_FORMAT_FREQ,
-    OSD_LQ_FORMAT_COUNT
-} lq_format_e;
 
 // Make sure the number of warnings do not exceed the available 16bit storage
 STATIC_ASSERT(OSD_WARNING_COUNT <= 16, osdwarnings_overflow);
@@ -196,7 +190,6 @@ typedef struct osdConfig_s {
     // Alarms
     uint16_t cap_alarm;
     uint16_t alt_alarm;
-    crsfformat_e lq_format;
     uint16_t lq_alarm;
     uint8_t rssi_alarm;
     uint16_t distance_alarm;
@@ -213,6 +206,8 @@ typedef struct osdConfig_s {
     int16_t esc_rpm_alarm;
     int16_t esc_current_alarm;
     uint8_t core_temp_alarm;
+
+    crsfformat_e lq_format;
 } osdConfig_t;
 
 PG_DECLARE(osdConfig_t, osdConfig);

--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -135,7 +135,17 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
     CRSFsetRFMode(stats.rf_Mode);
     CRSFsetSnR(stats.downlink_SNR);
     CRSFsetTXPower(stats.uplink_TX_Power);
+    if(stats.uplink_RSSI_1 == 0)
+    CRSFsetRSSI(stats.uplink_RSSI_2);
+    else if(stats.uplink_RSSI_2 == 0)
+    CRSFsetRSSI(stats.uplink_RSSI_1);
+    else
+    {
+      uint8_t rssimin=MIN(stats.uplink_RSSI_1, stats.uplink_RSSI_2) *-1;
+      CRSFsetRSSI(rssimin);
+    }
 }
+
 
 STATIC_UNIT_TESTED uint8_t crsfFrameCRC(void)
 {

--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -78,6 +78,7 @@ static uint16_t crsflq = 0;
 static uint8_t crsfrfmode = 0;
 static uint16_t crsfsnr = 0;
 static uint16_t crsftxpower = 0;
+static uint16_t crsfrssi = 0;
 
 #define MSP_RSSI_TIMEOUT_US 1500000   // 1.5 sec
 
@@ -715,7 +716,7 @@ void CRSFsetRFMode(uint8_t crsfrfValue)
 
 void CRSFsetTXPower(uint16_t crsftxpValue)
 {
-    crsftxpower=crsftxpValue;
+    crsftxpower = crsftxpValue;
 }
 
 void CRSFsetSnR(uint16_t crsfsnrValue)
@@ -723,6 +724,15 @@ void CRSFsetSnR(uint16_t crsfsnrValue)
     crsfsnr = crsfsnrValue;
 }
 
+void CRSFsetRSSI(uint8_t crsfrssiValue)
+{
+  crsfrssi = crsfrssiValue;
+}
+
+uint8_t CRSFgetRSSI(void)
+{
+    return crsfrssi;
+}
 uint16_t CRSFgetLQ(void)
 {
     return crsflq;
@@ -733,7 +743,7 @@ uint8_t CRSFgetRFMode(void)
     return crsfrfmode;
 }
 
-uint16_t CRSFgetSnR(void)
+uint8_t CRSFgetSnR(void)
 {
     return crsfsnr;
 }

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -176,11 +176,13 @@ void resumeRxPwmPpmSignal(void);
 //set and get CRSF stats
 void CRSFsetLQ(uint16_t crsflqValue);
 void CRSFsetSnR(uint16_t crsfsnrValue);
+void CRSFsetRSSI(uint8_t crsfrssiValue);
 void CRSFsetRFMode(uint8_t crsfrfValue);
 void CRSFsetTXPower(uint16_t crsftxpValue);
+uint8_t CRSFgetRSSI(void);
 uint16_t CRSFgetLQ(void);
 uint8_t CRSFgetRFMode(void);
-uint16_t CRSFgetSnR(void);
+uint8_t CRSFgetSnR(void);
 uint16_t CRSFgetTXPower(void);
 
 uint16_t rxGetRefreshRate(void);


### PR DESCRIPTION
adding an option for for diffrent LQ formats
`osd_lq_format = TBS` (default) shows `LQ 300` style
`osd_lq_format = MODE` shows mode:LQ (e.g. `2:100`)
`osd_lq_format = FREQ` shows freq:LQ (e.g. `150HZ:100`)