### PR TITLE
Auto Notch

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -229,6 +229,7 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             common/maths.c \
             common/sdft.c \
             common/typeconversion.c \
+            common/auto_notch.c \
             drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_mpu3050.c \
             drivers/accgyro/accgyro_spi_bmi160.c \

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1701,6 +1701,7 @@ const clivalue_t valueTable[] = {
 #ifdef USE_RPM_FILTER
     { PARAM_NAME_RPM_FILTER_HARMONICS,     VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 3 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_harmonics) },
     { PARAM_NAME_RPM_FILTER_Q,             VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 250, 3000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_q) },
+    { "rpm_noise_limit",                   VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 255 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, noise_limit) },
     { PARAM_NAME_RPM_FILTER_MIN_HZ,        VAR_UINT8 | MASTER_VALUE, .config.minmaxUnsigned = { 30, 200 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_min_hz) },
     { PARAM_NAME_RPM_FILTER_FADE_RANGE_HZ, VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, 1000 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_fade_range_hz) },
     { PARAM_NAME_RPM_FILTER_LPF_HZ,        VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 100, 500 }, PG_RPM_FILTER_CONFIG, offsetof(rpmFilterConfig_t, rpm_filter_lpf_hz) },

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -693,6 +693,7 @@ const clivalue_t valueTable[] = {
 #if defined(USE_DYN_NOTCH_FILTER)
     { PARAM_NAME_DYN_NOTCH_COUNT,   VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 0, DYN_NOTCH_COUNT_MAX }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_count) },
     { PARAM_NAME_DYN_NOTCH_Q,       VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 1, 1000 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_q) },
+    { "dyn_notch_noise_limit",      VAR_UINT8   | MASTER_VALUE, .config.minmaxUnsigned = { 1, 255 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, noise_limit) },
     { PARAM_NAME_DYN_NOTCH_MIN_HZ,  VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 20, 250 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_min_hz) },
     { PARAM_NAME_DYN_NOTCH_MAX_HZ,  VAR_UINT16  | MASTER_VALUE, .config.minmaxUnsigned = { 200, 1000 }, PG_DYN_NOTCH_CONFIG, offsetof(dynNotchConfig_t, dyn_notch_max_hz) },
 #endif

--- a/src/main/common/auto_notch.c
+++ b/src/main/common/auto_notch.c
@@ -33,7 +33,7 @@
  */
 
 
