### PR TITLE
Improved CRSF flight mode reporting.

### DIFF
--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -268,7 +268,7 @@ void crsfFrameFlightMode(sbuf_t *dst) {
     } else
 
 #if defined(USE_GPS)
-    if (!ARMING_FLAG(ARMED) && featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
+    if (!ARMING_FLAG(ARMED) && feature(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
         flightMode = "WAIT"; // Waiting for GPS lock
     } else
 #endif
@@ -284,7 +284,7 @@ void crsfFrameFlightMode(sbuf_t *dst) {
         flightMode = "STAB";
     } else if (FLIGHT_MODE(HORIZON_MODE)) {
         flightMode = "HOR";
-    } else if (airmodeIsEnabled()) {
+    } else if (isAirmodeActive()) {
         flightMode = "AIR";
     }
 

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -253,8 +253,7 @@ void crsfFrameAttitude(sbuf_t *dst) {
 Payload:
 char[]      Flight mode ( Null terminated string )
 */
-void crsfFrameFlightMode(sbuf_t *dst)
-{
+void crsfFrameFlightMode(sbuf_t *dst) {
     // write zero for frame length, since we don't know it yet
     uint8_t *lengthPtr = sbufPtr(dst);
     sbufWriteU8(dst, 0);

--- a/src/main/telemetry/crsf.c
+++ b/src/main/telemetry/crsf.c
@@ -253,24 +253,46 @@ void crsfFrameAttitude(sbuf_t *dst) {
 Payload:
 char[]      Flight mode ( Null terminated string )
 */
-void crsfFrameFlightMode(sbuf_t *dst) {
+void crsfFrameFlightMode(sbuf_t *dst)
+{
     // write zero for frame length, since we don't know it yet
     uint8_t *lengthPtr = sbufPtr(dst);
     sbufWriteU8(dst, 0);
     sbufWriteU8(dst, CRSF_FRAMETYPE_FLIGHT_MODE);
-    // use same logic as OSD, so telemetry displays same flight text as OSD
+
+    // Acro is the default mode
     const char *flightMode = "ACRO";
-    if (isAirmodeActive()) {
-        flightMode = "AIR";
-    }
+
+    // Modes that are only relevant when disarmed
+    if (!ARMING_FLAG(ARMED) && isArmingDisabled()) {
+        flightMode = "!ERR";
+    } else
+
+#if defined(USE_GPS)
+    if (!ARMING_FLAG(ARMED) && featureIsEnabled(FEATURE_GPS) && (!STATE(GPS_FIX) || !STATE(GPS_FIX_HOME))) {
+        flightMode = "WAIT"; // Waiting for GPS lock
+    } else
+#endif
+
+    // Flight modes in decreasing order of importance
     if (FLIGHT_MODE(FAILSAFE_MODE)) {
-        flightMode = "!FS";
+        flightMode = "!FS!";
+    } else if (FLIGHT_MODE(GPS_RESCUE_MODE)) {
+        flightMode = "RTH";
+    } else if (FLIGHT_MODE(PASSTHRU_MODE)) {
+        flightMode = "MANU";
     } else if (FLIGHT_MODE(ANGLE_MODE)) {
         flightMode = "STAB";
     } else if (FLIGHT_MODE(HORIZON_MODE)) {
         flightMode = "HOR";
+    } else if (airmodeIsEnabled()) {
+        flightMode = "AIR";
     }
+
     sbufWriteString(dst, flightMode);
+    if (!ARMING_FLAG(ARMED)) {
+        sbufWriteU8(dst, '*');
+    }
     sbufWriteU8(dst, '\0');     // zero-terminate string
     // write in the frame length
     *lengthPtr = sbufPtr(dst) - lengthPtr;


### PR DESCRIPTION
Improve Crossfire telemetry flight modes to match Betaflight and INAV.

This matches the pull request I created for INAV and Betaflight here:

https://github.com/iNavFlight/inav/commit/c0964cbb2cf15d878fa6b57efe45ef2a3a96e9ad#diff-5b4ded67d6b41332a7188e3100bec940e517ea32550f01e25709b13f86eabc77

https://github.com/betaflight/betaflight/commit/4d8bf61d94614f20ff8ace847b5d2b12d8710bdf#diff-5b4ded67d6b41332a7188e3100bec940e517ea32550f01e25709b13f86eabc77

It not only provides additional telemetry flight information, it also allows compatibility with [LuaTelemetry](https://github.com/teckel12/LuaTelemetryINAV).  Feature requested by @Xedos9er https://github.com/teckel12/LuaTelemetryINAV/issues/442

This is **UNTESTED** as I don't fly EmuFlight.