### PR TITLE
MATEKF722SE - allow mpu6500 on gyro 1 and/or mpu6000 on gyro 2

### DIFF
--- a/src/main/target/MATEKF722SE/target.h
+++ b/src/main/target/MATEKF722SE/target.h
@@ -46,7 +46,7 @@
 #define USE_EXTI
 #define GYRO_1_EXTI_PIN         PC4
 #define GYRO_2_EXTI_PIN         PC3
-#define MPU_INT_EXTI
+#define MPU_INT_EXTI            PC4
 
 #define GYRO_1_CS_PIN           PB2
 #define GYRO_1_SPI_INSTANCE     SPI1
@@ -61,15 +61,19 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_MPU6500
 
+#define GYRO_1_ALIGN            CW180_DEG_FLIP
+#define ACC_1_ALIGN             CW180_DEG_FLIP
 #define GYRO_MPU6000_1_ALIGN    CW180_DEG_FLIP
 #define ACC_MPU6000_1_ALIGN     CW180_DEG_FLIP
-#define GYRO_1_ALIGN            GYRO_MPU6000_1_ALIGN
-#define ACC_1_ALIGN             ACC_MPU6000_1_ALIGN
+#define GYRO_MPU6500_1_ALIGN    CW180_DEG_FLIP
+#define ACC_MPU6500_1_ALIGN     CW180_DEG_FLIP
 
+#define GYRO_2_ALIGN            CW90_DEG
+#define ACC_2_ALIGN             CW90_DEG
 #define GYRO_MPU6500_2_ALIGN    CW90_DEG
 #define ACC_MPU6500_2_ALIGN     CW90_DEG
-#define GYRO_2_ALIGN            GYRO_MPU6500_2_ALIGN
-#define ACC_2_ALIGN             ACC_MPU6500_2_ALIGN
+#define GYRO_MPU6000_2_ALIGN    CW90_DEG
+#define ACC_MPU6000_2_ALIGN     CW90_DEG
 
 #define USE_MPU_DATA_READY_SIGNAL
 #define ENSURE_MPU_DATA_READY_IS_LOW

--- a/src/main/target/MATEKF722SE/target.mk
+++ b/src/main/target/MATEKF722SE/target.mk
@@ -3,6 +3,7 @@ FEATURES       += VCP ONBOARDFLASH SDCARD
 
 
 TARGET_SRC = \
+            drivers/accgyro/accgyro_mpu.c \
             drivers/accgyro/accgyro_spi_mpu6500.c \
             drivers/accgyro/accgyro_mpu6500.c \
             drivers/accgyro/accgyro_spi_mpu6000.c \


### PR DESCRIPTION
* fixes mpu6500 gyro not available for pilot (@kaji331) 
* https://github.com/emuflight/EmuFlight/issues/926#issuecomment-1672639664
