### PR TITLE
[Target] DIAT_MAMBAF405_2022B - MPU6000, MPU6500, ICM42688P

### DIFF
--- a/src/main/target/DIAT_MAMBAF405_2022B/target.c
+++ b/src/main/target/DIAT_MAMBAF405_2022B/target.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of EmuFlight. It is derived from Betaflight.
+ *
+ * This is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include <stdint.h>
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM2, CH2, PB3,  TIM_USE_LED,                  0, 0 ), // LED_STRIP,
+    DEF_TIM(TIM4, CH3, PB8,  TIM_USE_ANY,                  0, 0),  // baro/mag // no dps310 in EmuFlight,
+    DEF_TIM(TIM11, CH1, PB9,  TIM_USE_ANY,                 0, 0),  // baro/mag // no dps310 in EmuFlight,
+    DEF_TIM(TIM1,  CH2, PA9,  TIM_USE_MOTOR,               0, 0 ), // M1
+    DEF_TIM(TIM1,  CH1, PA8,  TIM_USE_MOTOR,               0, 0 ), // M2
+    DEF_TIM(TIM8,  CH4, PC9,  TIM_USE_MOTOR,               0, 0 ), // M3
+    DEF_TIM(TIM8,  CH3, PC8,  TIM_USE_MOTOR,               0, 0 ), // M4
+    DEF_TIM(TIM3,  CH3, PB0,  TIM_USE_MOTOR,               0, 0 ), // M5
+    DEF_TIM(TIM3,  CH4, PB1,  TIM_USE_MOTOR,               0, 0 ), // M6
+};
+
+// notice - this file was programmatically generated and may be incomplete.

