### PR TITLE
Fix the XILOF4 NO_GYRO problem.

### DIFF
--- a/src/main/target/XILOF4/target.h
+++ b/src/main/target/XILOF4/target.h
@@ -42,16 +42,17 @@
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
-//#define USE_GYRO_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
 #define MPU6000_CS_PIN          SPI1_NSS_PIN
 #define MPU6000_SPI_INSTANCE    SPI1
+#define MPU6500_SPI_INSTANCE    SPI1
 #define GYRO_MPU6000_ALIGN      CW180_DEG
 //#define MPU_INT_EXTI            NONE
 //#define GYRO_1_EXTI_PIN         NONE
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
-//#define USE_ACC_SPI_MPU6500
+#define USE_ACC_SPI_MPU6500
 
 // *************** Flash **************************
 #define USE_SPI_DEVICE_2

--- a/src/main/target/XILOF4/target.mk
+++ b/src/main/target/XILOF4/target.mk
@@ -2,6 +2,8 @@ F405_TARGETS    += $(TARGET)
 FEATURES        += VCP ONBOARDFLASH
 
 TARGET_SRC = \
-						drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_mpu.c \
+            drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6000.c \
+            drivers/accgyro/accgyro_spi_mpu6500.c \
             drivers/max7456.c


### PR DESCRIPTION
Enable the SPI gyro and fix the XILOF4 target.
