### PR TITLE
clean up osdWarnDjiEnabled - disable usbVcpIsConnected() check for dj…

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -766,9 +766,9 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
     }
     break;
     case MSP_NAME: {
-      // Show warning for DJI OSD instead of pilot name
+        // Show warning for DJI OSD instead of pilot name
         // works if osd warnings enabled, osd_warn_dji is on and usb is not connected
-        if (osdWarnDjiEnabled()) {
+        if (osdWarnGetState(OSD_WARNING_DJI)) {
             sbufWriteString(dst, djiWarningBuffer);
             break;
         }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -394,7 +394,7 @@ static void osdFormatMessage(char *buff, size_t size, const char *message) {
         memcpy(buff, message, strlen(message));
     }
     // Write warning for DJI
-    if (osdWarnDjiEnabled()) {
+    if (osdWarnGetState(OSD_WARNING_DJI)) {
         if (message) {
             tfp_sprintf(djiWarningBuffer, message);
         } else {
@@ -440,14 +440,6 @@ void osdWarnSetState(uint8_t warningIndex, bool enabled) {
 
 bool osdWarnGetState(uint8_t warningIndex) {
     return osdConfig()->enabledWarnings & (1 << warningIndex);
-}
-
-bool osdWarnDjiEnabled(void) {
-    return osdWarnGetState(OSD_WARNING_DJI)
-#ifdef USE_VCP
-           && !usbVcpIsConnected()
-#endif
-           ;
 }
 
 static bool osdDrawSingleElement(uint8_t item) {

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -229,5 +229,4 @@ void osdStatSetState(uint8_t statIndex, bool enabled);
 bool osdStatGetState(uint8_t statIndex);
 void osdWarnSetState(uint8_t warningIndex, bool enabled);
 bool osdWarnGetState(uint8_t warningIndex);
-bool osdWarnDjiEnabled(void);
 void setCrsfRssi(bool b);


### PR DESCRIPTION
This fix allowed TRANSTECF7 to work with dji warnings. 

The usbVcpIsConnected() check was preventing it from working even when usb was disconnected. Credit @nerdCopter for suggesting this. I do not see a reason why DJI warnings should be disabled when usb is connected, you are able to see analog warnings when usb is connected.

The check was done by a boolean function, that was removed to save memory and now it just tests if the osd setting is enabled.

These targets were known to have the issue: 

MatekfF722
mamba f7 mini
HGLRCF722
TRANSTECF7

