### PR TITLE
Target Updates - MATEKF722PX - Fixed Black Box

### DIFF
--- a/src/main/target/MATEKF722PX/target.c
+++ b/src/main/target/MATEKF722PX/target.c
@@ -42,9 +42,9 @@ const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
     DEF_TIM(TIM4, CH1, PB6,   TIM_USE_ANY,   0, 0),   // SERVO
     DEF_TIM(TIM4, CH2, PB7,   TIM_USE_ANY,   0, 0),   // servo
 
-    DEF_TIM(TIM1, CH1, PA8,   TIM_USE_LED,   0, 2),   // TX2
-    DEF_TIM(TIM9, CH2, PA3,   TIM_USE_ANY,   0, 0),   // RX4
-    DEF_TIM(TIM5, CH3, PA2,   TIM_USE_ANY,   0, 0),   // TX4
-    DEF_TIM(TIM12, CH2, PB15, TIM_USE_ANY,   0, 0),   // TX4
+    DEF_TIM(TIM1, CH1, PA8,   TIM_USE_LED,   0, 2),   // led
+    DEF_TIM(TIM9, CH2, PA3,   TIM_USE_ANY,   0, 0),   // RX4, ppm
+    DEF_TIM(TIM5, CH3, PA2,   TIM_USE_ANY,   0, 0),   // TX2, pwm
+    DEF_TIM(TIM12, CH2, PB15, TIM_USE_ANY,   0, 0),   // camera
 
 };

--- a/src/main/target/MATEKF722PX/target.h
+++ b/src/main/target/MATEKF722PX/target.h
@@ -89,19 +89,20 @@
 #define USE_SPI_DEVICE_2
 #define SPI2_SCK_PIN            PB13
 #define SPI2_MISO_PIN           PB14
-#define SPI2_MOSI_PIN           PB15
+#define SPI2_MOSI_PIN           PC3
 
-#define USE_MAX7456
-#define MAX7456_SPI_INSTANCE    SPI2
-#define MAX7456_SPI_CS_PIN      PC15
-#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD)
-#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
+//#define USE_MAX7456
+//#define MAX7456_SPI_INSTANCE    SPI2
+//#define MAX7456_SPI_CS_PIN      PC15
+//#define MAX7456_SPI_CLK         (SPI_CLOCK_STANDARD)
+//#define MAX7456_RESTORE_CLK     (SPI_CLOCK_FAST)
 
 // *************** SPI3  BLACKBOX****************
 
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
+#define USE_FLASH_W25M
 #define FLASH_CS_PIN            PB12
 #define FLASH_SPI_INSTANCE      SPI2
 
@@ -135,13 +136,13 @@
 #define UART6_TX_PIN            PC6
 #define UART6_RX_PIN            PC7
 
-#define USE_UART10
-#define UART10_TX_PIN           PA2
+//#define USE_UART10
+//#define UART10_TX_PIN           PA2
 
 
 #define USE_SOFTSERIAL1
 
-#define SERIAL_PORT_COUNT       9
+#define SERIAL_PORT_COUNT       8
 
 #define DEFAULT_RX_FEATURE      FEATURE_RX_SERIAL
 #define SERIALRX_PROVIDER       SERIALRX_SBUS
@@ -162,7 +163,7 @@
 #define PINIO2_PIN              PB3
 #define USE_PINIOBOX
 
-#define DEFAULT_FEATURES        (FEATURE_OSD | FEATURE_TELEMETRY )
+#define DEFAULT_FEATURES        ( FEATURE_TELEMETRY )
 #define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define CURRENT_METER_SCALE_DEFAULT 179

--- a/src/main/target/MATEKF722PX/target.mk
+++ b/src/main/target/MATEKF722PX/target.mk
@@ -10,4 +10,3 @@ TARGET_SRC = \
             drivers/barometer/barometer_ms5611.c \
             drivers/compass/compass_hmc5883l.c \
             drivers/compass/compass_qmc5883l.c \
-            drivers/max7456.c


### PR DESCRIPTION
Tested fix for Black Box on MATEKF722PX target
![image](https://user-images.githubusercontent.com/85623381/187032969-6c1d99e3-f5ec-4cdb-8538-7197b8ad6dba.png)

As well as some minor upkeep to fix a definition for SPI2 pin and remove MAX7456 osd definitions as this FC uses FrskyOSD, which is not currently supported by Emuflight. 

Merge if approved. 
Closes #858 