### PR TITLE
pt-BR osd_languages.h

### DIFF
--- a/src/main/osd/osd_languages.h
+++ b/src/main/osd/osd_languages.h
@@ -28,6 +28,7 @@
 //#define FRENCH_OSD
 //#define GERMAN_OSD
 //#define TAGALOG_OSD
+//#define PORTUGUESE_BRAZIL_OSD
 
 #ifdef ENGLISH_OSD
 // text from osd_elements.c
@@ -273,6 +274,94 @@
 #define TOTAL_DISTANCE "TOTAL DISTANCE"
 #define STATS "  --- STATS ---" // keep the length the same
 #define OSD_ARMED "ARMED"
+// text from cms_menu_blackbox.c
+// text from cms_menu_failsafe.c
+// text from cms_menu_firmware.c
+// text from cms_menu_gps_rescue.c
+// text from cms_menu_imu.c
+// text from cms_menu_ledstrip.c
+// text from cms_menu_main.c
+// text from cms_menu_misc.c
+// text from cms_menu_osd.c
+// text from cms_menu_persistent_stats.c
+// text from cms_menu_power.c
+// text from cms_menu_saveexit.c
+// text from cms_menu_vtx_common.c
+// text from cms_menu_vtx_rtc6705.c
+// text from cms_menu_vtx_smartaudio.c
+// text from cms_menu_vtx_tramp.c
+// text from cms.c
+#endif
+
+#elif defined(PORTUGUESE_BRAZIL_OSD)
+// text from osd_elements.c
+#define AG "ag" // shortened version of antigravity
+#define CRAFTNAME "NOME_AERONV"
+#define DBG "DBG %5d %5d %5d %5d" // keep the same except for the DBG which is short for debug
+#define DISARMED "DESARMADO"
+#define DISPLAYNAME "NOME_DISPLAY"
+#define RATE "RATE_%u" // only change the RATE portion
+#define FS "!FS!" // only change the FS part which is short for failsafe, keep 4 characters long which inlcude the ! !
+#define RESC "SALV" // RESC is short for rescue, keep 4 characters long
+#define HEAD "HEAD" // HEAD is short for headfree mode, keep 4 characters long
+#define ANGL "ANGL" // short for angle mode, keep 4 characters long
+#define HOR "HOR " // short for horizon mode, keep 4 characters long
+#define NFE "NFE " // stands for NFE mode, keep 4 characters long
+#define AIR "AIR " // short for airmode, keep 4 characters long
+#define ACRO "ACRO" // short for acro mode, keep 4 characters long
+#define PIT "ARF" // short for pitch, keep 3 characters long
+#define ROL "ROL" // short for roll, keep 3 characters long
+#define YA "GUI" // keep 3 characters long
+#define BEACON_ON " BIP LIG" // keep the space and try to keep the same length
+#define ARM_IN "ARMAR EM %d.%d" // only change the ARM IN keep the rest the same.
+#define FAIL_SAFE "FAIL SAFE"
+#define CRASH_FLIP "CRASH FLIP" // also known as turtle mode, keep naming consistent with crash flip
+#define LAUNCH_ANGLE "LNCMNTO %d" // only change the LAUNCH portion
+#define LAUNCH "LANÇAR"
+#define RSSI_LOW "RSSI BAIXO"
+#define RSSI_DBM "RSSI DBM"
+#define LINK_QUALITY "QUALIDADE LINK"
+#define LAND_NOW " POUSE JÁ"
+#define RESCUE_NA "SALVAMTO N/A"
+#define RESCUE_OFF "SALVAMTO DES"
+#define HEADFREE "HEADFREE"
+#define ACC_RECOVERY "RECUPERA ACC"
+#define CORE "CORE %c: %3d%c" // only change the CORE portion
+#define LOW_BATTERY "BATERIA FRACA"
+#define RCSMOOTHING "RCSMOOTHING"
+#define OVER_CAP "CAP EXCEDIDA" // short for over capacity, as in your battery capacity
+#define BATT_LESS_FULL "BAT < CHEIA" // short for battery < full, keep the <
+// text from osd.c
+#define ON_TIME "TEMPO LIG" // keep the length the same
+#define TOTAL_ARM "TOTAL ARM" // keep the length the same
+#define LAST_ARM "ULTMO ARM" // keep the length the same
+#define ON_ARM "LIG/ARM  " // keep the length the same
+#define FAULT "FAULT"
+#define NO_RTC "NO RTC" // stands for no real time clock
+#define MAX_ALTITUDE "ALTITUDE MAX"
+#define MAX_SPEED "VELOC MAX"
+#define MAX_DISTANCE "DISTANCIA MAX"
+#define FLIGHT_DISTANCE "DISTANCIA VOO"
+#define MIN_BATTERY "BATERIA MIN"
+#define END_BATTERY "BATERIA FINAL"
+#define BATTERY "BATERIA"
+#define MIN_RSSI "RSSI MIN"
+#define MAX_CURRENT "CORRENTE MAX"
+#define USED_MAH "MAH USADO"
+#define BLACKBOX "CAIXA PRETA"
+#define BB_LOG_NUM "NUM LOG CXPRTA" // stands for blackbox log number
+#define MAX_G_FORCE "FORÇA-G MAX"
+#define MAX_ESC_TEMP "TEMP ESC MAX"
+#define MAX_ESC_RPM "RPM ESC MAX"
+#define MIN_LINK "LINK MIN"
+#define PEAK_FFT "PEAK FFT"
+#define THRT_LESS_20 "ACEL<20%" // short for throttle less than 20
+#define MIN_RSSI_DBM "RSSI MIN DBM"
+#define TOTAL_FLIGHTS "TOTAL DE VOOS"
+#define TOTAL_FLIGHT_TIME "TEMPO TOTAL DE VOOS"
+#define TOTAL_DISTANCE "DISTÂNCIA TOTAL"
+#define STATS "  --- RESUM ---" // keep the length the same
+#define OSD_ARMED "ARMADO"
 // text from cms_menu_blackbox.c
 // text from cms_menu_failsafe.c
 // text from cms_menu_firmware.c


### PR DESCRIPTION
Portuguese Brazil (pt-BR) included. I couldn´t find a translation to some words that could fit the number of characters to keep things simple on the OSD (formatting-wise) so some words were described in shorter versions (for example "SHRTER" instead of "SHORTER"). Some other words simply don't make sense to translate, so I´ve kept the English version of them.