### PR TITLE
Gyro ABG filter apply

### DIFF
--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -35,6 +35,7 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor) {
         gyroADCf = gyroSensor->lowpassFilterApplyFn((filter_t *)&gyroSensor->lowpassFilter[axis], gyroADCf);
         gyroADCf = gyroSensor->notchFilter1ApplyFn((filter_t *)&gyroSensor->notchFilter1[axis], gyroADCf);
         gyroADCf = gyroSensor->notchFilter2ApplyFn((filter_t *)&gyroSensor->notchFilter2[axis], gyroADCf);
+        gyroADCf = gyroSensor->gyroABGFilterApplyFn((filter_t *)&gyroSensor->gyroABGFilter[axis], gyroADCf);
 #ifdef USE_GYRO_DATA_ANALYSE
         if (isDynamicFilterActive()) {
             if (axis == X) {


### PR DESCRIPTION
Gyro ABG filter was initialized previously, but it was never actually applied, this fixes that. Seriously check the code, gyroABGFilterApplyFn is never used up until I add it here. UGHGHGHGH. This code will work though, been tested on 1.0.0 (and yes it is initialized there). This should be merged asap there is no reason to wait on it.