### PR TITLE
Fix FrSky SPI receiver range and lockups

### DIFF
--- a/src/main/rx/cc2500_frsky_d.c
+++ b/src/main/rx/cc2500_frsky_d.c
@@ -167,7 +167,7 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
     switch (*protocolState) {
     case STATE_STARTING:
         listLength = 47;
-        initialiseData(0);
+        initialiseData(false);
         *protocolState = STATE_UPDATE;
         nextChannel(1);
         cc2500Strobe(CC2500_SRX);
@@ -187,9 +187,11 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
     case STATE_DATA:
         if (cc2500getGdo()) {
             uint8_t ccLen = cc2500ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
+            bool packetOk = false;
             if (ccLen >= 20) {
                 cc2500ReadFifo(packet, 20);
                 if (packet[19] & 0x80) {
+                    packetOk = true;
                     missingPackets = 0;
                     timeoutUs = 1;
                     if (packet[0] == 0x11) {
@@ -214,6 +216,9 @@ rx_spi_received_e frSkyDHandlePacket(uint8_t * const packet, uint8_t * const pro
                         }
                     }
                 }
+            }
+            if (!packetOk) {
+                cc2500Strobe(CC2500_SRX);
             }
         }
         if (cmpTimeUs(currentPacketReceivedTime, lastPacketReceivedTime) > (timeoutUs * SYNC_DELAY_MAX)) {

--- a/src/main/rx/cc2500_frsky_shared.c
+++ b/src/main/rx/cc2500_frsky_shared.c
@@ -150,12 +150,17 @@ static void initialise() {
     }
 }
 
-void initialiseData(uint8_t adr) {
+void initialiseData(bool inBindState) {
     cc2500WriteReg(CC2500_0C_FSCTRL0, (uint8_t)rxFrSkySpiConfig()->bindOffset);
     cc2500WriteReg(CC2500_18_MCSM0, 0x8);
-    cc2500WriteReg(CC2500_09_ADDR, adr ? 0x03 : rxFrSkySpiConfig()->bindTxId[0]);
+    cc2500WriteReg(CC2500_09_ADDR, inBindState ? 0x03 : rxFrSkySpiConfig()->bindTxId[0]);
     cc2500WriteReg(CC2500_07_PKTCTRL1, 0x0D);
     cc2500WriteReg(CC2500_19_FOCCFG, 0x16);
+
+    if (!inBindState) {
+        cc2500WriteReg(CC2500_03_FIFOTHR,  0x0E);
+    }
+
     delay(10);
 }
 
@@ -324,7 +329,7 @@ rx_spi_received_e frSkySpiDataReceived(uint8_t *packet) {
     case STATE_BIND_TUNING:
         if (tuneRx(packet)) {
             initGetBind();
-            initialiseData(1);
+            initialiseData(true);
             protocolState = STATE_BIND_BINDING1;
         }
         break;

--- a/src/main/rx/cc2500_frsky_shared.h
+++ b/src/main/rx/cc2500_frsky_shared.h
@@ -52,6 +52,6 @@ extern uint8_t listLength;
 extern uint32_t missingPackets;
 extern timeDelta_t timeoutUs;
 
-void initialiseData(uint8_t adr);
+void initialiseData(bool inBindState);
 
 void nextChannel(uint8_t skip);


### PR DESCRIPTION
Betaflight recently fixed a bug in frsky_d16 mode for SPI based recievers. The bug caused random drop out even in short range.

This is a port of 2 commits from betaflight:
https://github.com/mikeller/betaflight/commit/cb66ee09ba56a5f52f3355a404b43bbd3b7f0ec4

and one to fix lockups in frsky_x mode:
https://github.com/mikeller/betaflight/commit/77eb4f217272f9febeaa2dd5bec5b74060b407f7

All credit goes to @mikeller and @kevindehecker

Tested on Tinyhawk2 MATEKF411RX target.