### PR TITLE
Simplify the Rate Dynamics processing

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -578,6 +578,53 @@ static void applyPolarExpo(void) {
     rcCommand[FD_PITCH] *= roll_pitch_scale;
 }
 
+FAST_CODE static float calculateK(float k, const float dT) {
+    if (k == 0.0f) {
+        return 0;
+    }
+    // scale so it feels like running at 62.5hz (16ms) regardless of the current rx rate
+    const float rxRate = 1.0f / dT;
+    const float rxRateFactor = (rxRate / 62.5f) * rxRate;
+    const float freq = k / ((1.0f / rxRateFactor) * (1.0f - k));
+    const float RC = 1.0f / freq;
+
+    return dT / (RC + dT);
+}
+
+FAST_CODE static float rateDynamics(float rcCommand, const int axis, const float dT) {
+    static FAST_RAM_ZERO_INIT float lastRcCommandData[3];
+    static FAST_RAM_ZERO_INIT float iterm[3];
+    if (((currentControlRateProfile->rateDynamics.rateSensCenter != 100) || (currentControlRateProfile->rateDynamics.rateSensEnd != 100))
+            || ((currentControlRateProfile->rateDynamics.rateWeightCenter > 0) || (currentControlRateProfile->rateDynamics.rateWeightEnd > 0))) {
+        float pterm_centerStick, pterm_endStick, pterm, iterm_centerStick, iterm_endStick, dterm_centerStick, dterm_endStick, dterm;
+        float rcCommandPercent;
+        float rcCommandError;
+        float inverseRcCommandPercent;
+
+        rcCommandPercent = fabsf(rcCommand) / 500.0f; // make rcCommandPercent go from 0 to 1
+        inverseRcCommandPercent = 1.0f - rcCommandPercent;
+
+        pterm_centerStick = inverseRcCommandPercent * rcCommand * (currentControlRateProfile->rateDynamics.rateSensCenter / 100.0f); // valid pterm values are between 50-150
+        pterm_endStick = rcCommandPercent * rcCommand * (currentControlRateProfile->rateDynamics.rateSensEnd / 100.0f);
+        pterm = pterm_centerStick + pterm_endStick;
+        rcCommandError = rcCommand - (pterm + iterm[axis]);
+        rcCommand = pterm; // add this fake pterm to the rcCommand
+
+        iterm_centerStick = inverseRcCommandPercent * rcCommandError * calculateK(currentControlRateProfile->rateDynamics.rateCorrectionCenter / 100.0f, dT); // valid iterm values are between 0-95
+        iterm_endStick = rcCommandPercent * rcCommandError * calculateK(currentControlRateProfile->rateDynamics.rateCorrectionEnd / 100.0f, dT);
+        iterm[axis] += iterm_centerStick + iterm_endStick;
+        rcCommand = rcCommand + iterm[axis]; // add the iterm to the rcCommand
+
+        dterm_centerStick = inverseRcCommandPercent * (lastRcCommandData[axis] - rcCommand) * calculateK(currentControlRateProfile->rateDynamics.rateWeightCenter / 100.0f, dT); // valid dterm values are between 0-95
+        dterm_endStick = rcCommandPercent * (lastRcCommandData[axis] - rcCommand) * calculateK(currentControlRateProfile->rateDynamics.rateWeightEnd / 100.0f, dT);
+        dterm = dterm_centerStick + dterm_endStick;
+        rcCommand = rcCommand + dterm; // add dterm to the rcCommand (this is real dterm)
+
+        lastRcCommandData[axis] = rcCommand;
+    }
+    return rcCommand;
+}
+
 FAST_CODE FAST_CODE_NOINLINE void updateRcCommands(void) {
     isRXDataNew = true;
     // PITCH & ROLL only dynamic PID adjustment,  depending on throttle value
@@ -617,6 +664,8 @@ FAST_CODE FAST_CODE_NOINLINE void updateRcCommands(void) {
         }
         throttleDAttenuation = propD / 100.0f;
     }
