### PR TITLE
fix PR#500; dynamicFilter/dynamicDtermNotch

### DIFF
--- a/src/main/common/sdft.c
+++ b/src/main/common/sdft.c
@@ -40,8 +40,8 @@ void sdftInit(sdft_t *sdft, const uint8_t startBin, const uint8_t endBin, const 
     if (!isInitialized) {
         rPowerN = powf(SDFT_R, SDFT_SAMPLE_SIZE);
         const float c = 2.0f * M_PIf / (float)SDFT_SAMPLE_SIZE;
-        float phi = 0.0f;
         for (uint8_t i = 0; i < SDFT_BIN_COUNT; i++) {
+            float phi = 0.0f;
             phi = c * i;
             twiddle[i] = SDFT_R * (cos_approx(phi) + _Complex_I * sin_approx(phi));
         }
@@ -103,10 +103,9 @@ FAST_CODE void sdftPushBatch(sdft_t* sdft, const float *sample, const uint8_t *b
 // Get squared magnitude of frequency spectrum
 FAST_CODE void sdftMagSq(const sdft_t *sdft, float *output)
 {
-    float re;
-    float im;
-
     for (uint8_t i = sdft->startBin; i <= sdft->endBin; i++) {
+        float re;
+        float im;
         re = crealf(sdft->data[i]);
         im = cimagf(sdft->data[i]);
         output[i] = re * re + im * im;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -197,7 +197,7 @@ void resetPidProfile(pidProfile_t *pidProfile) {
     .dterm_ABG_half_life = 50,
     .emuGravityGain = 50,
     .angle_filter = 100,
-    .dtermDynNotch = true,
+    .dtermDynNotch = false,
     .dterm_dyn_notch_q = 400,
                 );
 }

--- a/src/main/sensors/gyroanalyse.c
+++ b/src/main/sensors/gyroanalyse.c
@@ -319,10 +319,9 @@ static FAST_CODE_NOINLINE void gyroDataAnalyseUpdate(gyroAnalyseState_t *state)
 
                     // get centerFreq in Hz from weighted bins
                     float centerFreq = dynNotchMaxHz;
-                    float sdftMeanBin = 0;
 
                     if (sdftSum > 0) {
-                        sdftMeanBin = (sdftWeightedSum / sdftSum);
+                        float sdftMeanBin = (sdftWeightedSum / sdftSum);
                         centerFreq = sdftMeanBin * sdftResolutionHz;
                         centerFreq = constrainf(centerFreq, dynNotchMinHz, dynNotchMaxHz);
                         // In theory, the index points to the centre frequency of the bin.


### PR DESCRIPTION
* fix Codacy `The scope of the variable 'XXXXX' can be reduced.`
* set `dtermDynNotch = false` by default