### PR TITLE
revert rc-smoothing to interpolation (manual 21 RPTY)

### DIFF
--- a/src/main/pg/rx.c
+++ b/src/main/pg/rx.c
@@ -61,7 +61,7 @@ void pgResetFn_rxConfig(rxConfig_t *rxConfig) {
                    .cinematicYaw = 0,
                    .airModeActivateThreshold = 32,
                    .max_aux_channel = DEFAULT_AUX_CHANNEL_COUNT,
-                   .rc_smoothing_type = RC_SMOOTHING_TYPE_FILTER,
+                   .rc_smoothing_type = RC_SMOOTHING_TYPE_INTERPOLATION,
                    .rc_smoothing_input_cutoff = 50,      // automatically calculate the cutoff by default
                    .rc_smoothing_debug_axis = ROLL,     // default to debug logging for the roll axis
                    .rc_smoothing_input_type = RC_SMOOTHING_INPUT_PT2,


### PR DESCRIPTION
* default RC smoothing interpolation 21 RPTY
* because pilots dont tune it, and most submitted logs have stepping feeding into PIDS.
![image](https://user-images.githubusercontent.com/56646290/175979310-390adb71-8287-4a62-bbf5-33b28588e95c.png)

