### PR TITLE
yaw_spin_recovery AUTO

### DIFF
--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -54,6 +54,7 @@
 
 #include "sensors/battery.h"
 #include "sensors/acceleration.h"
+#include "sensors/gyro.h"
 
 enum {
     ROLL_FLAG = 1 << ROLL,
@@ -828,6 +829,10 @@ void initRcProcessing(void) {
         interpolationChannels |= THROTTLE_FLAG;
         break;
     }
+#ifdef USE_YAW_SPIN_RECOVERY
+    const int maxYawRate = (int)applyRates(FD_YAW, 1.0f, 1.0f);
+    initYawSpinRecovery(maxYawRate);
+#endif
 }
 
 bool rcSmoothingIsEnabled(void) {

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -381,6 +381,10 @@ static const char *const lookupTableMixerImplType[] = {
     "LEGACY", "SMOOTH", "2PASS"
 };
 
+static const char * const lookupTableOffOnAuto[] = {
+    "OFF", "ON", "AUTO"
+};
+
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
@@ -469,6 +473,7 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOsdLogoOnArming),
 #endif
     LOOKUP_TABLE_ENTRY(lookupTableMixerImplType),
+    LOOKUP_TABLE_ENTRY(lookupTableOffOnAuto),
 };
 
 #undef LOOKUP_TABLE_ENTRY
@@ -529,8 +534,8 @@ const clivalue_t valueTable[] = {
     { "gyro_overflow_detect",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_GYRO_OVERFLOW_CHECK }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, checkOverflow) },
 #endif
 #ifdef USE_YAW_SPIN_RECOVERY
-    { "yaw_spin_recovery",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_recovery) },
-    { "yaw_spin_threshold",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { 500,  1950 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_threshold) },
+    { "yaw_spin_recovery",          VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_recovery) },
+    { "yaw_spin_threshold",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { YAW_SPIN_RECOVERY_THRESHOLD_MIN,  YAW_SPIN_RECOVERY_THRESHOLD_MAX }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, yaw_spin_threshold) },
 #endif
 
 #if defined(GYRO_USES_SPI) && defined(USE_32K_CAPABLE_GYRO) || defined(USE_GYRO_IMUF9001)

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -140,6 +140,10 @@ static const char * const lookupTableOffOn[] = {
     "OFF", "ON"
 };
 
+static const char * const lookupTableOffOnAuto[] = {
+    "OFF", "ON", "AUTO"
+};
+
 static const char * const lookupTableCrashRecovery[] = {
     "OFF", "ON", "BEEP"
 };
@@ -381,14 +385,11 @@ static const char *const lookupTableMixerImplType[] = {
     "LEGACY", "SMOOTH", "2PASS"
 };
 
-static const char * const lookupTableOffOnAuto[] = {
-    "OFF", "ON", "AUTO"
-};
-
 #define LOOKUP_TABLE_ENTRY(name) { name, ARRAYLEN(name) }
 
 const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOffOn),
+    LOOKUP_TABLE_ENTRY(lookupTableOffOnAuto),
     LOOKUP_TABLE_ENTRY(lookupTableUnit),
     LOOKUP_TABLE_ENTRY(lookupTableCrsfformat),
     LOOKUP_TABLE_ENTRY(lookupTableAlignment),
@@ -473,7 +474,6 @@ const lookupTableEntry_t lookupTables[] = {
     LOOKUP_TABLE_ENTRY(lookupTableOsdLogoOnArming),
 #endif
     LOOKUP_TABLE_ENTRY(lookupTableMixerImplType),
-    LOOKUP_TABLE_ENTRY(lookupTableOffOnAuto),
 };
 
 #undef LOOKUP_TABLE_ENTRY

