### PR TITLE
specify "uncommitted" in .hex & .bin when applicable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,11 @@ ifneq ($(TRAVIS_BUILD_NUMBER),)
 BUILDNO := $(TRAVIS_BUILD_NUMBER)
 endif
 
+BUILDDATETIME := $(shell date +'%Y%m%d')
+REVISION := uncommitted_$(BUILDDATETIME)
+ifeq ($(shell git diff --shortstat),)
 REVISION := $(shell git log -1 --format="%h")
+endif
 
 FC_VER_MAJOR := $(shell grep " FC_VERSION_MAJOR" src/main/build/version.h | awk '{print $$3}' )
 FC_VER_MINOR := $(shell grep " FC_VERSION_MINOR" src/main/build/version.h | awk '{print $$3}' )

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ ifneq ($(TRAVIS_BUILD_NUMBER),)
 BUILDNO := $(TRAVIS_BUILD_NUMBER)
 endif
 
-BUILDDATETIME := $(shell date +'%Y%m%d')
+BUILDDATETIME := $(shell date +'%Y%m%d%Z')
 REVISION := uncommitted_$(BUILDDATETIME)
 ifeq ($(shell git diff --shortstat),)
 REVISION := $(shell git log -1 --format="%h")


### PR DESCRIPTION
Specify `uncommitted+YYYYMMDD` when building uncommitted source-code, otherwise same as before (`Build_####_SHA`)

* uncommitted: `EmuFlight_0.3.3_STRIXF10_Build_uncommitted_20210312CDT.hex`
* normal `EmuFlight_0.3.3_STRIXF10_Build_5a995933f.hex`
* i wanted time as well, but filename length caused error. did include Timezone which can estimate who might have compiled.
