### PR TITLE
Fix the correction yaw gives in 2pass

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -1003,14 +1003,11 @@ static void twoPassMix(float *motorMix, const float *yawMix, const float *rollPi
     float maxMotorYawMix = -1000.0f;
 
     // filling up motorMix with throttle, and yaw
+    // clipping handling
+    float yawOffset = mixerLaziness ? (ABS(yawMix[i]) * SCALE_UNITARY_RANGE(throttleMotor, 1, -1))
+                                    : SCALE_UNITARY_RANGE(throttleMotor, -yawMixMin, -yawMixMax);
     for (int i = 0; i < motorCount; i++) {
-        motorMix[i] = throttleMotor; // motorMix have to contain output-proportional values
-
-        // clipping handling
-        float yawOffset = mixerLaziness ? (ABS(yawMix[i]) * SCALE_UNITARY_RANGE(throttleMotor, 1, -1))
-                                        : SCALE_UNITARY_RANGE(throttleMotor, -yawMixMin, -yawMixMax);
-
-        motorMix[i] += (yawMix[i] + yawOffset) * controllerMixNormFactor; // yaw is an output-proportional value (RPM-proportional, actually)
+        motorMix[i] = throttleMotor + (yawMix[i] + yawOffset) * controllerMixNormFactor; // yaw is an output-proportional value (RPM-proportional, actually)
         postYawThrottle += motorMix[i];
 
         if (motorMix[i] > maxMotorYawMix) {
@@ -1025,18 +1022,19 @@ static void twoPassMix(float *motorMix, const float *yawMix, const float *rollPi
     // deal with yaw throttle correction values that would cause motor outputs that are greater or less than 1
     yawThrottleCorrection = constrainf(yawThrottleCorrection, maxMotorYawMix - 1.0f, minMotorYawMix);
 
-    // correct for the extra thrust yaw adds, then fill up motorMix with pitch and roll
-    for (int i = 0; i < motorCount; i++) {
+    throttlePostYaw = postYawThrottle - yawThrottleCorrection;
+    thrustPostYaw = motorToThrust(throttlePostYaw, true);
 
+    // correct for the extra thrust yaw adds, then fill up motorMix with pitch and roll
+    // clipping handling
+    float rollPitchOffset = mixerLaziness ? (ABS(rollPitchMix[i]) * SCALE_UNITARY_RANGE(thrustPostYaw , 1, -1))
+                                          : SCALE_UNITARY_RANGE(thrustPostYaw , -rollPitchMixMin, -rollPitchMixMax);
+    for (int i = 0; i < motorCount; i++) {
         if (currentPidProfile->mixer_yaw_throttle_comp) {  //!==0
             // prefer calculating all of the above and maybe not use it, than multiple if/then statements to save from calculating.
             motorMix[i] = motorMix[i] - yawThrottleCorrection;
         };
         float motorMixThrust = motorToThrust(motorMix[i], true); // convert into thrust value
-
-        // clipping handling
-        float rollPitchOffset = mixerLaziness ? (ABS(rollPitchMix[i]) * SCALE_UNITARY_RANGE(motorMixThrust, 1, -1))
-                                              : SCALE_UNITARY_RANGE(motorMixThrust, -rollPitchMixMin, -rollPitchMixMax);
 
         motorMixThrust += (rollPitchOffset + rollPitchMix[i]) * controllerMixNormFactor; // roll and pitch are thrust-proportional values
 


### PR DESCRIPTION
Previously yaw correction would change based on how much roll and pitch was mixed. When mixing an even amount of roll and yaw you would end up with the motors producing more roll than yaw. This problem only even shows up during yaw movements that involve pitch or roll.

example from simulated roll and yaw pidsum with current and new code.

```
pidsum inputs = 0.2roll, 0.0pitch, 0.2yaw

current code
m1 = -roll+pitch-yaw = 0.09 = -0.03roll+0.03pitch-0.3yaw
m2 = -roll-pitch+yaw = 0.33 = -0.11roll-0.11pitch+0.11yaw
m3 = +roll+pitch+yaw = 0.73 = +0.243roll+0.243pitch+0.243yaw
m4 = +roll-pitch-yaw = 0.49 = +0.163roll-0.163pitch-0.163yaw

roll = -0.03-0.11+0.243+0.163 = 0.266
pitch = 0.03-0.11+0.243-0.163 = 0.0
yaw = -0.03+0.11+0.243-0.163 = 0.16

new code
m1 = -roll+pitch-yaw = 0.01 = -0.003roll+0.003pitch-0.003yaw
m2 = -roll-pitch+yaw = 0.41 = -0.136roll-0.136pitch+0.136yaw
m3 = +roll+pitch+yaw = 0.81 = +0.27roll+0.27pitch+0.27yaw
m4 = +roll-pitch-yaw = 0.41 = +0.136roll-0.136pitch-0.136yaw

roll = -0.003-0.136+0.27+0.136 = 0.267
pitch = +0.003-0.136+0.27-0.136 = 0.0
yaw = -0.003+0.136+0.27-0.136 = 0.267
```

This code makes sure that yaw will not be shrunk during roll or pitch movements and should improve handling during quick yaw movements.