### PR TITLE
[target] add IFLIGHT_BLITZ_F411RX - CC2500 version

### DIFF
--- a/src/main/target/IFLIGHT_BLITZ_F411RX/target.c
+++ b/src/main/target/IFLIGHT_BLITZ_F411RX/target.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of EmuFlight. It is derived from Betaflight.
+ *
+ * This is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This resource file generated using https://github.com/nerdCopter/target-convert
+// Commit: 3f33ae6 + 1 file changed, 24 deletions(-)
+
+#include <stdint.h>
+#include "platform.h"
+#include "drivers/io.h"
+#include "drivers/dma.h"
+#include "drivers/timer.h"
+#include "drivers/timer_def.h"
+
+const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
+    DEF_TIM(TIM2, CH1, PA0, TIM_USE_MOTOR, 0, 0), // motor 1
+    DEF_TIM(TIM2, CH2, PA1, TIM_USE_MOTOR, 0, 0), // motor 2
+    DEF_TIM(TIM4, CH1, PB6, TIM_USE_MOTOR, 0, 0), // motor 3
+    DEF_TIM(TIM4, CH2, PB7, TIM_USE_MOTOR, 0, 0), // motor 4
+    DEF_TIM(TIM9, CH2, PA3, TIM_USE_PPM, 0, 0), // ppm RX_PPM_PIN; dma 0 assumed, please verify
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_LED, 0, 0), // led
+};
+
+// notice - this file was programmatically generated and may be incomplete.

--- a/src/main/target/IFLIGHT_BLITZ_F411RX/target.h
+++ b/src/main/target/IFLIGHT_BLITZ_F411RX/target.h
@@ -1,0 +1,121 @@
+/*
+ * This file is part of EmuFlight. It is derived from Betaflight.
+ *
+ * This is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// This resource file generated using https://github.com/nerdCopter/target-convert
+// Commit: 3f33ae6 + 1 file changed, 24 deletions(-)
+
+#pragma once
+
+#define BOARD_NAME        IFLIGHT_BLITZ_F411RX
+#define MANUFACTURER_ID   IFRC
+#define TARGET_BOARD_IDENTIFIER "S411"  // generic ID
+#define FC_TARGET_MCU     STM32F411     // not used in EmuF
+
+#define USE_GYRO
+#define USE_ACC
+#define USE_ACCGYRO_BMI270
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACC_SPI_MPU6000
+#define USE_MAX7456
+
+#define USE_VCP
+#define USE_OSD
+
+#define USE_LED
+#define LED0_PIN             PC13
+#define LED_STRIP_PIN        PA10
+
+#define USE_SPI
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN         PA5
+#define SPI1_MISO_PIN        PA6
+#define SPI1_MOSI_PIN        PA7
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN         PB13
+#define SPI2_MISO_PIN        PB14
+#define SPI2_MOSI_PIN        PB15
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN         PB3
+#define SPI3_MISO_PIN        PB4
+#define SPI3_MOSI_PIN        PB5
+
+#define USE_SPI_GYRO
+#define USE_EXTI
+#define USE_GYRO_EXTI
+
+#define USE_MPU_DATA_READY_SIGNAL
+
+#define MPU_INT_EXTI         PB10
+
+#define ACC_MPU6000_ALIGN        CW180_DEG
+#define GYRO_MPU6000_ALIGN       CW180_DEG
+#define MPU6000_CS_PIN           PA4
+#define MPU6000_SPI_INSTANCE     SPI1
+
+#define ACC_BMI270_ALIGN         CW180_DEG
+#define GYRO_BMI270_ALIGN        CW180_DEG
+#define BMI270_CS_PIN            PA4
+#define BMI270_SPI_INSTANCE      SPI1
+
+#define USE_UART1
+#define UART1_TX_PIN         PA9
+#define USE_UART2
+#define UART2_TX_PIN         PA2
+#define UART2_RX_PIN         PA3
+#define SERIAL_PORT_COUNT 3
+
+#define RX_SPI_CS_PIN        PA15
+#define RX_SPI_EXTI_PIN      PC14
+#define RX_SPI_BIND_PIN      PB2
+#define RX_SPI_LED_PIN       PC15
+#define RX_CC2500_SPI_TX_EN_PIN PA8
+#define RX_SPI_INSTANCE SPI3
+#define RX_SPI_LED_INVERTED
+#define RX_CC2500_SPI_DISABLE_CHIP_DETECTION
+#define BINDPLUG_PIN PB2
+
+#define USE_I2C
+#define USE_I2C_DEVICE_1
+#define I2C_DEVICE_1      (I2CDEV_1)
+#define I2C1_SCL PB8
+#define I2C1_SDA PB9
+
+#define MAX7456_SPI_CS_PIN   PB12
+#define MAX7456_SPI_INSTANCE SPI2
+
+#define USE_ADC
+#define VBAT_ADC_PIN PB0
+#define CURRENT_METER_ADC_PIN PB1
+#define ADC1_DMA_OPT        0
+#define ADC1_DMA_STREAM DMA2_Stream0 //# ADC 1: DMA2 Stream 0 Channel 0
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE 180
+
+
+#define TARGET_IO_PORTA 0xffff
+#define TARGET_IO_PORTB 0xffff
+#define TARGET_IO_PORTC 0xffff
+// notice - masks were programmatically generated - please verify last port group for 0xffff or (BIT(2))
+
+#define DEFAULT_FEATURES       (FEATURE_OSD | FEATURE_TELEMETRY | FEATURE_AIRMODE | FEATURE_RX_SPI)
+#define DEFAULT_RX_FEATURE     FEATURE_RX_SPI
+
+#define USABLE_TIMER_CHANNEL_COUNT 6
+#define USED_TIMERS ( TIM_N(1) | TIM_N(2) | TIM_N(4) | TIM_N(9) )
+
+// notice - this file was programmatically generated and may be incomplete.

--- a/src/main/target/IFLIGHT_BLITZ_F411RX/target.mk
+++ b/src/main/target/IFLIGHT_BLITZ_F411RX/target.mk
@@ -1,0 +1,21 @@
+F411_TARGETS   += $(TARGET)
+FEATURES       += VCP ONBOARDFLASH
+
+TARGET_SRC = \
+drivers/accgyro/accgyro_spi_mpu6000.c \
+drivers/accgyro/accgyro_spi_bmi270.c \
+drivers/light_led.h \
+drivers/light_ws2811strip.c \
+drivers/max7456.c \
+drivers/rx/rx_cc2500.c \
+rx/cc2500_common.c \
+rx/cc2500_frsky_shared.c \
+rx/cc2500_frsky_d.c \
+rx/cc2500_frsky_x.c \
+rx/cc2500_redpine.c \
+rx/cc2500_sfhss.c
+
+# notice - this file was programmatically generated and may be incomplete.
+
+# This resource file generated using https://github.com/nerdCopter/target-convert
+# Commit: 3f33ae6 + 1 file changed, 24 deletions(-)


### PR DESCRIPTION
- CC2500 version
- needs testing: [EmuFlight_0.4.3_IFLIGHT_BLITZ_F411RX_Build_2db3cdfc1.hex.zip](https://github.com/emuflight/EmuFlight/files/15486192/EmuFlight_0.4.3_IFLIGHT_BLITZ_F411RX_Build_2db3cdfc1.hex.zip)
- requires newer Configurator: https://github.com/emuflight/dev-master/releases/tag/20240501.162228-cfg

closes #867
