### PR TITLE
Fix warning cast between incompatible function types

### DIFF
--- a/src/main/pg/pg.c
+++ b/src/main/pg/pg.c
@@ -49,7 +49,7 @@ void pgResetInstance(const pgRegistry_t *reg, uint8_t *base) {
         memcpy(base, reg->reset.ptr, regSize);
     } else if (reg->reset.fn) {
         // reset function, call it
-        reg->reset.fn(base, regSize);
+        reg->reset.fn(base);
     }
 }
 

--- a/src/main/pg/pg.h
+++ b/src/main/pg/pg.h
@@ -41,7 +41,7 @@ typedef enum {
 } pgRegistryInternal_e;
 
 // function that resets a single parameter group instance
-typedef void (pgResetFunc)(void * /* base */, int /* size */);
+typedef void (pgResetFunc)(void * /* base */);
 
 typedef struct pgRegistry_s {
     pgn_t pgn;             // The parameter group number, the top 4 bits are reserved for version


### PR DESCRIPTION
The function cast in macro PG_REGISTER_ARRAY_WITH_RESET_FN wants
(pgResetFunc)(void * /* base */)
rather than
(pgResetFunc)(void * /* base */, int /* size */);

This commit fixes the warning caused by incompatible function types.

Note: This fix is already available also in https://github.com/betaflight/betaflight/blob/daf202e8c365d14aeeb8a0942b7a0356a11d30d8/src/main/pg/pg.h#L44
and
https://github.com/betaflight/betaflight/blob/daf202e8c365d14aeeb8a0942b7a0356a11d30d8/src/main/pg/pg.c#L56