### PR TITLE
Making angle mode more responsive

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -498,16 +498,16 @@ static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPit
     if (!FLIGHT_MODE(HORIZON_MODE)) {
       if (pidProfile->angleExpo > 0) {
           const float expof = pidProfile->angleExpo / 100.0f;
-          angle = pidProfile->levelAngleLimit * scaledRcDeflection * (getRcDeflection(axis) * power3(getRcDeflectionAbs(axis)) * expof + getRcDeflection(axis) * (1 - expof));
+          angle = pidProfile->levelAngleLimit * (getRcDeflection(axis) * power3(getRcDeflectionAbs(axis)) * expof + getRcDeflection(axis) * (1 - expof));
       } else {
-          angle = pidProfile->levelAngleLimit * scaledRcDeflection * getRcDeflection(axis);
+          angle = pidProfile->levelAngleLimit * getRcDeflection(axis);
       }
     } else {
       if (pidProfile->angleExpo > 0) {
           const float expof = pidProfile->angleExpo / 100.0f;
-          angle = horizonCutoffDegrees * scaledRcDeflection * (getRcDeflection(axis) * power3(getRcDeflectionAbs(axis)) * expof + getRcDeflection(axis) * (1 - expof));
+          angle = horizonCutoffDegrees * (getRcDeflection(axis) * power3(getRcDeflectionAbs(axis)) * expof + getRcDeflection(axis) * (1 - expof));
       } else {
-          angle = horizonCutoffDegrees * scaledRcDeflection * getRcDeflection(axis);
+          angle = horizonCutoffDegrees * getRcDeflection(axis);
       }
     }
 #ifdef USE_GPS_RESCUE

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -486,15 +486,8 @@ static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPit
     // calculate error angle and limit the angle to the max inclination
     // rcDeflection is in range [-1.0, 1.0]
     static float attitudePrevious[2], previousAngle[2];
-    float p_term_low, p_term_high, d_term_low, d_term_high, f_term_low, currentAngle, scaledRcDeflection, scaledAngle = 0.0f;
+    float p_term_low, p_term_high, d_term_low, d_term_high, f_term_low, currentAngle, angle, scaledAngle = 0.0f;
 
-    if (getRcDeflection(axis) != 0) {
-        scaledRcDeflection = getRcDeflectionAbs(axis) / (getRcDeflectionAbs(FD_PITCH) + getRcDeflectionAbs(FD_ROLL));
-    } else {
-        scaledRcDeflection = 0.0f;
-    }
-
-    float angle;
     if (!FLIGHT_MODE(HORIZON_MODE)) {
       if (pidProfile->angleExpo > 0) {
           const float expof = pidProfile->angleExpo / 100.0f;


### PR DESCRIPTION
Project MockingBird has noted that the current angle mod implementation is not very responsive. This code change removes scaling on pitch and roll, which should in theory allow angle mode to go past your set max angle when pitch and roll are full. However it seems that event rarely or never occurs and allowing this results in a better flying experience.