### PR TITLE
3D-mode fix

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -865,13 +865,13 @@ void mixThingsUp(const float scaledAxisPidRoll, const float scaledAxisPidPitch, 
     float controllerMixMin = 0, controllerMixMax = 0;
 
     for (int i = 0; i < motorCount; i++) {
-        float yawMixVal = controllerMix3DModeSign * scaledAxisPidYaw * currentMixer[i].yaw;
+        float yawMixVal = scaledAxisPidYaw * currentMixer[i].yaw;
         if (yawMixVal > yawMixMax) {
             yawMixMax = yawMixVal;
         } else if (yawMixVal < yawMixMin) {
             yawMixMin = yawMixVal;
         }
-        yawMix[i] = yawMixVal;
+        yawMix[i] = yawMixVal * controllerMix3DModeSign;
 
         float rollPitchMixVal = scaledAxisPidRoll * currentMixer[i].roll + scaledAxisPidPitch * currentMixer[i].pitch;
         if (rollPitchMixVal > rollPitchMixMax) {
@@ -879,15 +879,15 @@ void mixThingsUp(const float scaledAxisPidRoll, const float scaledAxisPidPitch, 
         } else if (rollPitchMixVal < rollPitchMixMin) {
             rollPitchMixMin = rollPitchMixVal;
         }
-        rollPitchMix[i] = rollPitchMixVal;
+        rollPitchMix[i] = rollPitchMixVal * controllerMix3DModeSign;
 
-        float controllerMixVal = controllerMix3DModeSign * (rollPitchMixVal + yawMixVal);
+        float controllerMixVal = (rollPitchMixVal + yawMixVal);
         if (controllerMixVal > controllerMixMax) {
             controllerMixMax = controllerMixVal;
         } else if (controllerMixVal < controllerMixMin) {
             controllerMixMin = controllerMixVal;
         }
-        controllerMix[i] = controllerMixVal;
+        controllerMix[i] = controllerMixVal * controllerMix3DModeSign;
     }
 
     controllerMixRange = controllerMixMax - controllerMixMin; // measures how much the controller is trying to compensate


### PR DESCRIPTION
- this seems to have fixed it. motor output signals are correct.
- **_needs 3D flight testing and feedback_**
- [please test https://github.com/emuflight/dev-unstable/releases/tag/20240618.193242-hex](https://github.com/emuflight/dev-unstable/releases/tag/20240709.141832-hex)
- Tested good without props on BLHeli32 32.9.5 and BlueJay 0.16.
- Tested good with props on Bluejay 0.16. I did not "fly", but it rotates each axis properly and was able to hover inverted.
- BlueJay 0.17, 0.18, 0.19 are known to have broken 3D startup power.  Seemingly fixed in BlueJay 0.21-RC1, but BlueJay developers would like BlackBox logs for further analysis.

Please test-fly and report feedback this PR or Discord.
<hr>

- tentative 3D-mode fix 
  - broken in https://github.com/emuflight/EmuFlight/pull/398
  - fixes https://github.com/emuflight/EmuFlight/issues/873
  - fixes https://github.com/emuflight/EmuConfigurator/issues/523

![image](https://github.com/emuflight/EmuFlight/assets/56646290/ef094a3a-aa2d-4c63-9c81-a702e2d83685)
![configurator-output-testing](https://github.com/emuflight/EmuFlight/assets/56646290/865f2513-9d25-427c-af28-b81af16d476d)
