### PR TITLE
FPORT fix: port of Betaflight https://github.com/betaflight/betaflight/pull/10388

### DIFF
--- a/src/main/drivers/serial_uart_stm32f30x.c
+++ b/src/main/drivers/serial_uart_stm32f30x.c
@@ -178,8 +178,9 @@ void serialUARTInitIO(IO_t txIO, IO_t rxIO, portMode_e mode, portOptions_e optio
     if ((options & SERIAL_BIDIR) && txIO) {
         ioConfig_t ioCfg = IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz,
                                      ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP)) ? GPIO_OType_PP : GPIO_OType_OD,
-                                     ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP)) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP
+                                     (options & SERIAL_INVERTED) ? GPIO_PuPd_DOWN : GPIO_PuPd_UP
                                     );
+
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(index));
         IOConfigGPIOAF(txIO, ioCfg, af);
         if (!(options & SERIAL_INVERTED))

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -351,7 +351,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         ioConfig_t ioCfg = IO_CONFIG(
                                ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP)) ? GPIO_MODE_AF_PP : GPIO_MODE_AF_OD,
                                GPIO_SPEED_FREQ_HIGH,
-                               ((options & SERIAL_INVERTED) || (options & SERIAL_BIDIR_PP)) ? GPIO_PULLDOWN : GPIO_PULLUP
+                               (options & SERIAL_INVERTED) ? GPIO_PULLDOWN : GPIO_PULLUP
                            );
         IOInit(txIO, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
         IOConfigGPIOAF(txIO, ioCfg, hardware->af);


### PR DESCRIPTION
All credit goes to @tonycake for fixing this.

This is an awesome fix. I personally experience this bug on one of my quads with FPORT receiver (and MatekF722-STD FC).
Sometimes when plugging the quad in, telemetry does not come through. I have to turn it off and on again, even multiple times.

I've just tested this change and telemetry on FPORT is now rock solid. Comes through every single time the quad powers up. 🎉 

**Copy of message from betaflight pr:**

Fix the issue described in Issue #10220, typos in serial drivers for F7, F3, G4, H7 platforms.
Before this change, the serial line is incorrectly pulled down for bidirectional comms, which may cause dropped packets (silently) with any Rx protocol that uses bidirectional comms on the Tx line (GHST, SRXL-2, FPORT)

Issue this addresses: https://github.com/betaflight/betaflight/issues/10220