### PR TITLE
fix compiler warning - comment out getGhstFrame (defined but not used)

### DIFF
--- a/src/main/telemetry/ghst.c
+++ b/src/main/telemetry/ghst.c
@@ -82,9 +82,12 @@ static void ghstInitializeFrame(sbuf_t *dst)
     sbufWriteU8(dst, GHST_ADDR_RX);
 }
 
+//compiler reports unused
+/*
 STATIC_UNIT_TESTED uint8_t *getGhstFrame(){
     return ghstFrame;
 }
+*/
 
 static void ghstFinalize(sbuf_t *dst)
 {


### PR DESCRIPTION
fixes: 
```C
./src/main/telemetry/ghst.c:85:17: warning: 'getGhstFrame' defined but not used [-Wunused-function]
   85 | STATIC_UNIT_TESTED uint8_t *getGhstFrame(){
```
