### PR TITLE
suppress (don't fix) compiler warnings for 3rd party libraries - STM32F4 and STM32F7

### DIFF
--- a/lib/main/STM32F4/Drivers/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c
+++ b/lib/main/STM32F4/Drivers/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c
@@ -423,6 +423,8 @@ void I2S_Init(SPI_TypeDef* SPIx, I2S_InitTypeDef* I2S_InitStruct)
     /* Get the PLLM value */
     pllm = (uint32_t)(RCC->PLLCFGR & RCC_PLLCFGR_PLLM);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wduplicated-branches"
     if((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLCFGR_PLLSRC_HSE)
     {
       /* Get the I2S source clock value */
@@ -433,6 +435,7 @@ void I2S_Init(SPI_TypeDef* SPIx, I2S_InitTypeDef* I2S_InitStruct)
       i2sclk = (uint32_t)(((HSI_VALUE / pllm) * plln) / pllr);
     }
   #endif /* I2S_EXTERNAL_CLOCK_VAL */
+#pragma GCC diagnostic pop
     
     /* Compute the Real divider depending on the MCLK output state, with a floating point */
     if(I2S_InitStruct->I2S_MCLKOutput == I2S_MCLKOutput_Enable)

--- a/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_uart.c
+++ b/lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_uart.c
@@ -248,6 +248,8 @@ HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
     return HAL_ERROR;
   }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wduplicated-branches"
   if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
   {
     /* Check the parameters */
@@ -258,6 +260,7 @@ HAL_StatusTypeDef HAL_UART_Init(UART_HandleTypeDef *huart)
     /* Check the parameters */
     assert_param(IS_UART_INSTANCE(huart->Instance));
   }
+#pragma GCC diagnostic pop
 
   if(huart->gState == HAL_UART_STATE_RESET)
   {


### PR DESCRIPTION
suppresses (does not attempt to fix 3rd party libraries):
```C
./lib/main/STM32F4/Drivers/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c: In function 'I2S_Init':
./lib/main/STM32F4/Drivers/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_spi.c:426:7: warning: this condition has identical branches [-Wduplicated-branches]
  426 |     if((RCC->PLLCFGR & RCC_PLLCFGR_PLLSRC) == RCC_PLLCFGR_PLLSRC_HSE)
      |       ^
./lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_uart.c: In function 'HAL_UART_Init':
./lib/main/STM32F7/Drivers/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_uart.c:251:5: warning: this condition has identical branches [-Wduplicated-branches]
  251 |   if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
      |     ^
```
ref: https://stackoverflow.com/a/76435158/2013805

