### PR TITLE
bugfix gating USE_GYRO_DATA_ANALYSE

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -315,12 +315,14 @@ void pidInitFilters(const pidProfile_t *pidProfile) {
             dtermABGapplyFn = (filterApplyFnPtr)alphaBetaGammaApply;
             ABGInit(&dtermABG[axis], pidProfile->dterm_ABG_alpha, pidProfile->dterm_ABG_boost, pidProfile->dterm_ABG_half_life, dT);
         }
-
+#ifdef USE_GYRO_DATA_ANALYSE
         if (isDynamicFilterActive()) {
             for (int axis2 = 0; axis2 < gyroConfig()->dyn_notch_count; axis2++) {
                 biquadFilterInit(&dtermNotch[axis][axis2], 400, targetPidLooptime, gyroConfig()->dyn_notch_q / 100.0f, FILTER_NOTCH);
             }
         }
+#endif
+
     }
 
 #if defined(USE_THROTTLE_BOOST)

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -198,7 +198,9 @@ bool gyroYawSpinDetected(void);
 uint16_t gyroAbsRateDps(int axis);
 uint8_t gyroReadRegister(uint8_t whichSensor, uint8_t reg);
 float applySmithPredictor(smithPredictor_t *smithPredictor, float gyroFiltered);
+#ifdef USE_GYRO_DATA_ANALYSE
 bool isDynamicFilterActive(void);
+#endif
 #ifdef USE_YAW_SPIN_RECOVERY
 void initYawSpinRecovery(int maxYawRate);
 #endif


### PR DESCRIPTION
compiler-fix for gating dynamic_filter when `#undef USE_GYRO_DATA_ANALYSE` is used.