### PR TITLE
WIP: Set OSD background Black when entering menu

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -66,6 +66,9 @@
 // For VISIBLE*
 #include "io/osd.h"
 #include "io/rcdevice_cam.h"
+#ifdef USE_MAX7456
+#include "io/displayport_max7456.h"
+#endif
 
 #include "rx/rx.h"
 
@@ -588,6 +591,7 @@ void cmsMenuOpen(void) {
         }
     }
     displayGrab(pCurrentDisplay); // grab the display for use by the CMS
+
     if ( pCurrentDisplay->cols < NORMAL_SCREEN_MIN_COLS) {
         smallScreen       = true;
         linesPerMenuItem  = 2;
@@ -605,6 +609,9 @@ void cmsMenuOpen(void) {
 #endif
         maxMenuItems      = pCurrentDisplay->rows - 2;
     }
+#ifdef USE_MAX7456
+    setBackgroundBlack();
+#endif
     cmsMenuChange(pCurrentDisplay, currentCtx.menu);
 }
 
@@ -630,6 +637,9 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr) {
         break;
     }
     cmsInMenu = false;
+#ifdef USE_MAX7456
+    setBackgroundTransparent();
+#endif
     displayRelease(pDisplay);
     currentCtx.menu = NULL;
     if (exitType == CMS_EXIT_SAVEREBOOT) {

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -886,7 +886,7 @@ void cmsUpdate(uint32_t currentTimeUs) {
         //
         uint8_t key = KEY_NONE;
         if (IS_MID(THROTTLE) && IS_LO(YAW) && IS_HI(PITCH) && !ARMING_FLAG(ARMED)) {
-            key = KEY_MENU;
+            key = KEY_NONE;
         } else if (IS_HI(PITCH)) {
             key = KEY_UP;
         } else if (IS_LO(PITCH)) {

--- a/src/main/drivers/display.h
+++ b/src/main/drivers/display.h
@@ -59,6 +59,7 @@ typedef struct displayPortProfile_s {
     bool invert;
     uint8_t blackBrightness;
     uint8_t whiteBrightness;
+    bool useBlackBackgroundInMenus;
 } displayPortProfile_t;
 
 // Note: displayPortProfile_t used as a parameter group for CMS over CRSF (io/displayport_crsf)

--- a/src/main/drivers/max7456.h
+++ b/src/main/drivers/max7456.h
@@ -44,3 +44,6 @@ void    max7456RefreshAll(void);
 uint8_t* max7456GetScreenBuffer(void);
 bool    max7456DmaInProgress(void);
 bool    max7456BuffersSynced(void);
+void max7456BackgroundBlack(void);
+void max7456BackgroundTransparent(void);
+

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -1128,6 +1128,7 @@ const clivalue_t valueTable[] = {
     { "displayport_max7456_inv",        VAR_UINT8 | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DISPLAY_PORT_MAX7456_CONFIG, offsetof(displayPortProfile_t, invert) },
     { "displayport_max7456_blk",        VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 3 }, PG_DISPLAY_PORT_MAX7456_CONFIG, offsetof(displayPortProfile_t, blackBrightness) },
     { "displayport_max7456_wht",        VAR_UINT8 | MASTER_VALUE, .config.minmax = { 0, 3 }, PG_DISPLAY_PORT_MAX7456_CONFIG, offsetof(displayPortProfile_t, whiteBrightness) },
+    { "osd_menu_black_background",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_DISPLAY_PORT_MAX7456_CONFIG, offsetof(displayPortProfile_t, useBlackBackgroundInMenus) },
 #endif
 
 #ifdef USE_ESC_SENSOR

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -49,6 +49,7 @@ void pgResetFn_displayPortProfileMax7456(displayPortProfile_t *displayPortProfil
     displayPortProfile->rowAdjust = 0;
     // Set defaults as per MAX7456 datasheet
     displayPortProfile->invert = false;
+    displayPortProfile->useBlackBackgroundInMenus = false;
     displayPortProfile->blackBrightness = 0;
     displayPortProfile->whiteBrightness = 2;
 }
@@ -83,11 +84,15 @@ static int drawScreen(displayPort_t *displayPort) {
 }
 
 void setBackgroundBlack() {
-    max7456BackgroundBlack();;
+    if (displayPortProfileMax7456()->useBlackBackgroundInMenus) {
+        max7456BackgroundBlack();;
+    }
 }
 
 void setBackgroundTransparent() {
-    max7456BackgroundTransparent();
+    if (displayPortProfileMax7456()->useBlackBackgroundInMenus) {
+        max7456BackgroundTransparent();
+    }
 }
 
 static int screenSize(const displayPort_t *displayPort) {

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -82,6 +82,14 @@ static int drawScreen(displayPort_t *displayPort) {
     return 0;
 }
 
+void setBackgroundBlack() {
+    max7456BackgroundBlack();;
+}
+
+void setBackgroundTransparent() {
+    max7456BackgroundTransparent();
+}
+
 static int screenSize(const displayPort_t *displayPort) {
     UNUSED(displayPort);
     return maxScreenSize;

--- a/src/main/io/displayport_max7456.h
+++ b/src/main/io/displayport_max7456.h
@@ -27,3 +27,6 @@ PG_DECLARE(displayPortProfile_t, displayPortProfileMax7456);
 
 struct vcdProfile_s;
 displayPort_t *max7456DisplayPortInit(const struct vcdProfile_s *vcdProfile);
+
+void setBackgroundTransparent(void);
+void setBackgroundBlack(void);


### PR DESCRIPTION
Interesting idea pitched by @Quick-Flash 

This has the same effect as turning the camera off and makes the menu easier to read.

The code here works as proof of concept. I'm not particularly happy that i have to pull in the max7456 driver directly into cms.c. Suggstions on how to restructure this would be most welcome

Behaviour can be turned on/off via cli (default is off or same as legacy behaviour):

```
set osd_menu_black_background = ON
save
```

### TODO:
- [ ] Refactor
- [✅] Add cli option to toggle this behaviour on/off

Video of the code in action: https://www.youtube.com/watch?v=iRj8QfZfxSo
