### PR TITLE
Improve peak estimation

### DIFF
--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -349,10 +349,8 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
 
                     // Estimate true peak position
                     const float denom = y0 + y1 + y2;
-                    if (denom != 0.0f) {
-                        float upper_ratio = y2 / denom;
-                        float lower_ratio = y0 / denom;
-                        meanBin += upper_ratio - lower_ratio;
+                    if (denom != 0.0f) { 
+                        meanBin += (y2 - y0) / denom;
                     }
 
                     // Convert bin to frequency: freq = bin * binResoultion (bin 0 is 0Hz)

--- a/src/main/flight/dyn_notch_filter.c
+++ b/src/main/flight/dyn_notch_filter.c
@@ -356,8 +356,8 @@ static FAST_CODE_NOINLINE void dynNotchProcess(void)
                     // Convert bin to frequency: freq = bin * binResoultion (bin 0 is 0Hz)
                     const float centerFreq = constrainf(meanBin * sdftResolutionHz, dynNotch.minHz, dynNotch.maxHz);
 
-                    // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 10x faster 
-                    const float cutoffMult = constrainf(peaks[p].value / sdftNoiseThreshold, 1.0f, 10.0f);
+                    // PT1 style smoothing moves notch center freqs rapidly towards big peaks and slowly away, up to 5x faster 
+                    const float cutoffMult = constrainf((peaks[p].value * 0.5) / sdftNoiseThreshold, 1.0f, 5.0f);
                     const float gain = pt1FilterGain(DYN_NOTCH_SMOOTH_HZ * cutoffMult, pt1LooptimeS); // dynamic PT1 k value
 
                     // Finally update notch center frequency p on current axis


### PR DESCRIPTION
Fix an issue where the old estimation can cause some very off very bad numbers. When the old denom would be near 0 it would create wildly inaccurate peak estimations, this fixes that.

Thank you for contributing to EmuFlight!