-void init(autoNotch_t *autoNotch, float initial_frequency, int q, int noiseLimit, float looptimeUs) {
+void initAutoNotch(autoNotch_t *autoNotch, float initial_frequency, int q, int noiseLimit, float looptimeUs) {
     // creates an exponential moving average that will cover the freq we are nothing/bandpassing
     float adjustedQ = q / 100.0f;
 
@@ -48,7 +48,7 @@ void init(autoNotch_t *autoNotch, float initial_frequency, int q, int noiseLimit
     biquadFilterInit(&autoNotch->notchFilter, initial_frequency, looptimeUs, adjustedQ, FILTER_NOTCH, 1.0f);
 }
 
-float apply(autoNotch_t *autoNotch, float input) {
+float applyAutoNotch(autoNotch_t *autoNotch, float input) {
     float preNotchNoise = biquadFilterApplyDF1(&autoNotch->preVarianceBandpass, input);
     // variance is approximately the noise squared and averaged
     autoNotch->preVariance = pt1FilterApply(&autoNotch->preVarianceFilter, preNotchNoise * preNotchNoise);

--- a/src/main/common/auto_notch.c
+++ b/src/main/common/auto_notch.c
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Cleanflight and Betaflight and EmuFlight.
+ *
+ * Cleanflight and Betaflight and EmuFlight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight and EmuFlight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include "arm_math.h"
+
+#include "auto_notch.h"
+#include "fc/rc.h"
+#include "build/debug.h"
+#include "sensors/gyro.h"
+
+/*
+ * The idea is simple, run a passband at the notch frequency to isolate noise
+ * at the notch frequency. Then look at the averaged squared rate of change over
+ * a period of time great enough to cover at least 1 full wave of noise at notch
+ * frequency. This way we can measure noise and compare noise of pre/post notch.
+ * this allows us to crossfade based on noise.
+ */
+
+/*
+void init(auto_notch_t *auto_notch, float frequency, int gain) {
+  for (int i = 0; i < SAMPLE_LENGTH - 1; i++) {
+    float currentX = 1 * (i + 1.0);
+    filter->sumX += currentX;
+    filter->sumXSquared += currentX * currentX;
+  }
+  filter->sumXSquared = filter->sumXSquared * filter->w;
+  filter->squaredSumX = filter->sumX * filter->sumX;
+}
+
+void update_kalman_variance(kalman_t *state, float input) {
+  // put new data in the circular buffer
+  state->axisWindow[state->windex] = input;
+  state->windex++;
+
+  if (state->windex > state->w) {
+    state->windex = 0;
+  }
+
+  // least squares regression line
+  float sumXY = 0.0f;
+  float sumY = 0.0f;
+  int tempPointer = state->windex;
+  for (int i = 0; i < state->w; i++) {
+    float currentX = 1 * (i + 1.0);
+    sumXY += currentX * state->axisWindow[tempPointer];
+    sumY += state->axisWindow[tempPointer];
+    tempPointer++;
+    if (tempPointer > state->w) {
+      tempPointer = 0;
+    }
+  }
+
+  tempPointer = state->windex;
+  float m = (state->w * sumXY - state->sumX * sumY) * 2.9301453352086263478668541959681e-7f;
+  float b = (sumY - m * state->sumX) * 0.0125f;
+
+  // calculate variance against the curve
+  float variance = 0.0f;
+  for (int i = 0; i < state->w; i++) {
+    float currentX = 1 * (i + 1.0);
+    float pointOnLine = m * currentX + b;
+    float error = state->axisWindow[tempPointer] - pointOnLine;
+    variance += error * error;
+
+    tempPointer++;
+      if (tempPointer > state->w) {
+        tempPointer = 0;
+      }
+  }
+    float squirt;
+    arm_sqrt_f32(variance, &squirt);
+    state->variance = squirt * VARIANCE_SCALE;
+    state->variance = pt1FilterApply(&state->kFilter, state->variance);
+}
+*/

--- a/src/main/common/auto_notch.h
+++ b/src/main/common/auto_notch.h
@@ -27,7 +27,7 @@ typedef struct autoNotch_s {
     pt1Filter_t preVarianceFilter; // used as an exponential average, setup k to act like exponential average
     biquadFilter_t preVarianceBandpass;
 
-    float noiseLimit; // default of 50 allows 70 amplitude noise to be totally notched
+    float noiseLimitInv; // default of 50 allows 70 amplitude noise to be totally notched
     float weight;
     float invWeight;
 
@@ -36,5 +36,5 @@ typedef struct autoNotch_s {
 
 void initAutoNotch(autoNotch_t *autoNotch, float initial_frequency, int q, int noiseLimit, float looptimeUs);
 float applyAutoNotch(autoNotch_t *autoNotch, float input);
-void updateWeight(autoNotch_t *autoNotch, float weightMultiplier);
+void updateWeight(autoNotch_t *autoNotch, float frequency, float weightMultiplier);
 void updateAutoNotch(autoNotch_t *autoNotch, float frequency, float q, float weightMultiplier, float looptimeUs);

--- a/src/main/common/auto_notch.h
+++ b/src/main/common/auto_notch.h
@@ -33,3 +33,7 @@ typedef struct autoNotch_s {
 
     biquadFilter_t notchFilter; // the notch filter we apply to the data
 } autoNotch_t;
+
+void initAutoNotch(autoNotch_t *autoNotch, float initial_frequency, int q, int noiseLimit, float looptimeUs);
+float applyAutoNotch(autoNotch_t *autoNotch, float input);
+void updateAutoNotch(autoNotch_t *autoNotch, float frequency, float q, float weightMultiplier, float looptimeUs);

--- a/src/main/common/auto_notch.h
+++ b/src/main/common/auto_notch.h
@@ -22,36 +22,14 @@
 
 #include "filter.h"
 
-// 8k / 100 gives us ability to see down to 50hz noise
-#define SAMPLE_LENGTH (8000 / 100) + 1
-// SAMPLE_LENGTH = 81
+typedef struct autoNotch_s {
+    float preVariance;
+    pt1Filter_t preVarianceFilter; // used as an exponential average, setup k to act like exponential average
+    biquadFilter_t preVarianceBandpass;
 
-// code below is precomputed to find the value of sum, sum squared, and squared sum
-// will need to be recomputed for different SAMPLE_LENGTH values
-/*int main()
-{
-    int sum = 0;
-    int sum_squared = 0;
-    int squared_sum = 0;
-    for (int i = 0; i < SAMPLE_LENGTH - 1; i++) {
-        int current_value = 1.0 * (i + 1.0);
-        sum += current_value;
-        sum_squared += current_value * current_value;
-    }
-    sum_squared = sum_squared * (SAMPLE_LENGTH - 1);
-    squared_sum = sum * sum;
+    float noiseLimit; // default of 50 allows 70 amplitude noise to be totally notched
+    float weight;
+    float invWeight;
 
-    printf("Hello, World!\n");
-    printf("sum %d\n", sum);
-    printf("sum squared %d\n", sum_squared);
-    printf("squared sum %d\n", squared_sum);
-}*/
-
-#define SUM 3240
-#define SUM_SQUARED 13910400
-#define SQUARED_SUM 10497600
-
-
-typedef struct auto_notch_s {
-
-} auto_notch_t;
+    biquadFilter_t notchFilter; // the notch filter we apply to the data
+} autoNotch_t;

--- a/src/main/common/auto_notch.h
+++ b/src/main/common/auto_notch.h
@@ -36,4 +36,5 @@ typedef struct autoNotch_s {
 
 void initAutoNotch(autoNotch_t *autoNotch, float initial_frequency, int q, int noiseLimit, float looptimeUs);
 float applyAutoNotch(autoNotch_t *autoNotch, float input);
+void updateWeight(autoNotch_t *autoNotch, float weightMultiplier);
 void updateAutoNotch(autoNotch_t *autoNotch, float frequency, float q, float weightMultiplier, float looptimeUs);

--- a/src/main/common/auto_notch.h
+++ b/src/main/common/auto_notch.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Cleanflight and Betaflight and EmuFlight.
+ *
+ * Cleanflight and Betaflight and EmuFlight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight and EmuFlight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "filter.h"
+
+// 8k / 100 gives us ability to see down to 50hz noise
+#define SAMPLE_LENGTH (8000 / 100) + 1
+// SAMPLE_LENGTH = 81
+
+// code below is precomputed to find the value of sum, sum squared, and squared sum
+// will need to be recomputed for different SAMPLE_LENGTH values
+/*int main()
+{
+    int sum = 0;
+    int sum_squared = 0;
+    int squared_sum = 0;
+    for (int i = 0; i < SAMPLE_LENGTH - 1; i++) {
+        int current_value = 1.0 * (i + 1.0);
+        sum += current_value;
+        sum_squared += current_value * current_value;
+    }
+    sum_squared = sum_squared * (SAMPLE_LENGTH - 1);
+    squared_sum = sum * sum;
+
+    printf("Hello, World!\n");
+    printf("sum %d\n", sum);
+    printf("sum squared %d\n", sum_squared);
+    printf("squared sum %d\n", squared_sum);
+}*/
+
+#define SUM 3240
+#define SUM_SQUARED 13910400
+#define SQUARED_SUM 10497600
+
+
+typedef struct auto_notch_s {
+
+} auto_notch_t;

--- a/src/main/common/auto_notch.h
+++ b/src/main/common/auto_notch.h
@@ -25,7 +25,6 @@
 typedef struct autoNotch_s {
     float preVariance;
     pt1Filter_t preVarianceFilter; // used as an exponential average, setup k to act like exponential average
-    biquadFilter_t preVarianceBandpass;
 
     float noiseLimitInv; // default of 50 allows 70 amplitude noise to be totally notched
     float weight;

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -189,36 +189,36 @@ FAST_CODE void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint
     case FILTER_LPF:
         // 2nd order Butterworth (with Q=1/sqrt(2)) / Butterworth biquad section with Q
         // described in http://www.ti.com/lit/an/slaa447/slaa447.pdf
-        filter->b1 = 1 - cs;
+        filter->b1 = 1.0 - cs;
         filter->b0 = filter->b1 * 0.5f;
         filter->b2 = filter->b0;
-        filter->a1 = -2 * cs;
-        filter->a2 = 1 - alpha;
+        filter->a1 = -2.0 * cs;
+        filter->a2 = 1.0 - alpha;
         break;
     case FILTER_NOTCH:
-        filter->b0 = 1;
-        filter->b1 = -2 * cs;
-        filter->b2 = 1;
+        filter->b0 = 1.0;
+        filter->b1 = -2.0 * cs;
+        filter->b2 = 1.0;
         filter->a1 = filter->b1;
-        filter->a2 = 1 - alpha;
+        filter->a2 = 1.0 - alpha;
         break;
     case FILTER_BPF:
         filter->b0 = alpha;
-        filter->b1 = 0;
+        filter->b1 = 0.0;
         filter->b2 = -alpha;
-        filter->a1 = -2 * cs;
-        filter->a2 = 1 - alpha;
+        filter->a1 = -2.0 * cs;
+        filter->a2 = 1.0 - alpha;
         break;
     }
 
-    const float a0 = 1 + alpha;
+    const float a0 = 1.0 / (1.0 + alpha);
 
     // precompute the coefficients
-    filter->b0 /= a0;
-    filter->b1 /= a0;
-    filter->b2 /= a0;
-    filter->a1 /= a0;
-    filter->a2 /= a0;
+    filter->b0 *= a0;
+    filter->b1 *= a0;
+    filter->b2 *= a0;
+    filter->a1 *= a0;
+    filter->a2 *= a0;
 
     // update weight
     filter->weight = weight;

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -214,6 +214,7 @@ FAST_CODE void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint
     const float a0 = 1.0 / (1.0 + alpha);
 
     // precompute the coefficients
+    // consider moving inside switch statement as you could save cpu
     filter->b0 *= a0;
     filter->b1 *= a0;
     filter->b2 *= a0;

--- a/src/main/fc/controlrate_profile.c
+++ b/src/main/fc/controlrate_profile.c
@@ -37,7 +37,7 @@
 
 controlRateConfig_t *currentControlRateProfile;
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 4);
+PG_REGISTER_ARRAY_WITH_RESET_FN(controlRateConfig_t, CONTROL_RATE_PROFILE_COUNT, controlRateProfiles, PG_CONTROL_RATE_PROFILES, 0);
 
 void pgResetFn_controlRateProfiles(controlRateConfig_t *controlRateConfig)
 {

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -19,11 +19,11 @@
  */
 
 /* original work by Rav
- * 
+ *
  * 2018_07 updated by ctzsnooze to post filter, wider Q, different peak detection
  * coding assistance and advice from DieHertz, Rav, eTracer
  * test pilots icr4sh, UAV Tech, Flint723
- * 
+ *
  * 2021_02 updated by KarateBrot: switched FFT with SDFT, multiple notches per axis
  * test pilots: Sugar K, bizmar
  */
@@ -123,7 +123,7 @@ typedef struct dynNotch_s {
 
     int maxCenterFreq;
     float centerFreq[XYZ_AXIS_COUNT][DYN_NOTCH_COUNT_MAX];
-    
+
     timeUs_t looptimeUs;
     biquadFilter_t notch[XYZ_AXIS_COUNT][DYN_NOTCH_COUNT_MAX];
 
@@ -258,11 +258,11 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
     DEBUG_SET(DEBUG_FFT_TIME, 0, state.step);
 
     switch (state.step) {
-    
+
         case STEP_WINDOW: // 4.1us (3-6us) @ F722
         {
             sdftWinSq(&sdft[state.axis], sdftData);
-            
+
             // Get total vibrational power in dyn notch range for noise floor estimate in STEP_CALC_FREQUENCIES
             sdftNoiseThreshold = 0.0f;
             for (int bin = (sdftStartBin + 1); bin < sdftEndBin; bin++) {   // don't use startBin or endBin because they are not windowed properly
@@ -356,7 +356,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
                     // Convert bin to frequency: freq = bin * binResoultion (bin 0 is 0Hz)
                     const float centerFreq = constrainf(meanBin * sdftResolutionHz, dynNotch.minHz, dynNotch.maxHz);
 
-                    // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 10x faster 
+                    // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 10x faster
                     const float cutoffMult = constrainf(peaks[p].value / sdftNoiseThreshold, 1.0f, 10.0f);
                     const float gain = pt1FilterGain(DYN_NOTCH_SMOOTH_HZ * cutoffMult, pt1LooptimeS); // dynamic PT1 k value
 
@@ -387,6 +387,7 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
             for (int p = 0; p < dynNotch.count; p++) {
                 // Only update notch filter coefficients if the corresponding peak got its center frequency updated in the previous step
                 if (peaks[p].bin != 0 && peaks[p].value > sdftNoiseThreshold) {
+                  // todo update autonotch crossfade value
                     biquadFilterUpdate(&dynNotch.notch[state.axis][p], dynNotch.centerFreq[state.axis][p], dynNotch.looptimeUs, dynNotch.q, FILTER_NOTCH, 1.0f);
                 }
             }
@@ -400,10 +401,15 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
     state.step = (state.step + 1) % STEP_COUNT;
 }
 
-FAST_CODE float dynNotchFilter(const int axis, float value) 
+FAST_CODE float dynNotchFilter(const int axis, float value)
 {
     for (int p = 0; p < dynNotch.count; p++) {
-        value = biquadFilterApplyDF1(&dynNotch.notch[axis][p], value);
+        float preFiltered = value;
+        value = biquadFilterApplyDF1Weighted(&dynNotch.notch[axis][p], value);
+        float postFiltered = value;
+
+        // TODO add new data to the auto_notch here
+
     }
 
     return value;

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -121,7 +121,7 @@ PG_RESET_TEMPLATE(pidConfig_t, pidConfig,
 
 #define LAUNCH_CONTROL_YAW_ITERM_LIMIT 50 // yaw iterm windup limit when launch mode is "FULL" (all axes)
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 3);
+PG_REGISTER_ARRAY_WITH_RESET_FN(pidProfile_t, PID_PROFILE_COUNT, pidProfiles, PG_PID_PROFILE, 0);
 
 void resetPidProfile(pidProfile_t *pidProfile)
 {
@@ -1125,7 +1125,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         if (feedforwardGain > 0) {
             // halve feedforward in Level mode since stick sensitivity is weaker by about half
             feedforwardGain *= FLIGHT_MODE(ANGLE_MODE) ? 0.5f : 1.0f;
-            // transition now calculated in feedforward.c when new RC data arrives 
+            // transition now calculated in feedforward.c when new RC data arrives
             float feedForward = feedforwardGain * pidSetpointDelta * pidRuntime.pidFrequency;
 
 #ifdef USE_FEEDFORWARD

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -96,7 +96,7 @@ void pgResetFn_rpmFilterConfig(rpmFilterConfig_t *config)
 
     config->rpm_filter_lpf_hz = 150;
 
-    config->noise_limit = 50;
+    config->noise_limit = 30;
 }
 
 static void rpmNotchFilterInit(rpmNotchFilter_t *filter, const rpmFilterConfig_t *config, const timeUs_t looptimeUs)

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -210,11 +210,6 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             clone->notchFilter.a1 = template->notchFilter.a1;
             clone->notchFilter.a2 = template->notchFilter.a2;
 
-            clone->preVarianceBandpass.b0 = template->preVarianceBandpass.b0;
-            //clone->preVarianceBandpass.b1 = template->preVarianceBandpass.b1; // always 0
-            clone->preVarianceBandpass.b2 = template->preVarianceBandpass.b2;
-            clone->preVarianceBandpass.b0 = template->preVarianceBandpass.a1;
-            clone->preVarianceBandpass.b2 = template->preVarianceBandpass.a2;
             updateWeight(clone, frequency, weight);
             }
 

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -215,7 +215,7 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
             clone->preVarianceBandpass.b2 = template->preVarianceBandpass.b2;
             clone->preVarianceBandpass.b0 = template->preVarianceBandpass.a1;
             clone->preVarianceBandpass.b2 = template->preVarianceBandpass.a2;
-            updateWeight(clone, weight);
+            updateWeight(clone, frequency, weight);
             }
 
         if (++currentHarmonic == currentFilter->harmonics) {

--- a/src/main/flight/rpm_filter.c
+++ b/src/main/flight/rpm_filter.c
@@ -31,6 +31,7 @@
 #include "common/filter.h"
 #include "common/maths.h"
 #include "common/time.h"
+#include "common/auto_notch.h"
 
 #include "drivers/dshot.h"
 
@@ -62,7 +63,7 @@ typedef struct rpmNotchFilter_s {
     float    q;
     timeUs_t looptimeUs;
 
-    biquadFilter_t notch[XYZ_AXIS_COUNT][MAX_SUPPORTED_MOTORS][RPM_FILTER_MAXHARMONICS];
+    autoNotch_t notch[XYZ_AXIS_COUNT][MAX_SUPPORTED_MOTORS][RPM_FILTER_MAXHARMONICS];
 
 } rpmNotchFilter_t;
 
@@ -94,6 +95,8 @@ void pgResetFn_rpmFilterConfig(rpmFilterConfig_t *config)
     config->rpm_filter_q = 500;
 
     config->rpm_filter_lpf_hz = 150;
+
+    config->noise_limit = 50;
 }
 
 static void rpmNotchFilterInit(rpmNotchFilter_t *filter, const rpmFilterConfig_t *config, const timeUs_t looptimeUs)
@@ -108,8 +111,8 @@ static void rpmNotchFilterInit(rpmNotchFilter_t *filter, const rpmFilterConfig_t
     for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
         for (int motor = 0; motor < getMotorCount(); motor++) {
             for (int i = 0; i < filter->harmonics; i++) {
-                biquadFilterInit(
-                    &filter->notch[axis][motor][i], filter->minHz * i, filter->looptimeUs, filter->q, FILTER_NOTCH, 0.0f);
+                initAutoNotch(
+                    &filter->notch[axis][motor][i], filter->minHz * i, filter->q, config->noise_limit, filter->looptimeUs);
             }
         }
     }
@@ -153,7 +156,7 @@ static float applyFilter(rpmNotchFilter_t *filter, const int axis, float value)
     }
     for (int motor = 0; motor < getMotorCount(); motor++) {
         for (int i = 0; i < filter->harmonics; i++) {
-            value = biquadFilterApplyDF1Weighted(&filter->notch[axis][motor][i], value);
+            value = applyAutoNotch(&filter->notch[axis][motor][i], value);
         }
     }
     return value;
@@ -183,31 +186,37 @@ FAST_CODE_NOINLINE void rpmFilterUpdate(void)
 
         float frequency = constrainf(
             (currentHarmonic + 1) * motorFrequency[currentMotor], currentFilter->minHz, currentFilter->maxHz);
-        biquadFilter_t *template = &currentFilter->notch[0][currentMotor][currentHarmonic];
+        autoNotch_t *template = &currentFilter->notch[0][currentMotor][currentHarmonic];
         // uncomment below to debug filter stepping. Need to also comment out motor rpm DEBUG_SET above
         /* DEBUG_SET(DEBUG_RPM_FILTER, 0, harmonic); */
         /* DEBUG_SET(DEBUG_RPM_FILTER, 1, motor); */
         /* DEBUG_SET(DEBUG_RPM_FILTER, 2, currentFilter == &gyroFilter); */
         /* DEBUG_SET(DEBUG_RPM_FILTER, 3, frequency) */
-        
+
         // fade out notch when approaching minHz (turn it off)
         float weight = 1.0f;
         if (frequency < currentFilter->minHz + currentFilter->fadeRangeHz) {
             weight = (frequency - currentFilter->minHz) / currentFilter->fadeRangeHz;
         }
 
-        biquadFilterUpdate(
-            template, frequency, currentFilter->looptimeUs, currentFilter->q, FILTER_NOTCH, weight);
+        updateAutoNotch(
+            template, frequency, currentFilter->q, weight, currentFilter->looptimeUs);
 
         for (int axis = 1; axis < XYZ_AXIS_COUNT; axis++) {
-            biquadFilter_t *clone = &currentFilter->notch[axis][currentMotor][currentHarmonic];
-            clone->b0 = template->b0;
-            clone->b1 = template->b1;
-            clone->b2 = template->b2;
-            clone->a1 = template->a1;
-            clone->a2 = template->a2;
-            clone->weight = template->weight;
-        }
+            autoNotch_t *clone = &currentFilter->notch[axis][currentMotor][currentHarmonic];
+            clone->notchFilter.b0 = template->notchFilter.b0;
+            clone->notchFilter.b1 = template->notchFilter.b1;
+            clone->notchFilter.b2 = template->notchFilter.b2;
+            clone->notchFilter.a1 = template->notchFilter.a1;
+            clone->notchFilter.a2 = template->notchFilter.a2;
+
+            clone->preVarianceBandpass.b0 = template->preVarianceBandpass.b0;
+            //clone->preVarianceBandpass.b1 = template->preVarianceBandpass.b1; // always 0
+            clone->preVarianceBandpass.b2 = template->preVarianceBandpass.b2;
+            clone->preVarianceBandpass.b0 = template->preVarianceBandpass.a1;
+            clone->preVarianceBandpass.b2 = template->preVarianceBandpass.a2;
+            updateWeight(clone, weight);
+            }
 
         if (++currentHarmonic == currentFilter->harmonics) {
             currentHarmonic = 0;

--- a/src/main/flight/rpm_filter.h
+++ b/src/main/flight/rpm_filter.h
@@ -32,6 +32,8 @@ typedef struct rpmFilterConfig_s
 
     uint16_t rpm_filter_lpf_hz;        // the cutoff of the lpf on reported motor rpm
 
+    uint8_t noise_limit;
+
 } rpmFilterConfig_t;
 
 PG_DECLARE(rpmFilterConfig_t, rpmFilterConfig);

--- a/src/main/osd/osd.c
+++ b/src/main/osd/osd.c
@@ -386,7 +386,7 @@ void pgResetFn_osdConfig(osdConfig_t *osdConfig)
 
     osdConfig->stat_show_cell_value = false;
     osdConfig->framerate_hz = OSD_FRAMERATE_DEFAULT_HZ;
-    osdConfig->cms_background_type = DISPLAY_BACKGROUND_TRANSPARENT;
+    osdConfig->cms_background_type = DISPLAY_BACKGROUND_BLACK;
 }
 
 void pgResetFn_osdElementConfig(osdElementConfig_t *osdElementConfig)
@@ -739,7 +739,7 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
         osdDisplayStatisticLabel(displayRow, osdConfig()->stat_show_cell_value ? "END AVG CELL" : "END BATTERY", buff);
         return true;
 
-    case OSD_STAT_BATTERY: 
+    case OSD_STAT_BATTERY:
         {
             const uint16_t statsVoltage = getStatsVoltage();
             osdPrintFloat(buff, SYM_NONE, statsVoltage / 100.0f, "", 2, true, SYM_VOLT);
@@ -747,7 +747,7 @@ static bool osdDisplayStat(int statistic, uint8_t displayRow)
             return true;
         }
         break;
-        
+
     case OSD_STAT_MIN_RSSI:
         itoa(stats.min_rssi, buff, 10);
         strcat(buff, "%");

--- a/src/main/pg/bus_i2c.c
+++ b/src/main/pg/bus_i2c.c
@@ -75,6 +75,6 @@ void pgResetFn_i2cConfig(i2cConfig_t *i2cConfig)
     }
 }
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(i2cConfig_t, I2CDEV_COUNT, i2cConfig, PG_I2C_CONFIG, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(i2cConfig_t, I2CDEV_COUNT, i2cConfig, PG_I2C_CONFIG, 0);
 
 #endif // defined(USE_I2C) && !defined(USE_SOFT_I2C)

--- a/src/main/pg/bus_quadspi.c
+++ b/src/main/pg/bus_quadspi.c
@@ -65,7 +65,7 @@ const quadSpiDefaultConfig_t quadSpiDefaultConfig[] = {
 #endif
 };
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(quadSpiConfig_t, QUADSPIDEV_COUNT, quadSpiConfig, PG_QUADSPI_CONFIG, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(quadSpiConfig_t, QUADSPIDEV_COUNT, quadSpiConfig, PG_QUADSPI_CONFIG, 0);
 
 void pgResetFn_quadSpiConfig(quadSpiConfig_t *quadSpiConfig)
 {

--- a/src/main/pg/bus_spi.c
+++ b/src/main/pg/bus_spi.c
@@ -61,7 +61,7 @@ const spiDefaultConfig_t spiDefaultConfig[] = {
 #endif
 };
 
-PG_REGISTER_ARRAY_WITH_RESET_FN(spiPinConfig_t, SPIDEV_COUNT, spiPinConfig, PG_SPI_PIN_CONFIG, 1);
+PG_REGISTER_ARRAY_WITH_RESET_FN(spiPinConfig_t, SPIDEV_COUNT, spiPinConfig, PG_SPI_PIN_CONFIG, 0);
 
 void pgResetFn_spiPinConfig(spiPinConfig_t *spiPinConfig)
 {

--- a/src/main/pg/dyn_notch.c
+++ b/src/main/pg/dyn_notch.c
@@ -34,7 +34,7 @@ PG_RESET_TEMPLATE(dynNotchConfig_t, dynNotchConfig,
     .dyn_notch_max_hz = 600,
     .dyn_notch_q = 300,
     .dyn_notch_count = 3,
-    .noise_limit = 50,
+    .noise_limit = 20,
 );
 
 #endif // USE_DYN_NOTCH_FILTER

--- a/src/main/pg/dyn_notch.c
+++ b/src/main/pg/dyn_notch.c
@@ -33,7 +33,8 @@ PG_RESET_TEMPLATE(dynNotchConfig_t, dynNotchConfig,
     .dyn_notch_min_hz = 150,
     .dyn_notch_max_hz = 600,
     .dyn_notch_q = 300,
-    .dyn_notch_count = 3
+    .dyn_notch_count = 3,
+    .noise_limit = 50,
 );
 
 #endif // USE_DYN_NOTCH_FILTER

--- a/src/main/pg/dyn_notch.h
+++ b/src/main/pg/dyn_notch.h
@@ -30,6 +30,7 @@ typedef struct dynNotchConfig_s
     uint16_t dyn_notch_max_hz;
     uint16_t dyn_notch_q;
     uint8_t  dyn_notch_count;
+    uint8_t  noise_limit;
 
 } dynNotchConfig_t;
 


### PR DESCRIPTION
* Cherry-Pick @Quick-Flash code from #758

`Autonotch is code that automatically decides how much the notch filter is crossfaded with its input signal. By determining the amount of noise at the notch frequency we can set up a limit. As noise approaches that limit the notch filter is used more, as noise is low it isn't used. This will automatically phase out rpm and dynamic notch filters that to do not have much use. This should reduce delay and turn off the effect of notch filters that are doing nothing.`

`To test you have new rpm_noise_limit, and dyn_notch_noise_limit, both of which determine how much noise can pass through before the notch filter is fully turned on. A higher value allows more noise to pass through before the notch filter takes full effect, smaller values happen sooner.`
