### PR TITLE
[gh actions] use date as tag for dev-unstable dev-master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
           echo "outputs.shortsha: ${{ needs.build.outputs.shortsha }}"
           echo "outputs.artfact: ${{ needs.build.outputs.artifact }}"
           echo "outputs.artfact: ${{ needs.build.outputs.version }}"
+          echo "NOW=$(date +'%Y%m%d.%H%M%S')" >> $GITHUB_ENV
         continue-on-error: true
 
       - name: download artifacts
@@ -181,7 +182,7 @@ jobs:
           repo: dev-unstable
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "hex-${{ github.run_number }}"
+          tag: "${{ env.NOW }}-hex"
           draft: true
           prerelease: true
           allowUpdates: true
@@ -213,7 +214,7 @@ jobs:
           repo: dev-master
           owner: emuflight
           token: ${{ secrets.NC_PAT_EMUF }}
-          tag: "hex-${{ github.run_number }}"
+          tag: "${{ env.NOW }}-hex"
           draft: true
           prerelease: true
           allowUpdates: true


### PR DESCRIPTION
use datestamp as tag for dev-unstable dev-master
![image](https://github.com/emuflight/EmuFlight/assets/56646290/d3e4e55f-012c-4072-9ce8-b264aae50b72)

not build number which loses sorting
![image](https://github.com/emuflight/EmuFlight/assets/56646290/116995b6-a8f4-4c00-b7d8-dcf79cd16450)


