### PR TITLE
Adding ICM20689 Gyro to MATEKF411RX/CRAZYBEEF4 target

### DIFF
--- a/src/main/target/MATEKF411RX/target.h
+++ b/src/main/target/MATEKF411RX/target.h
@@ -49,7 +49,9 @@
 #define SPI1_MOSI_PIN           PA7
 
 #define MPU6000_CS_PIN          PA4
+#define ICM20689_CS_PIN         MPU6000_CS_PIN
 #define MPU6000_SPI_INSTANCE    SPI1
+#define ICM20689_SPI_INSTANCE   MPU6000_SPI_INSTANCE
 
 #define USE_EXTI
 #define MPU_INT_EXTI            PA1
@@ -57,18 +59,24 @@
 
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM20689
 
 #if defined(CRAZYBEEF4FS) || defined(CRAZYBEEF4FR) || defined(CRAZYBEEF4DX)
 #define GYRO_MPU6000_ALIGN      CW90_DEG
+#define GYRO_ICM20689_ALIGN      CW90_DEG
 #else
 #define GYRO_MPU6000_ALIGN      CW180_DEG
+#define GYRO_ICM20689_ALIGN      CW180_DEG
 #endif
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM20689
 #if defined(CRAZYBEEF4FS) || defined(CRAZYBEEF4FR) || defined(CRAZYBEEF4DX)
 #define ACC_MPU6000_ALIGN       CW90_DEG
+#define ACC_ICM20689_ALIGN       CW90_DEG
 #else
 #define ACC_MPU6000_ALIGN       CW180_DEG
+#define ACC_ICM20689_ALIGN       CW180_DEG
 #endif
 // *************** SPI2 OSD *****************************
 #define USE_SPI_DEVICE_2

--- a/src/main/target/MATEKF411RX/target.mk
+++ b/src/main/target/MATEKF411RX/target.mk
@@ -4,6 +4,7 @@ FEATURES        += VCP SDCARD
 
 TARGET_SRC = \
             drivers/accgyro/accgyro_spi_mpu6000.c \
+						drivers/accgyro/accgyro_spi_icm20689.c \
             drivers/max7456.c \
             drivers/rx/rx_cc2500.c \
 						rx/cc2500_common.c \


### PR DESCRIPTION
New updates to the Happy Model Mobula6 V2 requires ICM20689 gyro drivers.

Tested by pilot requesting upgrade with verification that the addition of drivers does allow for arming, flight, and working gyros on the Mob6V2. (see issue https://github.com/emuflight/EmuFlight/issues/794)

Tested by myself on older Mobula to make sure target still works with mpu6000 gyros on the Mob6 V1 models. 

Merge-able if approved. 

(new issue and further work will need to be done to look into op's OpenVTX issues on the Mob6V2)