### PR TITLE
Fix warning statement may fall through

### DIFF
--- a/src/main/rx/rx.c
+++ b/src/main/rx/rx.c
@@ -428,7 +428,8 @@ static uint16_t getRxfailValue(uint8_t channel) {
                 return rxConfig()->rx_min_usec;
             }
         }
-    /* no break */
+
+    FALLTHROUGH;
     default:
     case RX_FAILSAFE_MODE_INVALID:
     case RX_FAILSAFE_MODE_HOLD:


### PR DESCRIPTION
This commit fixes warning:
statement may fall through [-Wimplicit-fallthrough=]

This patch is also borrowed from betaflight to fix the above described problem:
https://github.com/betaflight/betaflight/blob/daf202e8c365d14aeeb8a0942b7a0356a11d30d8/src/main/rx/rx.c#L589