### PR TITLE
fix mixer.c for when undefining USE_BRUSHED_ESC_AUTODETECT

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -759,7 +759,12 @@ float applyThrottleLimit(float throttle) {
 
 void mixWithThrottleLegacy(float *motorMix, float *controllerMix, float controllerMixMin, float controllerMixMax) {
     float throttleThrust = currentPidProfile->linear_throttle ? throttle : motorToThrust(throttle, true);
+
+#ifdef USE_BRUSHED_ESC_AUTODETECT
     float normFactor = 1 / (controllerMixRange > 1.0f && hardwareMotorType != MOTOR_BRUSHED ? controllerMixRange : 1.0f);
+#else
+    float normFactor = 1 / (controllerMixRange > 1.0f ? controllerMixRange : 1.0f);
+#endif
 
     if (mixerImpl == MIXER_IMPL_LEGACY) {
         // legacy clipping handling


### PR DESCRIPTION
* fix mixer.c for when using `#undef USE_BRUSHED_ESC_AUTODETECT`
* please validate logic; this compiles but untested.
