### PR TITLE
enhancement: CLI: allow vtx power to be changed by a switch

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2075,7 +2075,7 @@ static void cliVtx(char *cmdline) {
                 if (memcmp(cac, &emptyCac, sizeof(emptyCac)) == 0)
                         // FIXME Use VTX API to get min
                 {
-                    cliPrintErrorLinef("Empty vtx line provided. Reseting this vtx option");
+                    cliPrintErrorLinef("Empty vtx line provided. Resetting this vtx option.");
                     parseError = true;
                 }
             }

--- a/src/main/io/vtx_control.c
+++ b/src/main/io/vtx_control.c
@@ -98,15 +98,25 @@ void vtxUpdateActivatedChannel(void) {
     if (ARMING_FLAG(ARMED)) {
         locked = 1;
     }
-    if (!locked && vtxCommonDevice()) {
+    if (vtxCommonDevice()) {
         static uint8_t lastIndex = -1;
         for (uint8_t index = 0; index < MAX_CHANNEL_ACTIVATION_CONDITION_COUNT; index++) {
             const vtxChannelActivationCondition_t *vtxChannelActivationCondition = &vtxConfig()->vtxChannelActivationConditions[index];
             if (isRangeActive(vtxChannelActivationCondition->auxChannelIndex, &vtxChannelActivationCondition->range)
                     && index != lastIndex) {
                 lastIndex = index;
-                vtxSettingsConfigMutable()->band = vtxChannelActivationCondition->band;
-                vtxSettingsConfigMutable()->channel = vtxChannelActivationCondition->channel;
+                if (!locked) { // once armed, do not change band or channel
+                    if (vtxChannelActivationCondition->band > 0) {
+                        vtxSettingsConfigMutable()->band = vtxChannelActivationCondition->band;
+                    }
+                    if (vtxChannelActivationCondition->channel > 0) {
+                        vtxSettingsConfigMutable()->channel = vtxChannelActivationCondition->channel;
+                    }
+                }
+                // vtx power can be changed in flight
+                if (vtxChannelActivationCondition->power > 0) {
+                    vtxSettingsConfigMutable()->power = vtxChannelActivationCondition->power;
+                }
                 break;
             }
         }

--- a/src/main/io/vtx_control.h
+++ b/src/main/io/vtx_control.h
@@ -34,6 +34,7 @@ typedef struct vtxChannelActivationCondition_s {
     uint8_t auxChannelIndex;
     uint8_t band;
     uint8_t channel;
+    uint8_t power;
     channelRange_t range;
 } vtxChannelActivationCondition_t;
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -86,6 +86,9 @@ cli_unittest_SRC := \
                 $(USER_DIR)/common/typeconversion.c
 
 cli_unittest_DEFINES := \
+		USE_VTX_COMMON \
+		USE_VTX_CONTROL \
+		USE_VTX_SMARTAUDIO \
 		USE_OSD \
 		USE_CLI \
 		SystemCoreClock=1000000


### PR DESCRIPTION
Backported from Betaflight: Adds an option to change vtx power with an aux channel.

more info on usage:
https://github.com/betaflight/betaflight/wiki/VTX-CLI-Settings

Example cli settings:
```
#channels on a 6 pos switch
vtx 0 7 5 1 0 900 1100
vtx 1 7 5 2 0 1100 1300
vtx 2 7 5 3 0 1300 1500
vtx 3 7 5 4 0 1500 1700
vtx 4 7 5 6 0 1700 1900
vtx 5 7 5 8 0 1900 2100
#vtx power on a 2 pos switch
vtx 6 6 0 0 1 900 1200
vtx 7 6 0 0 2 1800 2100
```

thanks @Quick-Flash  and @nerdCopter for help! 


This was was tested on Tinyhawk2 board (matekf411rx target) and works perfectly.


### Testing

To test this, flash your FC with the build.
Setup a switch to control a spare Aux Channel on the radio.

Run the following commands in cli:
```
vtx 1 6 0 0 1 900 1200
vtx 2 6 0 0 2 1800 2100
```

The above uses AUX7 ( channels are zero indexed, change to whatever channel number you have set up on the radio minus 1) and will switch between power modes 1 and 2 when channel is withing related ranges.

Easiest way to tell is to enable VTX osd element. You will see power change in the OSD. Make sure you have armed the quad once (to make sure you are not in lowpower disarm mode)

### Note:

For Smart audio, the power levels are hardcoded as:
1: 25mw
2: 200mw
3: 800mw

make sure you do not use more than your vtx allows.

I'm not sure but I do not think this applies to Tramp, I think there the levels are preset in the vtx itself
