### PR TITLE
fix osd bug

### DIFF
--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -210,7 +210,7 @@ static OSD_Entry cmsx_menuPidAdvancedEntries[] = {
     { "I RELAX THRESH YAW", OME_UINT8, NULL, &(OSD_UINT8_t){ &itermRelaxThresholdYaw,   0, 100, 1 }, 0 },
     { "I WINDUP",          OME_UINT8, NULL, &(OSD_UINT8_t){ &itermWindup,              0, 100, 1 }, 0 },
 
-    { "EMU GRAVITY",       OME_UINT16, NULL, &(OSD_UINT8_t){ &emuGravityGain,         0,  255, 1}, 0 },
+    { "EMU GRAVITY",       OME_UINT8, NULL, &(OSD_UINT8_t){ &emuGravityGain,         0,  255, 1}, 0 },
 
     { "LINEAR THRUST LOW",  OME_UINT8, NULL, &(OSD_UINT8_t) { &linear_thrust_low_output, 0, 100,  1}, 0 },
     { "LINEAR THRUST HIGH", OME_UINT8, NULL, &(OSD_UINT8_t) { &linear_thrust_high_output, 0, 100,  1}, 0 },


### PR DESCRIPTION
Fix a bug with emugravity in the osd. it was an 8 bit number being treated as a 16 bit number... oops.