### PR TITLE
Add angle mode filtering

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -490,12 +490,12 @@ static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPit
         const float horizonLevelStrength = calcHorizonLevelStrength();
         currentPidSetpoint = ((getSetpointRate(axis) * (1 - horizonLevelStrength)) + getSetpointRate(axis)) * 0.5f + (currentPidSetpoint * horizonLevelStrength * horizonStrength);
     } else if (axis == FD_PITCH && pidProfile->angle_yaw_correction == 1) {
-        yawAngleCorrection = currentPidSetpoint * fabsf(cos_approx((attitude.raw[FD_ROLL] - angleTrim->raw[FD_ROLL]) * 0.1f));
-        currentPidSetpoint = currentPidSetpoint * fabsf(sin_approx((attitude.raw[FD_ROLL] - angleTrim->raw[FD_ROLL]) * 0.1f));
+        yawAngleCorrection = currentPidSetpoint * fabsf(sin_approx((attitude.raw[FD_ROLL] - angleTrim->raw[FD_ROLL]) * 0.1f));
+        currentPidSetpoint = currentPidSetpoint * fabsf(cos_approx((attitude.raw[FD_ROLL] - angleTrim->raw[FD_ROLL]) * 0.1f));
     } else if (pidProfile->angle_yaw_correction == 1){
-        yawAngleCorrection = yawAngleCorrection + currentPidSetpoint * sin_approx((attitude.raw[FD_PITCH] - angleTrim->raw[FD_PITCH]) * 0.1f);
+        yawAngleCorrection = yawAngleCorrection + currentPidSetpoint * cos_approx((attitude.raw[FD_PITCH] - angleTrim->raw[FD_PITCH]) * 0.1f);
         yawAngleCorrection = yawAngleSetpointFilterApplyFn((filter_t *)&yawAngleSetpointFilter, yawAngleCorrection);
-        currentPidSetpoint = currentPidSetpoint * cos_approx((attitude.raw[FD_PITCH] - angleTrim->raw[FD_PITCH]) * 0.1f);
+        currentPidSetpoint = currentPidSetpoint * sin_approx((attitude.raw[FD_PITCH] - angleTrim->raw[FD_PITCH]) * 0.1f);
     }
     currentPidSetpoint = angleSetpointFilterApplyFn((filter_t *)&angleSetpointFilter[axis], currentPidSetpoint);
     return currentPidSetpoint;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -183,6 +183,8 @@ void resetPidProfile(pidProfile_t *pidProfile) {
     .mixer_impl = MIXER_IMPL_LEGACY,
     .mixer_laziness = false,
     .horizonStrength = 15,
+    .angle_yaw_correction = 1,
+    .angle_filter = 100,
                 );
 }
 
@@ -214,6 +216,10 @@ static FAST_RAM filterApplyFnPtr dtermLowpassApplyFn = nullFilterApply;
 static FAST_RAM_ZERO_INIT dtermLowpass_t dtermLowpass[XYZ_AXIS_COUNT];
 static FAST_RAM filterApplyFnPtr dtermLowpass2ApplyFn = nullFilterApply;
 static FAST_RAM_ZERO_INIT dtermLowpass_t dtermLowpass2[XYZ_AXIS_COUNT];
+static FAST_RAM filterApplyFnPtr angleSetpointFilterApplyFn = nullFilterApply;
+static FAST_RAM_ZERO_INIT dtermLowpass_t angleSetpointFilter[2];
+static FAST_RAM filterApplyFnPtr yawAngleSetpointFilterApplyFn = nullFilterApply;
+static FAST_RAM_ZERO_INIT dtermLowpass_t yawAngleSetpointFilter;
 
 #if defined(USE_ITERM_RELAX)
 static FAST_RAM_ZERO_INIT pt1Filter_t windupLpf[XYZ_AXIS_COUNT];
