### PR TITLE
Revert "default vtx_low_power_disarm = ON"

### DIFF
--- a/src/main/drivers/vtx_common.h
+++ b/src/main/drivers/vtx_common.h
@@ -40,7 +40,7 @@
 #define VTX_SETTINGS_DEFAULT_CHANNEL            1
 #define VTX_SETTINGS_DEFAULT_FREQ               5740
 #define VTX_SETTINGS_DEFAULT_PITMODE_FREQ       0
-#define VTX_SETTINGS_DEFAULT_LOW_POWER_DISARM   1
+#define VTX_SETTINGS_DEFAULT_LOW_POWER_DISARM   0
 #define VTX_SETTINGS_DEFAULT_AKK_HACK           0
 
 #define VTX_SETTINGS_MAX_FREQUENCY_MHZ 5999          //max freq (in MHz) for 'vtx_freq' setting


### PR DESCRIPTION
Reverts emuflight/EmuFlight#829
* although convenient, may interrupt pitmode-on-switch or power-on-switch