### PR TITLE
GitHub Actions Draft Releases to dev-unstable and dev-master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ on:
   push:
     tags:
     - '*'
-    branches:
-    - '*'
+    #branches:
+    #- '*'
   pull_request:
     branches:
     - '*'
@@ -14,14 +14,19 @@ on:
 name: Build EmuFlight
 jobs:
   build:
+    continue-on-error: false
     timeout-minutes: 75
     strategy:
       max-parallel: 4
       matrix:
         targets: [targets-group-1, targets-group-2, targets-group-3, targets-group-rest]
+    outputs:
+      buildtag: ${{ steps.ids.outputs.buildtag }}
+      shortsha: ${{ steps.ids.outputs.shortsha }}
+      artifact: ${{ steps.ids.outputs.artifact }}
     runs-on: ubuntu-latest
-    steps:
 
+    steps:
     # curl, by default, may timeout easily
     - name: curl fix
       run: function curl () { command curl --connect-timeout 30 --retry 10 "$@" ; }
@@ -42,13 +47,15 @@ jobs:
       continue-on-error: true
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
 
     - name: Setup Toolchain
-      uses: fiam/arm-none-eabi-gcc@master
+      uses: fiam/arm-none-eabi-gcc@v1
+      #uses: emuflight/arm-none-eabi-gcc@retry_timeout
       with:
         release: '9-2020-q2' # The arm-none-eabi-gcc release to use.
 
+    # EmuFlight version
     - name: Get code version
       id: get_version
       run: echo "VERSION=$(make version)" >> $GITHUB_ENV
@@ -69,6 +76,12 @@ jobs:
       run: echo "REVISION_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       if: startsWith(github.ref, 'refs/tags/')
 
+    - name: get tag & short-sha
+      run: |
+        echo "REVISION_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+        echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      continue-on-error: true
+
     - name: Make artifact name
       id: make_artifactname
       run: |
@@ -80,6 +93,14 @@ jobs:
         echo "${ARTIFACT_NAME}"
         echo "ARTIFACT_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
 
+    - id: ids
+      name : set outputs
+      run: |
+        echo "::set-output name=buildtag::${{ env.REVISION_TAG }}"
+        echo "::set-output name=shortsha::${{ env.SHORT_SHA }}"
+        echo "::set-output name=artifact::${{ env.ARTIFACT_NAME }}"
+      continue-on-error: true
+
     # for debugging
     - name: Show Variables
       id: show_vars
@@ -89,10 +110,15 @@ jobs:
         echo "Build: ${{ github.run_number }}"
         echo "Firmware: ${{ env.VERSION }}"
         echo "Commit: ${{ github.sha }}"
+        echo "ShortSHA: ${{ env.SHORT_SHA }}"
         echo "Tag: ${{ env.REVISION_TAG}}"
         echo "Artifact name: ${{ env.ARTIFACT_NAME }}"
+        echo "outputs.buildtag: ${{ steps.ids.outputs.buildtag }}"
+        echo "outputs.shortsha: ${{ steps.ids.outputs.shortsha }}"
+        echo "outputs.artfact: ${{ steps.ids.outputs.artifact }}"
       continue-on-error: true
 
+    # Build HEX
     - name: Compile Code
       run: |
         make ${{ matrix.targets }}
@@ -104,44 +130,119 @@ jobs:
         name: ${{ env.ARTIFACT_NAME }}
         path: obj/*.hex
 
-    # Upload to Bintray before .hex renames / only for tag
-    - name: Upload to Bintray
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        curl -fL https://getcli.jfrog.io | sh
-        export JFROG_CLI_OFFER_CONFIG=false
-        export CI=true
-        export JFROG_CLI_LOG_LEVEL=DEBUG
-        ./jfrog bt config --user=${{secrets.BINTRAYUSERNAME}} --key=${{secrets.BINTRAYAPIKEY}} --licenses=GPL-3.0
-        export repo="emuflight-dev/dev_hex"
-        export package="${{env.REVISION_TAG}}"
-        export version="${{github.run_number}}-${{env.VERSION}}-${{env.REVISION_TAG}}"
-        ./jfrog bt package-create --pub-dn=true --vcs-url="https://github.com/emuflight" "${repo}/${package}" || true
-        ./jfrog bt version-create "${repo}/${package}/${version}"  || true
-        ./jfrog bt upload --publish=true "obj/*.hex" "${repo}/${package}/${version}" "GitHub_Build_${version}/" || true
-      continue-on-error: true
 
-    # Rename .hex for Releases
-    - name: Rename Artifacts
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        sudo apt -y install rename
-        cd obj
-        rename 's/_Build_.*/.hex/' *.hex
+  releases:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      # for debugging
+      - name: show variables
+        run: |
+          echo "Build: ${{ github.RUN_NUMBER }}"
+          echo "Commit: ${{ github.SHA }}"
+          echo "Ref: ${{ GITHUB.REF }}"
+          echo "Actor: ${{ github.ACTOR }}"
+          echo "Repo: ${{ github.REPOSITORY }}"
+          echo "outputs.buildtag: ${{ needs.build.outputs.buildtag }}"
+          echo "outputs.shortsha: ${{ needs.build.outputs.shortsha }}"
+          echo "outputs.artfact: ${{ needs.build.outputs.artifact }}"
+        continue-on-error: true
 
