### PR TITLE
Avarage cell voltage for CSRF

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -193,7 +193,13 @@ void crsfFrameBatterySensor(sbuf_t *dst) {
     // use sbufWrite since CRC does not include frame length
     sbufWriteU8(dst, CRSF_FRAME_BATTERY_SENSOR_PAYLOAD_SIZE + CRSF_FRAME_LENGTH_TYPE_CRC);
     sbufWriteU8(dst, CRSF_FRAMETYPE_BATTERY_SENSOR);
-    sbufWriteU16BigEndian(dst, getBatteryVoltage()); // vbat is in units of 0.1V
+    
+    uint16_t voltage = getBatteryVoltage();
+    if (telemetryConfig()->report_cell_voltage) {
+        voltage /= getBatteryCellCount();
+    }
+    sbufWriteU16BigEndian(dst, voltage); // vbat is in units of 0.1V
+    
     sbufWriteU16BigEndian(dst, getAmperage() / 10);
     const uint32_t mAhDrawn = getMAhDrawn();
     const uint8_t batteryRemainingPercentage = calculateBatteryPercentageRemaining();


### PR DESCRIPTION
```report_cell_voltage``` is not used currently for crossfire. This request fixes it.

Issue: #445 