### PR TITLE
PreArm allow Re-Arm (without resetting PreArm AUX)

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -225,7 +225,7 @@ void updateArmingStatus(void) {
             unsetArmingDisabled(ARMING_DISABLED_CALIBRATING);
         }
         if (isModeActivationConditionPresent(BOXPREARM)) {
-            if (IS_RC_MODE_ACTIVE(BOXPREARM) && !ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {
+            if (IS_RC_MODE_ACTIVE(BOXPREARM) && (!ARMING_FLAG(WAS_ARMED_WITH_PREARM) || armingConfig()->prearm_allow_rearm)) {
                 unsetArmingDisabled(ARMING_DISABLED_NOPREARM);
             } else {
                 setArmingDisabled(ARMING_DISABLED_NOPREARM);

--- a/src/main/fc/rc_controls.c
+++ b/src/main/fc/rc_controls.c
@@ -82,11 +82,12 @@ PG_RESET_TEMPLATE(rcControlsConfig_t, rcControlsConfig,
                   .yaw_control_reversed = false
                  );
 
-PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 1);
+PG_REGISTER_WITH_RESET_TEMPLATE(armingConfig_t, armingConfig, PG_ARMING_CONFIG, 2);
 
 PG_RESET_TEMPLATE(armingConfig_t, armingConfig,
                   .gyro_cal_on_first_arm = 0,  // TODO - Cleanup retarded arm support
                   .auto_disarm_delay = 5,
+                  .prearm_allow_rearm = 0,
                   .isUsingSticksForArming = false
                  );
 

--- a/src/main/fc/rc_controls.h
+++ b/src/main/fc/rc_controls.h
@@ -149,6 +149,7 @@ PG_DECLARE(flight3DConfig_t, flight3DConfig);
 typedef struct armingConfig_s {
     uint8_t gyro_cal_on_first_arm;          // allow disarm/arm on throttle down + roll left/right
     uint8_t auto_disarm_delay;              // allow automatically disarming multicopters after auto_disarm_delay seconds of zero throttle. Disabled when 0
+    uint8_t prearm_allow_rearm;             // allow re-arming without need to reset the preArm AUX channel
     bool isUsingSticksForArming;            // allow using sticks position to arm
 } armingConfig_t;
 

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -826,6 +826,7 @@ const clivalue_t valueTable[] = {
 // PG_ARMING_CONFIG
     { "auto_disarm_delay",          VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0, 60 }, PG_ARMING_CONFIG, offsetof(armingConfig_t, auto_disarm_delay) },
     { "gyro_cal_on_first_arm",      VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, gyro_cal_on_first_arm) },
+    { "prearm_allow_rearm",         VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, prearm_allow_rearm) },
     { "use_stick_arming",           VAR_INT8   | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_ARMING_CONFIG, offsetof(armingConfig_t, isUsingSticksForArming) },
 
 


### PR DESCRIPTION
- Arming still requires PreArm switch.
- `set prearm_allow_rearm = ON`, default is `OFF`.
- This allows re-arming mid-air, still **_requiring_** preArm, but without need for PreArm AUX _resetting_.
- TESTED SUCCESSFUL
- Required for mid-air rearm: `set small_angle = 180` (when using ACC)
- **WARNING** - it is very hard to coordinate 0 throttle (**_required_** for arming) in mid-air.

originally on Betaflight PR https://github.com/betaflight/betaflight/pull/14013