--- a/src/main/target/DIAT_MAMBAF405_2022B/target.h
+++ b/src/main/target/DIAT_MAMBAF405_2022B/target.h
@@ -1,0 +1,164 @@
+/*
+ * This file is part of EmuFlight. It is derived from Betaflight.
+ *
+ * This is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#pragma once
+
+#define TARGET_BOARD_IDENTIFIER "DIAT"
+#define USBD_PRODUCT_STRING "MAMBAF405_2022B"
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_M25P16
+#define USE_MAX7456
+#define USE_BARO
+#define USE_ADC
+#define USE_SPI_GYRO
+
+#define USE_VCP
+#define USE_FLASHFS
+#define USE_FLASH_M25P16  //testing
+#define USE_FLASH_W25M    //testing
+#define USE_FLASH_W25M512 //testing
+#define USE_FLASH_W25Q    //testing
+#define USE_OSD
+
+#define USE_LED
+#define LED0_PIN             PC15
+#define LED1_PIN             PC14
+#define LED_STRIP_PIN        PB3
+#define USE_BEEPER
+#define BEEPER_PIN           PC13
+#define BEEPER_INVERTED
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN         PA5
+#define SPI1_MISO_PIN        PA6
+#define SPI1_MOSI_PIN        PA7
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN         PB13
+#define SPI2_MISO_PIN        PB14
+#define SPI2_MOSI_PIN        PB15
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN         PC10
+#define SPI3_MISO_PIN        PC11
+#define SPI3_MOSI_PIN        PB5
+
+#define USE_EXTI
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define MPU_INT_EXTI               PC4
+
+#define ACC_MPU6000_ALIGN          CW270_DEG
+#define GYRO_MPU6000_ALIGN         CW270_DEG
+#define MPU6000_CS_PIN             PA4
+#define MPU6000_SPI_INSTANCE       SPI1
+
+#define ACC_MPU6500_ALIGN          CW270_DEG
+#define GYRO_MPU6500_ALIGN         CW270_DEG
+#define MPU6500_CS_PIN             PA4
+#define MPU6500_SPI_INSTANCE       SPI1
+
+#define ACC_ICM42688P_ALIGN        CW270_DEG
+#define GYRO_ICM42688P_ALIGN       CW270_DEG
+#define ICM42688P_CS_PIN           PA4
+#define ICM42688P_SPI_INSTANCE     SPI1
+
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE        (I2CDEV_1)
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define BARO_I2C_INSTANCE (I2CDEV_1)
+#define I2C1_SCL PB8
+#define I2C1_SDA PB9
+// notice - this file was programmatically generated and likely needs MAG/BARO manually added and/or verified.
+
+#define FLASH_CS_PIN         PA15
+#define FLASH_SPI_INSTANCE   SPI3
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#define MAX7456_SPI_CS_PIN   PB12
+#define MAX7456_SPI_INSTANCE SPI2
+
+#define USE_UART1
+#define USE_UART2
+#define USE_UART3
+#define USE_UART4
+#define USE_UART5
+#define USE_UART6
+#define UART1_TX_PIN         PB6
+#define UART2_TX_PIN         PA2
+#define UART3_TX_PIN         PB10
+#define UART4_TX_PIN         PA0
+#define UART5_TX_PIN         PC12
+#define UART6_TX_PIN         PC6
+#define UART1_RX_PIN         PB7
+#define UART2_RX_PIN         PA3
+#define UART3_RX_PIN         PB11
+#define UART4_RX_PIN         PA1
+#define UART5_RX_PIN         PD2
+#define UART6_RX_PIN         PC7
+#define INVERTER_PIN_UART1   PC0
+#define SERIAL_PORT_COUNT 7
+// notice - UART/USART were programmatically generated
+
+#define VBAT_ADC_PIN PC1
+#define CURRENT_METER_ADC_PIN PC3
+#define ADC3_DMA_STREAM DMA2_Stream0 // # ADC 3: DMA2 Stream 0 Channel 2
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE 183
+#define ADC_INSTANCE ADC3
+// notice - DMA conversion were programmatically generated and may be incomplete.
+
+#define ENABLE_DSHOT_DMAR true
+
+#define PINIO1_PIN           PC2
+#define PINIO2_PIN           PC5
+#define PINIO1_CONFIG 129
+#define PINIO2_CONFIG 129
+#define PINIO1_BOX 0
+#define PINIO2_BOX 40
+// notice - this file was programmatically generated and may not have accounted for any config instance of "#define TLM_INVERTED ON", etc.
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+// notice - masks were programmatically generated - please verify last port group for 0xffff or (BIT(2))
+
+#define DEFAULT_FEATURES       (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_AIRMODE | FEATURE_RX_SERIAL)
+#define DEFAULT_RX_FEATURE     FEATURE_RX_SERIAL
+// notice - incomplete; may need additional DEFAULT_FEATURES; e.g. FEATURE_SOFTSERIAL | FEATURE_RX_SPI
+
+#define USABLE_TIMER_CHANNEL_COUNT 9
+#define USED_TIMERS ( TIM_N(1)|TIM_N(2)|TIM_N(3)|TIM_N(4)|TIM_N(8)|TIM_N(11) )
+
+// notice - this file was programmatically generated and may be incomplete.

--- a/src/main/target/DIAT_MAMBAF405_2022B/target.mk
+++ b/src/main/target/DIAT_MAMBAF405_2022B/target.mk
@@ -1,0 +1,16 @@
+F405_TARGETS   += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+drivers/accgyro/accgyro_mpu.c \
+drivers/accgyro/accgyro_spi_mpu6000.c \
+drivers/accgyro/accgyro_mpu6500.c \
+drivers/accgyro/accgyro_spi_mpu6500.c \
+drivers/accgyro/accgyro_spi_icm426xx.c \
+drivers/light_led.h \
+drivers/light_ws2811strip.c \
+drivers/pinio.c \
+drivers/max7456.c \
+
+# notice - this file was programmatically generated and may be incomplete.
+#  eg: flash, compass, barometer, vtx6705, ledstrip, pinio, etc.


### PR DESCRIPTION
* `DIAT_MAMBAF405_2022B` MPU6000, ICM42688P
* tested as flying with blackbox
* no baro dps310 support

Closes #892