### PR TITLE
HDZERO - OSD Init/Menu/Stats Centering

### DIFF
--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -27,6 +27,8 @@
 //#define CMS_PAGE_DEBUG // For multi-page/menu debugging
 //#define CMS_MENU_DEBUG // For external menu content creators
 
+#pragma once
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -66,6 +68,7 @@
 // For VISIBLE*
 #include "io/osd.h"
 #include "io/rcdevice_cam.h"
+#include "pg/vcd.h"
 
 #include "rx/rx.h"
 
@@ -591,13 +594,18 @@ void cmsMenuOpen(void) {
     if ( pCurrentDisplay->cols < NORMAL_SCREEN_MIN_COLS) {
         smallScreen       = true;
         linesPerMenuItem  = 2;
-        leftMenuColumn    = 0;
+        leftMenuColumn    = SDINDENT;
         rightMenuColumn   = pCurrentDisplay->cols;
         maxMenuItems      = (pCurrentDisplay->rows) / linesPerMenuItem;
     } else {
         smallScreen       = false;
         linesPerMenuItem  = 1;
-        leftMenuColumn    = 2;
+#if defined(USE_HDZERO_OSD)
+    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
+        leftMenuColumn = HDINDENT + 2;
+    } else
+#endif
+        { leftMenuColumn    = SDINDENT + 2; }
 #ifdef CMS_OSD_RIGHT_ALIGNED_VALUES
         rightMenuColumn   = pCurrentDisplay->cols - 2;
 #else

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -599,16 +599,16 @@ void cmsMenuOpen(void) {
         smallScreen       = false;
         linesPerMenuItem  = 1;
 #if defined(USE_HDZERO_OSD)
-    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
-        leftMenuColumn = HDINDENTMENU + 2;
-    } else
+    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30))
+        { leftMenuColumn = HDINDENTMENU + 2; }
+    else
 #endif
         { leftMenuColumn    = SDINDENT + 2; }
 #ifdef CMS_OSD_RIGHT_ALIGNED_VALUES
 #if defined(USE_HDZERO_OSD)
-    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
-        rightMenuColumn   = pCurrentDisplay->cols - 3 - HDINDENTMENU;
-    } else
+    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30))
+        { rightMenuColumn   = pCurrentDisplay->cols - 3 - HDINDENTMENU; }
+    else
 #endif
         { rightMenuColumn   = pCurrentDisplay->cols - 2; }
 

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -600,14 +600,14 @@ void cmsMenuOpen(void) {
         linesPerMenuItem  = 1;
 #if defined(USE_HDZERO_OSD)
     if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30))
-        { leftMenuColumn = HDINDENTMENU + 2; }
+        { leftMenuColumn = HDINDENT + 2; }
     else
 #endif
         { leftMenuColumn    = SDINDENT + 2; }
 #ifdef CMS_OSD_RIGHT_ALIGNED_VALUES
 #if defined(USE_HDZERO_OSD)
     if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30))
-        { rightMenuColumn   = pCurrentDisplay->cols - 3 - HDINDENTMENU; }
+        { rightMenuColumn   = pCurrentDisplay->cols - 2 - HDINDENT; }
     else
 #endif
         { rightMenuColumn   = pCurrentDisplay->cols - 2; }

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -27,8 +27,6 @@
 //#define CMS_PAGE_DEBUG // For multi-page/menu debugging
 //#define CMS_MENU_DEBUG // For external menu content creators
 