+
+    const float dT = currentRxRefreshRate * 1e-6f;
     for (int axis = 0; axis < 3; axis++) {
         // non coupled PID reduction scaler used in PID controller 1 and PID controller 2.
         int32_t tmp = MIN(ABS(rcData[axis] - rxConfig()->midrc), 500);
@@ -638,7 +687,7 @@ FAST_CODE FAST_CODE_NOINLINE void updateRcCommands(void) {
         if (rcData[axis] < rxConfig()->midrc) {
             rcCommand[axis] = -rcCommand[axis];
         }
-        rcCommand[axis] = rateDynamics(rcCommand[axis], axis, currentRxRefreshRate);
+        rcCommand[axis] = rateDynamics(rcCommand[axis], axis, dT);
     }
 
       applyPolarExpo();
@@ -772,50 +821,3 @@ bool rcSmoothingInitializationComplete(void) {
 }
 #endif // USE_RC_SMOOTHING_FILTER
 
-FAST_CODE float calculateK(float k, int time) {
-    if (k == 0.0f) {
-        return 0;
-    }
-    // scale so it feels like running at 62.5hz (16ms) regardless of the current rx rate
-    const float dT = time * 1e-6f;
-    const float rxRate = 1.0f / dT;
-    const float rxRateFactor = (rxRate / 62.5f) * rxRate;
-    const float freq = k / ((1.0f / rxRateFactor) * (1.0f - k));
-    const float RC = 1.0f / freq;
-
-    return dT / (RC + dT);
-}
-
-FAST_CODE float rateDynamics(float rcCommand, int axis, int currentRxRefreshRate) {
-    static FAST_RAM_ZERO_INIT float lastRcCommandData[3];
-    static FAST_RAM_ZERO_INIT float iterm[3];
-    if (((currentControlRateProfile->rateDynamics.rateSensCenter != 100) || (currentControlRateProfile->rateDynamics.rateSensEnd != 100))
-            || ((currentControlRateProfile->rateDynamics.rateWeightCenter > 0) || (currentControlRateProfile->rateDynamics.rateWeightEnd > 0))) {
-        float pterm_centerStick, pterm_endStick, pterm, iterm_centerStick, iterm_endStick, dterm_centerStick, dterm_endStick, dterm;
-        float rcCommandPercent;
-        float rcCommandError;
-        float inverseRcCommandPercent;
-
-        rcCommandPercent = fabsf(rcCommand) / 500.0f; // make rcCommandPercent go from 0 to 1
-        inverseRcCommandPercent = 1.0f - rcCommandPercent;
-
-        pterm_centerStick = inverseRcCommandPercent * rcCommand * (currentControlRateProfile->rateDynamics.rateSensCenter / 100.0f); // valid pterm values are between 50-150
-        pterm_endStick = rcCommandPercent * rcCommand * (currentControlRateProfile->rateDynamics.rateSensEnd / 100.0f);
-        pterm = pterm_centerStick + pterm_endStick;
-        rcCommandError = rcCommand - (pterm + iterm[axis]);
-        rcCommand = pterm; // add this fake pterm to the rcCommand
-
-        iterm_centerStick = inverseRcCommandPercent * rcCommandError * calculateK(currentControlRateProfile->rateDynamics.rateCorrectionCenter / 100.0f, currentRxRefreshRate); // valid iterm values are between 0-95
-        iterm_endStick = rcCommandPercent * rcCommandError * calculateK(currentControlRateProfile->rateDynamics.rateCorrectionEnd / 100.0f, currentRxRefreshRate);
-        iterm[axis] += iterm_centerStick + iterm_endStick;
-        rcCommand = rcCommand + iterm[axis]; // add the iterm to the rcCommand
-
-        dterm_centerStick = inverseRcCommandPercent * (lastRcCommandData[axis] - rcCommand) * calculateK(currentControlRateProfile->rateDynamics.rateWeightCenter / 100.0f, currentRxRefreshRate); // valid dterm values are between 0-95
-        dterm_endStick = rcCommandPercent * (lastRcCommandData[axis] - rcCommand) * calculateK(currentControlRateProfile->rateDynamics.rateWeightEnd / 100.0f, currentRxRefreshRate);
-        dterm = dterm_centerStick + dterm_endStick;
-        rcCommand = rcCommand + dterm; // add dterm to the rcCommand (this is real dterm)
-
-        lastRcCommandData[axis] = rcCommand;
-    }
-    return rcCommand;
-}

--- a/src/main/fc/fc_rc.h
+++ b/src/main/fc/fc_rc.h
@@ -52,4 +52,3 @@ bool rcSmoothingAutoCalculate(void);
 bool rcSmoothingInitializationComplete(void);
 #endif
 void updateRcRefreshRate(timeUs_t currentTimeUs);
-float rateDynamics(float rcCommand, int axis, int currentRxRefreshRate);


### PR DESCRIPTION
`dT` computation for Rate Dynamincs is performed for each axis multiple time while it can be executed once and just passed below. 
Also, the  `rateDynamics` function can be made static and not present in header file