--- a/src/main/interface/settings.h
+++ b/src/main/interface/settings.h
@@ -27,6 +27,7 @@
 
 typedef enum {
     TABLE_OFF_ON = 0,
+    TABLE_OFF_ON_AUTO,
     TABLE_UNIT,
     TABLE_CRSFFORMAT,
     TABLE_ALIGNMENT,

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -117,6 +117,8 @@ static FAST_RAM_ZERO_INIT uint8_t overflowAxisMask;
 #endif
 
 #ifdef USE_YAW_SPIN_RECOVERY
+static FAST_RAM_ZERO_INIT bool yawSpinRecoveryEnabled;
+static FAST_RAM_ZERO_INIT int yawSpinRecoveryThreshold;
 static FAST_RAM_ZERO_INIT bool yawSpinDetected;
 #endif
 
@@ -245,7 +247,7 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
                   .gyro_soft_notch_hz_2 = 0,
                   .gyro_soft_notch_cutoff_2 = 0,
                   .checkOverflow = GYRO_OVERFLOW_CHECK_ALL_AXES,
-                  .yaw_spin_recovery = true,
+                  .yaw_spin_recovery = YAW_SPIN_RECOVERY_AUTO,
                   .yaw_spin_threshold = 1950,
                   .dyn_notch_q = 400,
                   .dyn_notch_count = 3, // default of 3 is similar to the matrix filter.
@@ -300,7 +302,7 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
                   .imuf_yaw_q = 6000,
                   .imuf_w = 32,
                   .gyro_offset_yaw = 0,
-                  .yaw_spin_recovery = true,
+                  .yaw_spin_recovery = YAW_SPIN_RECOVERY_AUTO,
                   .yaw_spin_threshold = 1950,
                   .dyn_notch_q = 350,
                   .dyn_notch_count = 3, // default of 3 is similar to the matrix filter.
@@ -1058,7 +1060,7 @@ static FAST_CODE void checkForOverflow(gyroSensor_t *gyroSensor, timeUs_t curren
 
 #ifdef USE_YAW_SPIN_RECOVERY
 static FAST_CODE_NOINLINE void handleYawSpin(gyroSensor_t *gyroSensor, timeUs_t currentTimeUs) {
-    const float yawSpinResetRate = gyroConfig()->yaw_spin_threshold - 100.0f;
+    const float yawSpinResetRate = yawSpinRecoveryThreshold - 100.0f;
     if (fabsf(gyroSensor->gyroDev.gyroADCf[Z]) < yawSpinResetRate) {
         // testing whether 20ms of consecutive OK gyro yaw values is enough
         if (cmpTimeUs(currentTimeUs, gyroSensor->yawSpinTimeUs) > 20000) {
@@ -1083,7 +1085,7 @@ static FAST_CODE void checkForYawSpin(gyroSensor_t *gyroSensor, timeUs_t current
     } else {
 #ifndef SIMULATOR_BUILD
         // check for spin on yaw axis only
-        if (fabsf(gyroSensor->gyroDev.gyroADCf[Z]) > gyroConfig()->yaw_spin_threshold) {
+        if (fabsf(gyroSensor->gyroDev.gyroADCf[Z]) > yawSpinRecoveryThreshold) {
             gyroSensor->yawSpinDetected = true;
             gyroSensor->yawSpinTimeUs = currentTimeUs;
         }
@@ -1183,7 +1185,7 @@ static FAST_CODE_NOINLINE void gyroUpdateSensor(gyroSensor_t* gyroSensor, timeUs
     }
 #endif
 #ifdef USE_YAW_SPIN_RECOVERY
-    if (gyroConfig()->yaw_spin_recovery) {
+    if (yawSpinRecoveryEnabled) {
         checkForYawSpin(gyroSensor, currentTimeUs);
     }
 #endif
@@ -1385,3 +1387,30 @@ uint8_t gyroReadRegister(uint8_t whichSensor, uint8_t reg) {
     return mpuGyroReadRegister(gyroSensorBusByDevice(whichSensor), reg);
 }
 #endif // USE_GYRO_REGISTER_DUMP
+
+#ifdef USE_YAW_SPIN_RECOVERY
+void initYawSpinRecovery(int maxYawRate)
+{
+    bool enabledFlag;
+    int threshold;
+
+    switch (gyroConfig()->yaw_spin_recovery) {
+    case YAW_SPIN_RECOVERY_OFF:
+        enabledFlag = false;
+        threshold = YAW_SPIN_RECOVERY_THRESHOLD_MAX;
+        break;
+    case YAW_SPIN_RECOVERY_ON:
+        enabledFlag = true;
+        threshold = gyroConfig()->yaw_spin_threshold;
+        break;
+    case YAW_SPIN_RECOVERY_AUTO:
+        enabledFlag = true;
+        const int overshootAllowance = MAX(maxYawRate / 4, 200); // Allow a 25% or minimum 200dps overshoot tolerance
+        threshold = constrain(maxYawRate + overshootAllowance, YAW_SPIN_RECOVERY_THRESHOLD_MIN, YAW_SPIN_RECOVERY_THRESHOLD_MAX);
+        break;
+    }
+
+    yawSpinRecoveryEnabled = enabledFlag;
+    yawSpinRecoveryThreshold = threshold;
+}
+#endif

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -32,6 +32,11 @@
 #define MAX_SMITH_SAMPLES 12 * 32
 #endif // USE_SMITH_PREDICTOR
 
+#ifdef USE_YAW_SPIN_RECOVERY
+#define YAW_SPIN_RECOVERY_THRESHOLD_MIN 500
+#define YAW_SPIN_RECOVERY_THRESHOLD_MAX 1950
+#endif
+
 extern float vGyroStdDevModulus;
 typedef enum {
     GYRO_NONE = 0,
@@ -65,6 +70,12 @@ typedef enum {
     GYRO_OVERFLOW_CHECK_YAW,
     GYRO_OVERFLOW_CHECK_ALL_AXES
 } gyroOverflowCheck_e;
+
+typedef enum {
+    YAW_SPIN_RECOVERY_OFF,
+    YAW_SPIN_RECOVERY_ON,
+    YAW_SPIN_RECOVERY_AUTO
+} yawSpinRecoveryMode_e;
 
 #define GYRO_CONFIG_USE_GYRO_1      0
 #define GYRO_CONFIG_USE_GYRO_2      1
@@ -186,3 +197,6 @@ uint16_t gyroAbsRateDps(int axis);
 uint8_t gyroReadRegister(uint8_t whichSensor, uint8_t reg);
 float applySmithPredictor(smithPredictor_t *smithPredictor, float gyroFiltered);
 bool isDynamicFilterActive(void);
+#ifdef USE_YAW_SPIN_RECOVERY
+void initYawSpinRecovery(int maxYawRate);
+#endif


### PR DESCRIPTION
* port [BF's yaw_spin_recovery AUTO](https://github.com/betaflight/betaflight/pull/9455) 
* `Allow a 25% or minimum 200dps overshoot tolerance` of rc yaw rate 
* default `yaw_spin_recovery = AUTO`
* needs further testing
* flew 1 quad and test-hovered 2 others as well

Co-authored-by: nerdCopter <56646290+nerdCopter@users.noreply.github.com>
