### PR TITLE
fix compiler warnings for ACC_2_ALIGN identical branches

### DIFF
--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -370,11 +370,15 @@ bool accInit(void) {
     acc.dev.mpuDetectionResult = *gyroMpuDetectionResult();
     acc.dev.acc_high_fsr = accelerometerConfig()->acc_high_fsr;
 #ifdef USE_DUAL_GYRO
+    #if defined ACC_2_ALIGN
     if (gyroConfig()->gyro_to_use == GYRO_CONFIG_USE_GYRO_2) {
         acc.dev.accAlign = ACC_2_ALIGN;
-    } else {
-        acc.dev.accAlign = ACC_1_ALIGN;
     }
+    #elif defined ACC_1_ALIGN
+        acc.dev.accAlign = ACC_1_ALIGN;
+    #else
+        acc.dev.accAlign = ALIGN_DEFAULT;
+    #endif
 #else
     acc.dev.accAlign = ALIGN_DEFAULT;
 #endif


### PR DESCRIPTION
fixes
```
warning /src/main/sensors/acceleration.c: In function 'accInit':
./src/main/sensors/acceleration.c:373:8: warning: this condition has identical branches [-Wduplicated-branches]
  373 |     if (gyroConfig()->gyro_to_use == GYRO_CONFIG_USE_GYRO_2) {
      |        ^
```

