### PR TITLE
Add ICM-426xx IMU to list of IMUs with overflow protection

### DIFF
--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -627,6 +627,8 @@ static bool gyroInitSensor(gyroSensor_t *gyroSensor) {
     case GYRO_MPU6000:
     case GYRO_MPU6500:
     case GYRO_MPU9250:
+    case GYRO_ICM42688P:
+    case GYRO_ICM42605:
         gyroSensor->gyroDev.gyroHasOverflowProtection = true;
         break;
     case GYRO_ICM20601:


### PR DESCRIPTION
reference:
- https://github.com/betaflight/betaflight/pull/13013
- https://github.com/betaflight/betaflight/pull/13194

Thank you TBolin and Betaflight 