### PR TITLE
github actions - remove fiam arm_sdk action and revert to Makefile's …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,20 @@ jobs:
       run: function curl () { command curl --connect-timeout 30 --retry 10 "$@" ; }
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
+    - name: Cache build toolchain
+      uses: actions/cache@v3
+      id: cache-toolchain
+      with:
+        path: tools
+        key: ${{ runner.os }}-${{ hashFiles('make/tools.mk') }}
+
+    - name: Download and install toolchain
+      if: steps.cache-toolchain.outputs.cache-hit != 'true'
+      run: make arm_sdk_install
 
     - name: Take the trash out
       run: |
@@ -49,12 +60,6 @@ jobs:
 
     - name: Setup Python
       uses: actions/setup-python@v2
-
-    - name: Setup Toolchain
-      uses: fiam/arm-none-eabi-gcc@v1
-      #uses: emuflight/arm-none-eabi-gcc@retry_timeout
-      with:
-        release: '9-2020-q2' # The arm-none-eabi-gcc release to use.
 
     # EmuFlight version
     - name: Get code version


### PR DESCRIPTION
* required fix for github actions to build `master` and any followup PR's
* removed github action `fiam/arm-none-eabi-gcc`
* setup cache for `tools` folder
* use Makefile's `make arm_sdk_install`
* tested/working

Co-authored-by: Mathias Rasmussen <mathiasvr@gmail.com>
