### PR TITLE
Remove packed on accDev_t for dropping alignment warning

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -107,7 +107,7 @@ typedef struct accDev_s {
     bool dataReady;
     bool acc_high_fsr;
     char revisionCode;                                      // a revision code for the sensor, if known
-}  __attribute__((packed)) accDev_t;
+} accDev_t;
 
 static inline void accDevLock(accDev_t *acc) {
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_MULTITHREAD)


### PR DESCRIPTION
With beginning of GCC 9 a great deal of warnings of "unaligned pointer value"
are introduced. For dropping the warning:

```
taking address of packed member of 'struct accDev_s' may result in an
unaligned pointer value [-Waddress-of-packed-member]
```
simply remove the 'packing' similar to commit:
[5b09b397a74e76fff4be254b35576b1aea321368](https://github.com/emuflight/EmuFlight/commit/5b09b397a74e76fff4be254b35576b1aea321368)

The __attribute__((packed)) means the smallest possible alignment (1 byte),
usually used for implementing binary network protocols.