### PR TITLE
[target] add HAKRCF722D dual gyro (mpu6000, mpu6500, bmi270, icm42688p)

### DIFF
--- a/src/main/target/HAKRCF722D/HARC_HAKRCF722D/target.c
+++ b/src/main/target/HAKRCF722D/HARC_HAKRCF722D/target.c
@@ -1,0 +1,53 @@
+/*
+ * This file is part of EmuFlight. It is derived from Betaflight.
+ *
+ * This is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+// This resource file generated using https://github.com/nerdCopter/target-convert
+// Commit: 4cb7ad1 
+
+#include <stdint.h>
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM3, CH1, PB4, TIM_USE_MOTOR, 0, 0), // motor 1
+    DEF_TIM(TIM3, CH2, PB5, TIM_USE_MOTOR, 0, 0), // motor 2
+    DEF_TIM(TIM3, CH3, PB0, TIM_USE_MOTOR, 0, 0), // motor 3
+    DEF_TIM(TIM3, CH4, PB1, TIM_USE_MOTOR, 0, 0), // motor 4
+    DEF_TIM(TIM2, CH1, PA15, TIM_USE_MOTOR, 0, 0), // motor 5
+    DEF_TIM(TIM2, CH2, PB3, TIM_USE_MOTOR, 0, 0), // motor 6
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_MOTOR, 0, 0), // motor 7
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_MOTOR, 0, 0), // motor 8
+    DEF_TIM(TIM1, CH1, PA8, TIM_USE_LED, 0, 2), // led
+    DEF_TIM(TIM9, CH2, PA3, TIM_USE_PPM, 0, 0), // ppm; dma 0 assumed, please verify
+    DEF_TIM(TIM9, CH1, PA2, TIM_USE_ANY, 0, 0), // could not determine TIM_USE_xxxxx - please check; dma 0 assumed, please verify
+    DEF_TIM(TIM5, CH2, PA1, TIM_USE_ANY, 0, 0), // could not determine TIM_USE_xxxxx - please check
+    DEF_TIM(TIM5, CH1, PA0, TIM_USE_ANY, 0, 0), // could not determine TIM_USE_xxxxx - please check
+    DEF_TIM(TIM2, CH3, PB10, TIM_USE_ANY, 0, 0), // could not determine TIM_USE_xxxxx - please check
+};
+
+// notice - DEF_TIM was programmatically generated and may be wrong or incomplete.
+//          please reference associated unified-target.
+//          some timers may associate with multiple pins. e.g baro/flash
+
+// notice - this file was programmatically generated and may be incomplete.

--- a/src/main/target/HAKRCF722D/HARC_HAKRCF722D/target.h
+++ b/src/main/target/HAKRCF722D/HARC_HAKRCF722D/target.h
@@ -1,0 +1,186 @@
+/*
+ * This file is part of EmuFlight. It is derived from Betaflight.
+ *
+ * This is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+// This resource file generated using https://github.com/nerdCopter/target-convert
+// Commit: 4cb7ad1 
+
+#pragma once
+
+#define TARGET_MANUFACTURER_IDENTIFIER "HARC"
+#define USBD_PRODUCT_STRING "HAKRCF722D"
+
+#define FC_TARGET_MCU     STM32F7X2     // not used in EmuF
+#define TARGET_BOARD_IDENTIFIER "S7X2"  // generic ID
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define USE_ACCGYRO_BMI270
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+#define USE_BARO
+#define USE_ADC
+#define USE_SPI_GYRO
+#define USE_SPI_GYRO
+#define USE_BARO
+
+#define USE_VCP
+#define USE_FLASHFS
+#define USE_FLASH_M25P16    // 16MB Micron M25P16 and others (ref: https://github.com/betaflight/betaflight/blob/master/src/main/drivers/flash_m25p16.c)
+//#define USE_FLASH_W25M    // 1Gb NAND flash support
+//#define USE_FLASH_W25M512 // 16, 32, 64 or 128MB Winbond stacked die support
+//#define USE_FLASH_W25Q    // 512Kb (256Kb x 2 stacked) NOR flash support
+#define USE_OSD
+
+#define USE_LED
+#define LED0_PIN             PA14
+#define LED1_PIN             PA13
+#define LED_STRIP_PIN        PA8
+#define USE_BEEPER
+#define BEEPER_PIN           PC13
+#define BEEPER_INVERTED
+#define USE_USB_DETECT
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN         PA5
+#define SPI1_MISO_PIN        PA6
+#define SPI1_MOSI_PIN        PA7
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN         PB13
+#define SPI2_MISO_PIN        PB14
+#define SPI2_MOSI_PIN        PB15
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN         PC10
+#define SPI3_MISO_PIN        PC11
+#define SPI3_MOSI_PIN        PC12
+
+#define GYRO_1_ALIGN         CW90_DEG
+#define ACC_1_ALIGN          CW90_DEG
+#define GYRO_1_CS_PIN        PB2
+#define GYRO_1_EXTI_PIN      PC4
+#define GYRO_1_SPI_INSTANCE  SPI1
+#define MPU_INT_EXTI         PC4
+
+#define GYRO_2_ALIGN         CW90_DEG
+#define ACC_2_ALIGN          CW90_DEG
+#define GYRO_2_CS_PIN        PC15
+#define GYRO_2_EXTI_PIN      PC3
+#define GYRO_2_SPI_INSTANCE  SPI1
+
+#define USE_DUAL_GYRO
+
+#define USE_EXTI // notice - REQUIRED when USE_GYRO_EXTI
+#define USE_GYRO_EXTI
+
+#define USE_MPU_DATA_READY_SIGNAL
+
+//don't need to define if dual_gyro already defined
+// #define ACC_MPU6000_ALIGN         CW90_DEG
+// #define GYRO_MPU6000_ALIGN        CW90_DEG
+// #define MPU6000_CS_PIN            PB2
+// #define MPU6000_SPI_INSTANCE      SPI1
+// 
+// #define ACC_MPU6500_ALIGN         CW90_DEG
+// #define GYRO_MPU6500_ALIGN        CW90_DEG
+// #define MPU6500_CS_PIN            PB2
+// #define MPU6500_SPI_INSTANCE      SPI1
+// 
+// #define ACC_ICM42688P_ALIGN       CW90_DEG
+// #define GYRO_ICM42688P_ALIGN      CW90_DEG
+// #define ICM42688P_CS_PIN          PB2
+// #define ICM42688P_SPI_INSTANCE    SPI1
+// 
+// #define USE_SPI_GYRO
+// #define ACC_BMI270_ALIGN          CW90_DEG
+// #define GYRO_BMI270_ALIGN         CW90_DEG
+// #define BMI270_CS_PIN             PB2
+// #define BMI270_SPI_INSTANCE       SPI1
+
+#define USE_UART1
+#define UART1_TX_PIN         PA9
+#define UART1_RX_PIN         PA10
+#define USE_UART2
+#define UART2_TX_PIN         PA2
+#define UART2_RX_PIN         PA3
+#define USE_UART3
+#define UART3_TX_PIN         PB10
+#define UART3_RX_PIN         PB11
+#define USE_UART4
+#define UART4_TX_PIN         PA0
+#define UART4_RX_PIN         PA1
+#define USE_UART6
+#define UART6_TX_PIN         PC6
+#define UART6_RX_PIN         PC7
+#define SERIAL_PORT_COUNT 6
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE        (I2CDEV_1)
+#define MAG_I2C_INSTANCE  (I2CDEV_1)
+#define BARO_I2C_INSTANCE (I2CDEV_1)
+#define I2C1_SCL PB8
+#define I2C1_SDA PB9
+// notice - this file was programmatically generated and likely needs MAG/BARO manually added, finished, or verified.
+//           e.g. USE_BARO_xxxxxx, USE_BARO_SPI_xxxxxx, DEFAULT_BARO_SPI_xxxxxx, xxxxxx_CS_PIN, xxxxxx_SPI_INSTANCE
+
+#define FLASH_CS_PIN         PD2
+#define FLASH_SPI_INSTANCE SPI3
+#define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
+
+#define MAX7456_SPI_CS_PIN   PB12
+#define MAX7456_SPI_INSTANCE SPI2
+
+#define VBAT_ADC_PIN PC2
+#define CURRENT_METER_ADC_PIN PC1
+#define RSSI_ADC_PIN PC0
+#define ADC1_DMA_STREAM DMA2_Stream0 //# ADC 1: DMA2 Stream 0 Channel 0
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE 210
+#define ADC_INSTANCE ADC1
+
+#define PINIO1_PIN           PC8
+#define PINIO2_PIN           PC9
+#define PINIO1_BOX 40
+#define PINIO2_BOX 41
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+#define TARGET_IO_PORTD 0xffff
+// notice - masks were programmatically generated - please verify last port group for 0xffff or (BIT(2))
+
+#define DEFAULT_FEATURES       (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_AIRMODE | FEATURE_RX_SERIAL)
+#define DEFAULT_RX_FEATURE     FEATURE_RX_SERIAL
+
+#define USABLE_TIMER_CHANNEL_COUNT 14
+#define USED_TIMERS ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) | TIM_N(5) | TIM_N(9) )
+
+// notice - this file was programmatically generated and may be incomplete.
+

--- a/src/main/target/HAKRCF722D/HARC_HAKRCF722D/target.mk
+++ b/src/main/target/HAKRCF722D/HARC_HAKRCF722D/target.mk
@@ -1,0 +1,27 @@
+F7X2RE_TARGETS += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+drivers/accgyro/accgyro_mpu.c \
+drivers/accgyro/accgyro_spi_mpu6000.c \
+drivers/accgyro/accgyro_mpu6500.c \
+drivers/accgyro/accgyro_spi_mpu6500.c \
+drivers/accgyro/accgyro_spi_icm426xx.c \
+drivers/accgyro/accgyro_spi_bmi270.c \
+drivers/light_led.h \
+drivers/light_ws2811strip.c \
+drivers/pinio.c \
+drivers/max7456.c \
+drivers/barometer/barometer_bmp085.c \
+drivers/barometer/barometer_bmp280.c \
+drivers/barometer/barometer_fake.c \
+drivers/barometer/barometer_lps.c \
+drivers/barometer/barometer_ms5611.c \
+drivers/barometer/barometer_qmp6988.c \
+
+# notice - this file was programmatically generated and may be incomplete.
+# eg: flash, compass, barometer, vtx6705, ledstrip, pinio, etc.   especially mag/baro
+
+# This resource file generated using https://github.com/nerdCopter/target-convert
+# Commit: 4cb7ad1 
+


### PR DESCRIPTION
* Resolves #919
* needs testing [EmuFlight_0.4.2_HARC_HAKRCF722D_Build_d2c062a9d_Analog_needs_testing.hex.zip](https://github.com/emuflight/EmuFlight/files/13311019/EmuFlight_0.4.2_HARC_HAKRCF722D_Build_d2c062a9d_Analog_needs_testing.hex.zip)
  - [Yes/No/Untested] _**Is the Serial Count correct? (ports tab)**_
  - [Yes/No/Untested] hex Flash & subsequent USB connect
  - [Yes/No/Untested] Gyro 
  - [Yes/No/Untested] Accelerometer
  - [Yes/No/Untested] Motors
  - [Yes/No/Untested] Onboard ADC
  - [Yes/No/Untested] OSD (analog)
  - [Yes/No/Untested] Smart Audio controls
  - [Yes/No/Untested] Beeper/Alarm switch
  - [Yes/No/Untested] Barometer
  - [Yes/No/Untested] Blackbox  flash-chip/sdcard
  - [Yes/No/Untested] LED Strip
  - [Yes/No/Untested] GPS
  - [Yes/No/Untested] BlueTooth (if applicable)