-#pragma once
-
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -594,7 +592,7 @@ void cmsMenuOpen(void) {
     if ( pCurrentDisplay->cols < NORMAL_SCREEN_MIN_COLS) {
         smallScreen       = true;
         linesPerMenuItem  = 2;
-        leftMenuColumn    = SDINDENT;
+        leftMenuColumn    = 0;
         rightMenuColumn   = pCurrentDisplay->cols;
         maxMenuItems      = (pCurrentDisplay->rows) / linesPerMenuItem;
     } else {
@@ -602,12 +600,18 @@ void cmsMenuOpen(void) {
         linesPerMenuItem  = 1;
 #if defined(USE_HDZERO_OSD)
     if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
-        leftMenuColumn = HDINDENT + 2;
+        leftMenuColumn = HDINDENTMENU + 2;
     } else
 #endif
         { leftMenuColumn    = SDINDENT + 2; }
 #ifdef CMS_OSD_RIGHT_ALIGNED_VALUES
-        rightMenuColumn   = pCurrentDisplay->cols - 2;
+#if defined(USE_HDZERO_OSD)
+    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
+        rightMenuColumn   = pCurrentDisplay->cols - 3 - HDINDENTMENU;
+    } else
+#endif
+        { rightMenuColumn   = pCurrentDisplay->cols - 2; }
+
 #else
         rightMenuColumn   = pCurrentDisplay->cols - CMS_DRAW_BUFFER_LEN;
 #endif

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -646,7 +646,7 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr) {
     currentCtx.menu = NULL;
     if (exitType == CMS_EXIT_SAVEREBOOT) {
         displayClearScreen(pDisplay);
-        displayWrite(pDisplay, leftMenuColumn + 5, 3, "REBOOTING...");
+        displayWrite(pDisplay, (pCurrentDisplay->cols % 2) - 6, 3, "REBOOTING...");
         displayResync(pDisplay); // Was max7456RefreshAll(); why at this timing?
         stopMotors();
         stopPwmAllMotors();

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -646,7 +646,7 @@ long cmsMenuExit(displayPort_t *pDisplay, const void *ptr) {
     currentCtx.menu = NULL;
     if (exitType == CMS_EXIT_SAVEREBOOT) {
         displayClearScreen(pDisplay);
-        displayWrite(pDisplay, 5, 3, "REBOOTING...");
+        displayWrite(pDisplay, leftMenuColumn + 5, 3, "REBOOTING...");
         displayResync(pDisplay); // Was max7456RefreshAll(); why at this timing?
         stopMotors();
         stopPwmAllMotors();

--- a/src/main/cms/cms.c
+++ b/src/main/cms/cms.c
@@ -611,7 +611,6 @@ void cmsMenuOpen(void) {
     else
 #endif
         { rightMenuColumn   = pCurrentDisplay->cols - 2; }
-
 #else
         rightMenuColumn   = pCurrentDisplay->cols - CMS_DRAW_BUFFER_LEN;
 #endif

--- a/src/main/cms/cms_menu_blackbox.c
+++ b/src/main/cms/cms_menu_blackbox.c
@@ -140,7 +140,7 @@ static long cmsx_EraseFlash(displayPort_t *pDisplay, const void *ptr) {
         return 0;
     }
     displayClearScreen(pDisplay);
-    displayWrite(pDisplay, 5, 3, "ERASING FLASH...");
+    displayWrite(pDisplay, (pCurrentDisplay->cols % 2) - 7, 3, "ERASING FLASH...");
     displayResync(pDisplay); // Was max7456RefreshAll(); Why at this timing?
     flashfsEraseCompletely();
     while (!flashfsIsReady()) {

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1384,9 +1384,9 @@ static void osdGetBlackboxStatusString(char * buff) {
 #endif
 
 static void osdDisplayStatisticLabel(uint8_t y, const char * text, const char * value) {
-    displayWrite(osdDisplayPort, 2, y, text);
-    displayWrite(osdDisplayPort, 20, y, ":");
-    displayWrite(osdDisplayPort, 22, y, value);
+    displayWrite(osdDisplayPort, leftScreen + 2, y, text);
+    displayWrite(osdDisplayPort, leftScreen + 20, y, ":");
+    displayWrite(osdDisplayPort, leftScreen + 22, y, value);
 }
 
 /*
@@ -1408,7 +1408,7 @@ static void osdShowStats(uint16_t endBatteryVoltage) {
     uint8_t top = 2;
     char buff[OSD_ELEMENT_BUFFER_LENGTH];
     displayClearScreen(osdDisplayPort);
-    displayWrite(osdDisplayPort, 2, top++, "  --- STATS ---");
+    displayWrite(osdDisplayPort, leftScreen + 2, top++, "  --- STATS ---");
     if (osdStatGetState(OSD_STAT_RTC_DATE_TIME)) {
         bool success = false;
 #ifdef USE_RTC_TIME
@@ -1417,7 +1417,7 @@ static void osdShowStats(uint16_t endBatteryVoltage) {
         if (!success) {
             tfp_sprintf(buff, "NO RTC");
         }
-        displayWrite(osdDisplayPort, 2, top++, buff);
+        displayWrite(osdDisplayPort, leftScreen + 2, top++, buff);
     }
     if (osdStatGetState(OSD_STAT_TIMER_1)) {
         osdFormatTimer(buff, false, (OSD_TIMER_SRC(osdConfig()->timers[OSD_TIMER_1]) == OSD_TIMER_SRC_ON ? false : true), OSD_TIMER_1);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1166,11 +1166,11 @@ void osdInit(displayPort_t *osdDisplayPortToUse) {
     memset(blinkBits, 0, sizeof(blinkBits));
     displayClearScreen(osdDisplayPort);
 #if defined(USE_HDZERO_OSD)
-    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
-        leftScreen = HDINDENTINIT;
-    } else
+    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30))
+        { leftScreen = HDINDENTINIT; }
+    else
 #endif
-    { leftScreen = SDINDENT; }
+        { leftScreen = SDINDENT; }
     osdDrawLogo(leftScreen + 3, 1);
     char string_buffer[30];
     tfp_sprintf(string_buffer, "V%s", FC_VERSION_STRING);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1170,7 +1170,7 @@ void osdInit(displayPort_t *osdDisplayPortToUse) {
         leftScreen = HDINDENT;
     } else
 #endif
-    { leftScreen = SDINDENT;}
+    { leftScreen = SDINDENT; }
     osdDrawLogo(leftScreen + 3, 1);
     char string_buffer[30];
     tfp_sprintf(string_buffer, "V%s", FC_VERSION_STRING);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1167,7 +1167,7 @@ void osdInit(displayPort_t *osdDisplayPortToUse) {
     displayClearScreen(osdDisplayPort);
 #if defined(USE_HDZERO_OSD)
     if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30))
-        { leftScreen = HDINDENTINIT; }
+        { leftScreen = HDINDENT; }
     else
 #endif
         { leftScreen = SDINDENT; }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -1166,8 +1166,8 @@ void osdInit(displayPort_t *osdDisplayPortToUse) {
     memset(blinkBits, 0, sizeof(blinkBits));
     displayClearScreen(osdDisplayPort);
 #if defined(USE_HDZERO_OSD)
-    if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
-        leftScreen = HDINDENT;
+    if ((vcdProfile()->video_system == VIDEO_SYSTEM_HD) && (pCurrentDisplay->cols > 30)) {
+        leftScreen = HDINDENTINIT;
     } else
 #endif
     { leftScreen = SDINDENT; }

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -169,6 +169,8 @@ static escSensorData_t *escDataCombined;
 #define AH_SIDEBAR_WIDTH_POS 7
 #define AH_SIDEBAR_HEIGHT_POS 3
 
+static uint8_t leftScreen;
+
 static const char compassBar[] = {
     SYM_HEADING_W,
     SYM_HEADING_LINE, SYM_HEADING_DIVIDED_LINE, SYM_HEADING_LINE,
@@ -1163,19 +1165,25 @@ void osdInit(displayPort_t *osdDisplayPortToUse) {
     armState = ARMING_FLAG(ARMED);
     memset(blinkBits, 0, sizeof(blinkBits));
     displayClearScreen(osdDisplayPort);
-    osdDrawLogo(3, 1);
+#if defined(USE_HDZERO_OSD)
+    if (vcdProfile()->video_system == VIDEO_SYSTEM_HD) {
+        leftScreen = HDINDENT;
+    } else
+#endif
+    { leftScreen = SDINDENT;}
+    osdDrawLogo(leftScreen + 3, 1);
     char string_buffer[30];
     tfp_sprintf(string_buffer, "V%s", FC_VERSION_STRING);
-    displayWrite(osdDisplayPort, 20, 6, string_buffer);
+    displayWrite(osdDisplayPort, leftScreen + 20, 6, string_buffer);
 #ifdef USE_CMS
-    displayWrite(osdDisplayPort, 7, 8,  CMS_STARTUP_HELP_TEXT1);
-    displayWrite(osdDisplayPort, 11, 9, CMS_STARTUP_HELP_TEXT2);
-    displayWrite(osdDisplayPort, 11, 10, CMS_STARTUP_HELP_TEXT3);
+    displayWrite(osdDisplayPort, leftScreen + 7, 8,  CMS_STARTUP_HELP_TEXT1);
+    displayWrite(osdDisplayPort, leftScreen + 11, 9, CMS_STARTUP_HELP_TEXT2);
+    displayWrite(osdDisplayPort, leftScreen + 11, 10, CMS_STARTUP_HELP_TEXT3);
 #endif
 #ifdef USE_RTC_TIME
     char dateTimeBuffer[FORMATTED_DATE_TIME_BUFSIZE];
     if (osdFormatRtcDateTime(&dateTimeBuffer[0])) {
-        displayWrite(osdDisplayPort, 5, 12, dateTimeBuffer);
+        displayWrite(osdDisplayPort, leftScreen + 5, 12, dateTimeBuffer);
     }
 #endif
     displayResync(osdDisplayPort);
@@ -1483,12 +1491,12 @@ static timeDelta_t osdShowArmed(void)
     timeDelta_t ret;
     displayClearScreen(osdDisplayPort);
     if ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_ON) || ((osdConfig()->logo_on_arming == OSD_LOGO_ARMING_FIRST) && !everArmed)) {
-        osdDrawLogo(3, 1);
+        osdDrawLogo(leftScreen + 3, 1);
         ret = osdConfig()->logo_on_arming_duration * 1e5;
     } else {
         ret = (REFRESH_1S / 2);
     }
-    displayWrite(osdDisplayPort, 12, 7, "ARMED");
+    displayWrite(osdDisplayPort, leftScreen + 12, 7, "ARMED");
     everArmed = true;
     return ret;
 }

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -45,8 +45,9 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_X(x)      ((x & OSD_POSITION_XY_MASK) | ((x & OSD_POSITION_XHD_MASK) >> (OSD_POSITION_BIT_XHD - OSD_POSITION_BITS)))
 #define OSD_Y(x)      ((x >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
 
-#define SDINDENT  0   //Analog leftmost character for OSD Init and Menus
-#define HDINDENT 15   //HD leftmost character for OSD Init and Menus
+#define SDINDENT      0   //Analog leftmost character for OSD Init and Menus
+#define HDINDENTINIT 10   //HD leftmost character for OSD Init and Menus
+#define HDINDENTMENU  4   //HD leftmost character for OSD Init and Menus
 
 // Timer configuration
 // Stored as 15[alarm:8][precision:4][source:4]0

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -46,8 +46,7 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
 #define OSD_Y(x)      ((x >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
 
 #define SDINDENT      0   //Analog leftmost character for OSD Init and Menus
-#define HDINDENTINIT 10   //HD leftmost character for OSD Init and Menus
-#define HDINDENTMENU  4   //HD leftmost character for OSD Init and Menus
+#define HDINDENT     10   //HD leftmost character for OSD Init and Menus
 
 // Timer configuration
 // Stored as 15[alarm:8][precision:4][source:4]0

--- a/src/main/io/osd.h
+++ b/src/main/io/osd.h
@@ -22,6 +22,7 @@
 
 #include "common/time.h"
 #include "pg/pg.h"
+#include "pg/vcd.h"
 
 #define OSD_NUM_TIMER_TYPES 3
 extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
@@ -43,6 +44,9 @@ extern const char * const osdTimerSourceNames[OSD_NUM_TIMER_TYPES];
                        ((y & OSD_POSITION_XY_MASK) << OSD_POSITION_BITS))
 #define OSD_X(x)      ((x & OSD_POSITION_XY_MASK) | ((x & OSD_POSITION_XHD_MASK) >> (OSD_POSITION_BIT_XHD - OSD_POSITION_BITS)))
 #define OSD_Y(x)      ((x >> OSD_POSITION_BITS) & OSD_POSITION_XY_MASK)
+
+#define SDINDENT  0   //Analog leftmost character for OSD Init and Menus
+#define HDINDENT 15   //HD leftmost character for OSD Init and Menus
 
 // Timer configuration
 // Stored as 15[alarm:8][precision:4][source:4]0

--- a/src/main/pg/vcd.h
+++ b/src/main/pg/vcd.h
@@ -27,7 +27,8 @@
 enum VIDEO_SYSTEMS {
     VIDEO_SYSTEM_AUTO = 0,
     VIDEO_SYSTEM_PAL,
-    VIDEO_SYSTEM_NTSC
+    VIDEO_SYSTEM_NTSC,
+    VIDEO_SYSTEM_HD
 };
 
 typedef struct vcdProfile_s {


### PR DESCRIPTION
- Text centering for OSD init (logo/etc), OSD CMS Menu's, and OSD Disarm-Statistics.
- unsure if this is complete, but works for Init, OSD CMS menu and disarm Statistics.
- tested one Analog and two HDZero.
- i noticed "Rebooting" and "Erasing Flash" text does not display on HDZero. :frowning_face:   (same as `master`)
- may be room for improvement, but much better than master.

Test DVR of this PR and PR 991 merged together. (some improvement committed after these DVR, but still valid for showing)
- HDZero Race v3 - https://youtu.be/qXyr4467I3g
- HDZero Freestyle v2 - https://youtu.be/656tzch6jZ8
- Analog - https://youtu.be/ShBYZvr1A8o

Everything was too left before:
![image](https://github.com/emuflight/EmuFlight/assets/56646290/5e419ab6-362b-42fe-ab83-6366b9667b6e)
![image](https://github.com/emuflight/EmuFlight/assets/56646290/e69e2adc-e171-4c01-a85b-b10e4f734811)

after
![image](https://github.com/emuflight/EmuFlight/assets/56646290/30154ba8-228b-4bb7-9eda-912db0afd167)
![image](https://github.com/emuflight/EmuFlight/assets/56646290/4b2512d4-341a-4cbc-9e8b-5fc49c81c18e)
![image](https://github.com/emuflight/EmuFlight/assets/56646290/731d2231-835d-48bc-819d-0ab4ebedcae6)
![image](https://github.com/emuflight/EmuFlight/assets/56646290/f6269866-0c52-48ba-9527-b92f7303bbbb)


