### PR TITLE
1.0.0 memory mgmt for test-builds - undef mavlink, ppm, servos

### DIFF
--- a/src/main/target/common_pre.h
+++ b/src/main/target/common_pre.h
@@ -431,3 +431,8 @@ extern uint8_t _dmaram_end__;
 #define USE_EMFAT_ICON
 #define USE_GPS_PLUS_CODES
 #endif
+
+// EMUFLIGHT memory management
+#undef USE_TELEMETRY_MAVLINK
+#undef USE_PPM
+#undef USE_SERVOS


### PR DESCRIPTION
* this is purely for test-build purposes.
* the idea here is to make test-branches from other PR's and include this so that they are small enough for flash-memory

