### PR TITLE
bump version 0.3.5

### DIFF
--- a/src/main/build/version.h
+++ b/src/main/build/version.h
@@ -25,7 +25,7 @@
 #define FC_FIRMWARE_NAME            "EmuFlight"
 #define FC_VERSION_MAJOR            0  // increment when a major release is made (big new feature, etc)
 #define FC_VERSION_MINOR            3  // increment when a minor release is made (small new feature, change etc)
-#define FC_VERSION_PATCH_LEVEL      3 // increment when a bug is fixed
+#define FC_VERSION_PATCH_LEVEL      5 // increment when a bug is fixed
 
 #define FC_VERSION_STRING STR(FC_VERSION_MAJOR) "." STR(FC_VERSION_MINOR) "." STR(FC_VERSION_PATCH_LEVEL)
 


### PR DESCRIPTION
* i think it appropriate to bump version to 0.3.4 since we released 0.3.4
* should avoid confusion for next test-builds