@@ -236,6 +242,8 @@ void pidInitFilters(const pidProfile_t *pidProfile) {
     const uint32_t pidFrequencyNyquist = pidFrequency / 2; // No rounding needed
     dtermLowpassApplyFn = nullFilterApply;
     dtermLowpass2ApplyFn = nullFilterApply;
+    angleSetpointFilterApplyFn = nullFilterApply;
+    yawAngleSetpointFilterApplyFn = nullFilterApply;
     for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
         if (pidProfile->dFilter[axis].dLpf && pidProfile->dFilter[axis].dLpf <= pidFrequencyNyquist) {
             switch (pidProfile->dterm_filter_type) {
@@ -263,6 +271,14 @@ void pidInitFilters(const pidProfile_t *pidProfile) {
                 break;
             }
         }
+    }
+    if (pidProfile->angle_filter) {
+        for (int axis = FD_ROLL; axis <= FD_PITCH; axis++) {
+            angleSetpointFilterApplyFn = (filterApplyFnPtr)pt1FilterApply;
+            pt1FilterInit(&angleSetpointFilter[axis].pt1Filter, pt1FilterGain(pidProfile->angle_filter, dT));
+        }
+        yawAngleSetpointFilterApplyFn = (filterApplyFnPtr)pt1FilterApply;
+        pt1FilterInit(&yawAngleSetpointFilter.pt1Filter, pt1FilterGain(pidProfile->angle_filter, dT));
     }
 #if defined(USE_THROTTLE_BOOST)
     pt1FilterInit(&throttleLpf, pt1FilterGain(pidProfile->throttle_boost_cutoff, dT));
@@ -331,6 +347,7 @@ static FAST_RAM_ZERO_INIT float setPointITransition[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT float setPointDTransition[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT float dtermBoostMultiplier, dtermBoostLimitPercent;
 static FAST_RAM_ZERO_INIT float P_angle_low, D_angle_low, P_angle_high, D_angle_high, F_angle, horizonTransition, horizonCutoffDegrees, horizonStrength;
+static FAST_RAM_ZERO_INIT float yawAngleCorrection;
 static FAST_RAM_ZERO_INIT float ITermWindupPointInv;
 static FAST_RAM_ZERO_INIT timeDelta_t crashTimeLimitUs;
 static FAST_RAM_ZERO_INIT timeDelta_t crashTimeDelayUs;
@@ -472,7 +489,15 @@ static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPit
         // mix in errorAngle to currentPidSetpoint to add a little auto-level feel
         const float horizonLevelStrength = calcHorizonLevelStrength();
         currentPidSetpoint = ((getSetpointRate(axis) * (1 - horizonLevelStrength)) + getSetpointRate(axis)) * 0.5f + (currentPidSetpoint * horizonLevelStrength * horizonStrength);
+    } else if (axis == FD_PITCH && pidProfile->angle_yaw_correction == 1) {
+        yawAngleCorrection = currentPidSetpoint * fabsf(cos_approx((attitude.raw[FD_ROLL] - angleTrim->raw[FD_ROLL]) * 0.1f));
+        currentPidSetpoint = currentPidSetpoint * fabsf(sin_approx((attitude.raw[FD_ROLL] - angleTrim->raw[FD_ROLL]) * 0.1f));
+    } else if (pidProfile->angle_yaw_correction == 1){
+        yawAngleCorrection = yawAngleCorrection + currentPidSetpoint * sin_approx((attitude.raw[FD_PITCH] - angleTrim->raw[FD_PITCH]) * 0.1f);
+        yawAngleCorrection = yawAngleSetpointFilterApplyFn((filter_t *)&yawAngleSetpointFilter, yawAngleCorrection);
+        currentPidSetpoint = currentPidSetpoint * cos_approx((attitude.raw[FD_PITCH] - angleTrim->raw[FD_PITCH]) * 0.1f);
     }
+    currentPidSetpoint = angleSetpointFilterApplyFn((filter_t *)&angleSetpointFilter[axis], currentPidSetpoint);
     return currentPidSetpoint;
 }
 
@@ -612,6 +637,11 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
             currentPidSetpoint = pidLevel(axis, pidProfile, angleTrim, currentPidSetpoint);
         } else if ((FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) && FLIGHT_MODE(NFE_RACE_MODE) && ((axis != FD_YAW) && (axis != FD_PITCH))) {
             currentPidSetpoint = pidLevel(axis, pidProfile, angleTrim, currentPidSetpoint);
+        }
+
+        if (axis == FD_YAW) {
+            currentPidSetpoint += yawAngleCorrection;
+            yawAngleCorrection = 0.0f;
         }
         // Handle yaw spin recovery - zero the setpoint on yaw to aid in recovery
         // It's not necessary to zero the set points for R/P because the PIDs will be zeroed below

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -102,7 +102,6 @@ typedef struct pidProfile_s {
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.
     uint8_t levelAngleLimit;                // Max angle in degrees in level mode
     uint8_t angleExpo;                      // How much expo to add to the
-    uint8_t angle_yaw_correction;           // if angle mode should use yaw to help correct angles
     uint8_t angle_filter;                   // filter we stick on the rate setpoint angle makes
 
     uint8_t horizonTransition;              // horizonTransition

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -102,10 +102,12 @@ typedef struct pidProfile_s {
     uint8_t pidAtMinThrottle;               // Disable/Enable pids on zero throttle. Normally even without airmode P and D would be active.
     uint8_t levelAngleLimit;                // Max angle in degrees in level mode
     uint8_t angleExpo;                      // How much expo to add to the
+    uint8_t angle_yaw_correction;           // if angle mode should use yaw to help correct angles
+    uint8_t angle_filter;                   // filter we stick on the rate setpoint angle makes
 
     uint8_t horizonTransition;              // horizonTransition
     uint8_t horizon_tilt_effect;            // inclination factor for Horizon mode
-    uint8_t horizonStrength;               // boost or shrink to angle pids while in horizon mode
+    uint8_t horizonStrength;                // boost or shrink to angle pids while in horizon mode
 
     // EmuFlight PID controller parameters
     uint8_t feathered_pids;                 // determine how feathered your pids are

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -920,7 +920,6 @@ const clivalue_t valueTable[] = {
 
     { "level_limit",                VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelAngleLimit) },
     { "angle_expo",                 VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, angleExpo) },
-    { "angle_yaw_correction",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_yaw_correction) },
     { "angle_filter",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_filter) },
 
     { "horizon_transition",         VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0,  200 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizonTransition) },

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -920,6 +920,8 @@ const clivalue_t valueTable[] = {
 
     { "level_limit",                VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 10, 90 }, PG_PID_PROFILE, offsetof(pidProfile_t, levelAngleLimit) },
     { "angle_expo",                 VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, angleExpo) },
+    { "angle_yaw_correction",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_yaw_correction) },
+    { "angle_filter",               VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0, 255 }, PG_PID_PROFILE, offsetof(pidProfile_t, angle_filter) },
 
     { "horizon_transition",         VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0,  200 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizonTransition) },
     { "horizon_tilt_effect",        VAR_UINT8  | PROFILE_VALUE, .config.minmax = { 0,  180 }, PG_PID_PROFILE, offsetof(pidProfile_t, horizon_tilt_effect) },


### PR DESCRIPTION
filters the setpoint which angle mode creates for the rate pid controller. Should lead to smoother angle mode. Has been tested by PJC and should be good to be merged. Should really be mostly an under the hood thing.