### PR TITLE
add ICM426xx support to FLYWOOF411_5IN1_AIO target

### DIFF
--- a/src/main/target/FLYWOOF411_5IN1_AIO/target.h
+++ b/src/main/target/FLYWOOF411_5IN1_AIO/target.h
@@ -61,6 +61,14 @@
 //#define USE_ACC_SPI_ICM20689
 //#define ACC_ICM20689_ALIGN CW180_DEG
 
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+
+#define ICM42688P_SPI_INSTANCE    SPI1
+#define ICM42688P_CS_PIN          PB2
+#define ACC_ICM426XX_ALIGN        CW90_DEG
+#define GYRO_ICM426XX_ALIGN       CW90_DEG
+
 // *************** Baro **************************
 #define USE_I2C
 

--- a/src/main/target/FLYWOOF411_5IN1_AIO/target.mk
+++ b/src/main/target/FLYWOOF411_5IN1_AIO/target.mk
@@ -6,6 +6,7 @@ TARGET_SRC = \
 						drivers/accgyro/accgyro_mpu.c \
 						drivers/accgyro/accgyro_spi_mpu6000.c \
 						drivers/accgyro/accgyro_spi_icm20689.c \
+						drivers/accgyro/accgyro_spi_icm426xx.c \
 						drivers/barometer/barometer_bmp085.c \
 						drivers/barometer/barometer_bmp280.c \
 						drivers/barometer/barometer_ms5611.c \


### PR DESCRIPTION
add ICM426xx support to FLYWOOF411_5IN1_AIO target

previously tested on a GOKU Versatile F411 ELRS 1S 5A AIO V2.0 w/ ELRS 2.4g , 25.5X25.5 board, gyro, accelerometer was working fine, LOS fly test also done.