### PR TITLE
multiple targets fix USE_LED_STRIP

### DIFF
--- a/src/main/target/AIRBOTF7HDV/target.h
+++ b/src/main/target/AIRBOTF7HDV/target.h
@@ -27,7 +27,7 @@
 
 #define ENABLE_DSHOT_DMAR       true
 
-#define USE_LEDS_TRIP
+#define USE_LED_STRIP
 
 #define LED0_PIN                PA3  //
 

--- a/src/main/target/AIRBOTF7HDV/target.h
+++ b/src/main/target/AIRBOTF7HDV/target.h
@@ -27,7 +27,7 @@
 
 #define ENABLE_DSHOT_DMAR       true
 
-#define USE_LEDSTRIP
+#define USE_LEDS_TRIP
 
 #define LED0_PIN                PA3  //
 

--- a/src/main/target/CLRACINGF7/target.h
+++ b/src/main/target/CLRACINGF7/target.h
@@ -24,7 +24,7 @@
 
 #define ENABLE_DSHOT_DMAR       true
 
-#define USE_LEDSTRIP
+#define USE_LED_STRIP
 #define LED0_PIN                PB3
 
 #define USE_BEEPER

--- a/src/main/target/MATEKF722HD/target.h
+++ b/src/main/target/MATEKF722HD/target.h
@@ -27,7 +27,7 @@
 
 #define ENABLE_DSHOT_DMAR       true
 
-#define USE_LEDSTRIP
+#define USE_LED_STRIP
 
 #define LED0_PIN                PA14  //Blue   SWCLK
 #define LED1_PIN                PA13  //Green  SWDIO

--- a/src/main/target/MATEKF722PX/target.h
+++ b/src/main/target/MATEKF722PX/target.h
@@ -27,7 +27,7 @@
 
 #define ENABLE_DSHOT_DMAR       true
 
-#define USE_LEDSTRIP
+#define USE_LED_STRIP
 
 #define LED0_PIN                PA14  //Blue   SWCLK
 #define LED1_PIN                PA13  //Green  SWDIO

--- a/src/main/target/RUSH_BLADE_F7_HD/target.h
+++ b/src/main/target/RUSH_BLADE_F7_HD/target.h
@@ -26,7 +26,7 @@
 
  	#define ENABLE_DSHOT_DMAR true
 
- 	#define USE_LEDSTRIP
+ 	#define USE_LED_STRIP
 
  	#define LED0_PIN PB10
 


### PR DESCRIPTION
* multiple targets fix `#define USE_LED_STRIP` (was wrongly `USE_LEDSTRIP`)
