### PR TITLE
toggle for yaw-throttle-correction (compensation) PR#502

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1209,6 +1209,7 @@ static bool blackboxWriteSysinfo(void) {
         BLACKBOX_PRINT_HEADER_LINE("linear_throttle", "%d",                 currentPidProfile->linear_throttle);
         BLACKBOX_PRINT_HEADER_LINE("mixer_impl", "%d",                      currentPidProfile->mixer_impl);
         BLACKBOX_PRINT_HEADER_LINE("mixer_laziness", "%d",                  currentPidProfile->mixer_laziness);
+        BLACKBOX_PRINT_HEADER_LINE("mixer_yaw_throttle_comp", "%d",         currentPidProfile->mixer_yaw_throttle_comp);
         // End of EmuFlight controller parameters
         BLACKBOX_PRINT_HEADER_LINE("deadband", "%d",                        rcControlsConfig()->deadband);
         BLACKBOX_PRINT_HEADER_LINE("yaw_deadband", "%d",                    rcControlsConfig()->yaw_deadband);

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -83,6 +83,7 @@ static uint8_t linear_thrust_high_output;
 static uint8_t linear_throttle;
 static mixerImplType_e mixer_impl;
 static uint8_t mixer_laziness;
+static uint8_t mixer_yaw_throttle_comp;
 static uint8_t tmpRateProfileIndex;
 static uint8_t rateProfileIndex;
 static char rateProfileIndexString[] = " p-r";
@@ -153,6 +154,7 @@ static long cmsx_PidAdvancedRead(void) {
     linear_throttle = pidProfile->linear_throttle;
     mixer_impl = pidProfile->mixer_impl;
     mixer_laziness = pidProfile->mixer_laziness;
+    mixer_yaw_throttle_comp = pidProfile->mixer_yaw_throttle_comp;
     return 0;
 }
 
@@ -185,6 +187,7 @@ static long cmsx_PidAdvancedWriteback(const OSD_Entry *self) {
     pidProfile->linear_throttle = linear_throttle;
     pidProfile->mixer_impl = mixer_impl;
     pidProfile->mixer_laziness = mixer_laziness;
+    pidProfile->mixer_yaw_throttle_comp = mixer_yaw_throttle_comp;
     pidInitConfig(currentPidProfile);
     return 0;
 }
@@ -217,6 +220,7 @@ static OSD_Entry cmsx_menuPidAdvancedEntries[] = {
     { "LINEAR THROTTLE",   OME_TAB,   NULL, &(OSD_TAB_t)   { (uint8_t *) &linear_throttle, 1, cms_offOnLabels }, 0 },
     { "MIXER IMPL",        OME_TAB,   NULL, &(OSD_TAB_t)   { &mixer_impl, MIXER_IMPL_COUNT - 1, cms_mixerImplTypeLabels }, 0 },
     { "MIXER LAZINESS",    OME_TAB,   NULL, &(OSD_TAB_t)   { (uint8_t *) &mixer_laziness, 1, cms_offOnLabels }, 0 },
+    { "MIXER YAW THR COMP", OME_TAB,   NULL, &(OSD_TAB_t)   { (uint8_t *) &mixer_yaw_throttle_comp, 1, cms_offOnLabels }, 0 },
 
     { "SAVE&EXIT",         OME_OSD_Exit, cmsMenuExit,   (void *)CMS_EXIT_SAVE, 0},
     { "BACK",              OME_Back, NULL, NULL, 0 },

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -1028,7 +1028,10 @@ static void twoPassMix(float *motorMix, const float *yawMix, const float *rollPi
     // correct for the extra thrust yaw adds, then fill up motorMix with pitch and roll
     for (int i = 0; i < motorCount; i++) {
 
-        motorMix[i] = motorMix[i] - yawThrottleCorrection;
+        if (currentPidProfile->mixer_yaw_throttle_comp) {  //!==0
+            // prefer calculating all of the above and maybe not use it, than multiple if/then statements to save from calculating.
+            motorMix[i] = motorMix[i] - yawThrottleCorrection;
+        };
         float motorMixThrust = motorToThrust(motorMix[i], true); // convert into thrust value
 
         // clipping handling

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -184,6 +184,7 @@ void resetPidProfile(pidProfile_t *pidProfile) {
     .linear_throttle = false,
     .mixer_impl = MIXER_IMPL_LEGACY,
     .mixer_laziness = false,
+    .mixer_yaw_throttle_comp = true,
     .horizonStrength = 15,
     .directFF_yaw = 15,
     .dterm_ABG_alpha = 0,

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -151,6 +151,7 @@ typedef struct pidProfile_s {
     uint8_t linear_throttle;                // When thrust linearization is enabled, tells whether the throttle has to be linear or counter-compensated for legacy feedback
     mixerImplType_e mixer_impl;             // Which mixer implementation use
     uint8_t mixer_laziness;                 // If enabled, mixer clipping strategy will shift values only by the minimum required amount per motor group. Requires linear thrust
+    uint8_t mixer_yaw_throttle_comp;        // If enabled, throttle compesesation for quick yaw movement in 2pass mixer
     uint16_t dterm_ABG_alpha;
     uint16_t dterm_ABG_boost;
     uint8_t dterm_ABG_half_life;

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -949,6 +949,8 @@ const clivalue_t valueTable[] = {
     { "linear_throttle",           VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, linear_throttle) },
     { "mixer_impl",                VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_MIXER_IMPL_TYPE }, PG_PID_PROFILE, offsetof(pidProfile_t, mixer_impl) },
     { "mixer_laziness",            VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, mixer_laziness) },
+    { "mixer_yaw_throttle_comp",   VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, mixer_yaw_throttle_comp) },
+
 
 // PG_TELEMETRY_CONFIG
 #ifdef USE_TELEMETRY


### PR DESCRIPTION
* needs code review for if a good `mixer.c` logic or not
* enabled by default.
* OSD PID>Advanced>`MIXER YAW THR COMP`.
* CLI `set mixer_yaw_throttle_comp = `.
* includes blackbox header.
* test hovered good on/off.
* OSD works
* CLI works

