### PR TITLE
[target] PYRODRONEF7 - fix / update Timers

### DIFF
--- a/src/main/target/PYRODRONEF7/target.c
+++ b/src/main/target/PYRODRONEF7/target.c
@@ -28,16 +28,23 @@
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
 // FILO arrangement for motor assignments, Motor 1 starts at 2nd DECLARATION
-    DEF_TIM(TIM2,  CH2,   PB3, TIM_USE_ANY,                0, 0), // USE FOR CAMERA CONTROL
+    DEF_TIM(TIM2,  CH2,   PB3, TIM_USE_ANY,                0, 0), // pin B03: TIM2 CH2 (AF1) // USE FOR CAMERA CONTROL 
 
-    DEF_TIM(TIM4,  CH1,  PB6, TIM_USE_MOTOR,               0, 0), // D1-ST0                   MOTOR1
-    DEF_TIM(TIM4,  CH2,  PB7, TIM_USE_MOTOR,               0, 0), // D1-ST3                   MOTOR2
-    DEF_TIM(TIM4,  CH3,  PB8, TIM_USE_MOTOR,               0, 0), // D1-ST7                   MOTOR3
-    DEF_TIM(TIM8,  CH3,  PC8, TIM_USE_MOTOR,               0, 0), // D2-ST2/D2-ST4            MOTOR4
-    DEF_TIM(TIM5,  CH2,  PA1, TIM_USE_MOTOR,               0, 0), // D1-ST4                   MOTOR5
-    DEF_TIM(TIM4,  CH4,  PB9, TIM_USE_MOTOR,               0, 0), // NONE  TIM4_UP_D1-ST6     MOTOR6
-    DEF_TIM(TIM8,  CH4,  PC9, TIM_USE_MOTOR,               0, 0), // D2-ST7                   MOTOR7
+    DEF_TIM(TIM4,  CH1,  PB6, TIM_USE_MOTOR,               0, 0), // pin B06: TIM4 CH1 (AF2) // D1-ST0                   MOTOR1
+    DEF_TIM(TIM4,  CH2,  PB7, TIM_USE_MOTOR,               0, 0), // pin B07: TIM4 CH2 (AF2) // D1-ST3                   MOTOR2
+    DEF_TIM(TIM4,  CH3,  PB8, TIM_USE_MOTOR,               0, 0), // pin B08: TIM4 CH3 (AF2) // D1-ST7                   MOTOR3
+    DEF_TIM(TIM8,  CH3,  PC8, TIM_USE_MOTOR,               0, 0), // pin C08: TIM8 CH3 (AF3) // D2-ST2/D2-ST4            MOTOR4
+    DEF_TIM(TIM5,  CH2,  PA1, TIM_USE_MOTOR,               0, 0), // pin A01: TIM5 CH2 (AF2) // D1-ST4                   MOTOR5
+    DEF_TIM(TIM4,  CH4,  PB9, TIM_USE_MOTOR,               0, 0), // pin B09: TIM4 CH4 (AF2) // NONE  TIM4_UP_D1-ST6     MOTOR6
+    DEF_TIM(TIM8,  CH4,  PC9, TIM_USE_MOTOR,               0, 0), // pin C09: TIM8 CH4 (AF3) // D2-ST7                   MOTOR7
 
-    DEF_TIM(TIM3,  CH4, PB1, TIM_USE_MOTOR | TIM_USE_LED,  0, 0), // D1-ST2                   LED/MOTOR5
+    DEF_TIM(TIM3,  CH4, PB1, TIM_USE_MOTOR | TIM_USE_LED,  0, 0), // pin B01: TIM3 CH4 (AF2) // D1-ST2                   LED/MOTOR5 
+
+    DEF_TIM(TIM9,  CH2,  PA3, TIM_USE_ANY,                 0, 0), // pin A03: TIM9 CH2 (AF3)
+    DEF_TIM(TIM1,  CH2N, PB0, TIM_USE_ANY,                 0, 0), // pin B00: TIM1 CH2N (AF1)
+    DEF_TIM(TIM5,  CH1,  PA0, TIM_USE_ANY,                 0, 0), // pin A00: TIM5 CH1 (AF2)
+    DEF_TIM(TIM3,  CH1,  PC6, TIM_USE_ANY,                 0, 0), // pin C06: TIM3 CH1 (AF2)
+    DEF_TIM(TIM8,  CH2,  PC7, TIM_USE_ANY,                 0, 0), // pin C07: TIM8 CH2 (AF3)
+    DEF_TIM(TIM3,  CH2,  PB5, TIM_USE_ANY,                 0, 0), // pin B05: TIM3 CH2 (AF2)
 
 };

--- a/src/main/target/PYRODRONEF7/target.h
+++ b/src/main/target/PYRODRONEF7/target.h
@@ -132,5 +132,5 @@
 #define TARGET_IO_PORTC         0xffff
 #define TARGET_IO_PORTD         (BIT(2))
 
-#define USABLE_TIMER_CHANNEL_COUNT      6
-#define USED_TIMERS             ( TIM_N(2) | TIM_N(3) | TIM_N(4)  )
+#define USABLE_TIMER_CHANNEL_COUNT      15
+#define USED_TIMERS             ( TIM_N(1) | TIM_N(2) | TIM_N(3) | TIM_N(4) |TIM_N(5) | TIM_N(8) | TIM_N(9) )

--- a/src/main/target/PYRODRONEF7/target.mk
+++ b/src/main/target/PYRODRONEF7/target.mk
@@ -9,4 +9,5 @@ TARGET_SRC = \
             drivers/light_ws2811strip_hal.c \
             drivers/compass/compass_hmc5883l.c \
             drivers/compass/compass_qmc5883l.c \
+            drivers/pinio.c \
             drivers/max7456.c


### PR DESCRIPTION
- via BF's `USE_TIMER_MAP_PRINT` cloud-build
