### PR TITLE
more descriptive USBD_PRODUCT_STRING when not defined in target.h

### DIFF
--- a/src/main/vcpf4/usbd_desc.c
+++ b/src/main/vcpf4/usbd_desc.c
@@ -66,6 +66,18 @@
 #define USBD_LANGID_STRING              0x409
 #define USBD_MANUFACTURER_STRING        FC_FIRMWARE_NAME
 
+#ifndef USBD_PRODUCT_STRING
+#if defined STM32F1
+#define USBD_PRODUCT_STRING        "EmuFlight STM32F1"
+#elif defined STM32F3
+#define USBD_PRODUCT_STRING        "EmuFlight STM32F3"
+#elif defined STM32F4
+#define USBD_PRODUCT_STRING        "EmuFlight STM32F4"
+#elif defined STM32F7
+#define USBD_PRODUCT_STRING        "EmuFlight STM32F7"
+#endif
+#endif
+
 #ifdef USBD_PRODUCT_STRING
 #define USBD_PRODUCT_HS_STRING          USBD_PRODUCT_STRING
 #define USBD_PRODUCT_FS_STRING          USBD_PRODUCT_STRING


### PR DESCRIPTION
- before: 
![image](https://github.com/emuflight/EmuFlight/assets/56646290/a9f3ef64-3f43-482d-be4f-7a1af9899222)

- after:
![image](https://github.com/emuflight/EmuFlight/assets/56646290/421bb8cf-0705-472f-912c-304a768a7691)

- when defined in target.h:
![image](https://github.com/emuflight/EmuFlight/assets/56646290/e3304b9c-7080-4b38-86c2-80a0552470f0)
