### PR TITLE
BMI270 - 6.4k code

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -69,6 +69,7 @@
 #define GYRO_RATE_1_kHz     1000.0f
 #define GYRO_RATE_1100_Hz   909.09f
 #define GYRO_RATE_3200_Hz   312.5f
+#define GYRO_RATE_6400_Hz   156.25f
 #define GYRO_RATE_8_kHz     125.0f
 #define GYRO_RATE_9_kHz     111.11f
 #define GYRO_RATE_16_kHz    64.0f

--- a/src/main/drivers/accgyro/gyro_sync.c
+++ b/src/main/drivers/accgyro/gyro_sync.c
@@ -62,7 +62,16 @@ uint32_t gyroSetSampleRate(gyroDev_t *gyro, uint8_t lpf, uint8_t gyroSyncDenomin
             if (lpfNoneOr256) { gyro->gyroRateKHz = GYRO_RATE_3200_Hz; }
             break;
         case BMI_270_SPI:    //bmi270
-            gyro->gyroRateKHz = GYRO_RATE_3200_Hz;
+#ifdef USE_GYRO_DLPF_EXPERIMENTAL
+            if (gyro->hardware_lpf == GYRO_HARDWARE_LPF_EXPERIMENTAL) {
+                // 6.4KHz sampling, but data is unfiltered (no hardware DLPF)
+                gyro->gyroRateKHz = GYRO_RATE_6400_Hz;
+                //gyroSampleRateHz = 6400;
+            } else
+#endif
+            {
+                gyro->gyroRateKHz = GYRO_RATE_3200_Hz;
+            }
             break;
         default:
             if (gyro_use_32khz) {


### PR DESCRIPTION
- the BMI270 code in master is incomplete and does not properly set 6.4k when `set gyro_hardware_lpf = EXPERIMENTAL`
- this code is needed, but still does not properly go into 6.4k
- if anyone willing to check code, please do.

