### PR TITLE
set CRSF/ELRS SNR to uplink_SNR rather than downlink_SNR

### DIFF
--- a/src/main/rx/crsf.c
+++ b/src/main/rx/crsf.c
@@ -133,7 +133,7 @@ static void handleCrsfLinkStatisticsFrame(const crsfLinkStatistics_t* statsPtr, 
     const crsfLinkStatistics_t stats = *statsPtr;
     CRSFsetLQ(stats.uplink_Link_quality);
     CRSFsetRFMode(stats.rf_Mode);
-    CRSFsetSnR(stats.downlink_SNR);
+    CRSFsetSnR(stats.uplink_SNR);
     CRSFsetTXPower(stats.uplink_TX_Power);
     if (stats.uplink_RSSI_1 == 0) {
         CRSFsetRSSI(stats.uplink_RSSI_2);


### PR DESCRIPTION
* ELRS uses uplink_SNR (working)
* Tested on CRSF (working)

`
2022-07-23 [12:24 PM CDT] CapnBry: downlink_SNR is the wrong field to use. That is the SNR going from the receiver to the transmitter. Note how all your other fields use the uplink versions because you want to display TX to RX uplink info.
uplink_TX_Power we fill but only in wide switch mode or Fullres modes in 3.0, since those are the only modes that have space to send them (edited)
`