-    - name: Draft Release
-      uses: softprops/action-gh-release@v1
-      if: startsWith(github.ref, 'refs/tags/')
-      with:
-        files: obj/*.hex
-        draft: true
-        prerelease: true
-        tag_name: ${{ github.run_number }}   # use the build Number, but we manually change to version so that it creates a version-tag on release
-        name:  DRAFT / EmuFlight ${{ env.VERSION }} / GitHub Build ${{ github.run_number }}
-        body: |
-          # EmuFlight ${{ env.VERSION }}
-          ## BuildTag: ${{ env.REVISION_TAG}}
-          ## Commit: ${{ github.sha }}
-          ## Changes in this Release:
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.build.outputs.artifact }} #no name parameter will download all artifacts, but crate separate subfolders
+          path: obj
+        continue-on-error: false
+
+      - name: list/find extractions
+        run: |
+          find ./ -name "*.hex"
+
+      # Draft Dev-Unstable releases via ncipollo/release-action
+      # softprops/action-gh-release fails to release on separate repo
+      - name: Draft Release Dev-Unstable repo
+        if: contains(github.ref, 'test') || contains(github.ref, 'unstab')
+        uses: ncipollo/release-action@v1
+        with:
+          repo: dev-unstable
+          owner: emuflight
+          token: ${{ secrets.NC_PAT_EMUF }}
+          tag: "hex-${{ github.run_number }}"
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          artifacts: obj/*.hex
+          artifactContentType: raw
+          name:  "DEV-UNSTABLE HEX / Build ${{ github.run_number }}"
+          body: |
+            ## HEX BUILD for TESTING
+            ### Build ${{ github.run_number }}
+            ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
+            ### BuildTag: ${{ needs.build.outputs.buildtag }}
+            ### EmuFlight ${{ env.VERSION }} base plus test code
+            ### Changes in this Build:
+            ### What to Test/Feedback: (Feedback in EmuFlight's Discord or GitHub Discussions)
+        continue-on-error: true
+
+      # Draft Dev-master releases via ncipollo/release-action
+      # softprops/action-gh-release fails to release on separate repo
+      - name: Draft Release Dev-Master repo
+        if: contains(github.ref, 'master')
+        uses: ncipollo/release-action@v1
+        with:
+          repo: dev-master
+          owner: emuflight
+          token: ${{ secrets.NC_PAT_EMUF }}
+          tag: "hex-${{ github.run_number }}"
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          artifacts: obj/*.hex
+          artifactContentType: raw
+          name:  "DEV-MASTER HEX / Build ${{ github.run_number }}"
+          body: |
+            ## HEX BUILD of MASTER
+            ### Build ${{ github.run_number }}
+            ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
+            ### BuildTag: ${{ needs.build.outputs.buildtag }}
+            ### EmuFlight ${{ env.VERSION }} base plus committed code
+            ### Changes in this Build:
+            ### Feedback Welcome in EmuFlight's Discord or GitHub Discussions.
+        continue-on-error: true
+
+      # Rename .hex for true Releases on main repo
+      - name: Rename Artifacts
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo apt -y install rename
+          cd obj
+          rename 's/_Build_.*/.hex/' *.hex
+
+      #Draft Releases on main Repo
+      # could potentially change to ncipollo/release-action as well
+      - name: Draft Release Main Repo
+        if: contains(github.ref, 'releas')
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          # tag: use the build Number, but we MUST manually change to version so that it creates a version-tag on release
+          tag: ${{ env.VERSION }}
+          artifacts: obj/*.hex
+          artifactContentType: raw
+          name:  DRAFT / EmuFlight ${{ env.VERSION }} / GitHub Build ${{ github.run_number }}
+          body: |
+            ## EmuFlight ${{ env.VERSION }}
+            ### Build ${{ github.run_number }}
+            ### Commit SHA: ${{ needs.build.outputs.shortsha }} (${{ github.sha }})
+            ### BuildTag: ${{ needs.build.outputs.buildtag }}
+            ### Changes in this Release:
+        continue-on-error: false


### PR DESCRIPTION
### Add GitHub Actions for Draft Releases to `dev-unstable` and `dev-master`
* All tags build to GH-Actions artifacts.
* Tag names containing substring `releas` will draft-release to `emuflight` repo.
* Tag names containing substring `unstab` or `test` will draft-release to `dev-unstable` repo.
* Tag names containing substring `master` will draft-release to `dev-master` repo.
* tag could potentially contain all of the above substrings for draft-release to multiple repos.
* Removes defunct JFrog BinTray uploading.
* Disable building all branches (now requires tagging)
* Forks can use tags as well for personal repo gh-actions artifacts.
* How to:
```shell
git checkout [master|branch|commit]
git tag buildMe
git push [origin|upstream] buildMe
git tag --delete buildMe   #delete local tag
git push --delete [origin|upstream] buildMe   #delete remote tag
```
* tagname examples that will apply draft-release to target repos: `forTesting`, `releaseThis`, `stableMaster`,`ReleaseMasterAndUnstable`