### PR TITLE
Fix Smith Predictor compilation guards

### DIFF
--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -105,13 +105,12 @@ typedef struct smithPredictor_s {
     uint8_t enabled;
     uint8_t samples;
     uint8_t idx;
-
     float data[MAX_SMITH_SAMPLES + 1]; // This is gonna be a ring buffer. Max of 8ms delay at 8khz
-
     pt1Filter_t smithPredictorFilter; // filter the smith predictor output for RPY
-
     float smithPredictorStrength;
 } smithPredictor_t;
+
+float applySmithPredictor(smithPredictor_t *smithPredictor, float gyroFiltered);
 #endif // USE_SMITH_PREDICTOR
 
 typedef enum {
@@ -208,7 +207,6 @@ bool gyroOverflowDetected(void);
 bool gyroYawSpinDetected(void);
 uint16_t gyroAbsRateDps(int axis);
 uint8_t gyroReadRegister(uint8_t whichSensor, uint8_t reg);
-float applySmithPredictor(smithPredictor_t *smithPredictor, float gyroFiltered);
 #ifdef USE_GYRO_DATA_ANALYSE
 bool isDynamicFilterActive(void);
 #endif

--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -62,7 +62,9 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor) {
 #ifndef USE_GYRO_IMUF9001
         update_kalman_covariance(gyroADCf, axis);
 #endif
+#ifdef USE_SMITH_PREDICTOR
         applySmithPredictor(gyroSensor->smithPredictor, gyroADCf);
+#endif
 
 #ifdef USE_GYRO_IMUF9001
         // DEBUG_GYRO_FILTERED records the scaled, filtered, after all software filtering has been applied.


### PR DESCRIPTION
TL;DR: Move applySmithPredictor function declaration inside USE_SMITH_PREDICTOR guard
and guard the function call in gyro_filter_impl.h to prevent compilation errors
when the Smith Predictor feature is disabled.

---

## Pull Request Description

**Title:** Fix Smith Predictor compilation guards

**Description:**

### Problem
The Smith Predictor feature had incomplete preprocessor guards, causing compilation errors when `USE_SMITH_PREDICTOR` is undefined. Two unguarded locations were found:

1. **Function declaration**: The `applySmithPredictor()` function declaration in `src/main/sensors/gyro.h` was not protected with `#ifdef USE_SMITH_PREDICTOR`
2. **Function call**: The call to `applySmithPredictor()` in `src/main/sensors/gyro_filter_impl.h` was not guarded

### Root Cause
- `smithPredictor_t` typedef: ✅ Guarded with `#ifdef USE_SMITH_PREDICTOR`
- `applySmithPredictor` declaration: ❌ **NOT guarded** (was outside the `#ifdef`)
- `applySmithPredictor` call: ❌ **NOT guarded**

### Solution
1. **Fixed function declaration**: Moved `applySmithPredictor` declaration inside the existing `#ifdef USE_SMITH_PREDICTOR` block in `gyro.h`
2. **Fixed function call**: Guarded the `applySmithPredictor` call in `gyro_filter_impl.h` with `#ifdef USE_SMITH_PREDICTOR`

### Files Changed
- `src/main/sensors/gyro.h`: Moved function declaration into proper guard
- `src/main/sensors/gyro_filter_impl.h`: Guarded function call

### Impact
- ✅ Fixes compilation errors in unit tests and builds where `USE_SMITH_PREDICTOR` is undefined
- ✅ Maintains compatibility with existing firmware builds where the feature is enabled
- ✅ No functional changes to the Smith Predictor feature itself

### Testing
- Verified header compiles with `USE_SMITH_PREDICTOR` defined (types/functions available)
- Verified header compiles without `USE_SMITH_PREDICTOR` defined (no compilation errors)
- Verified full firmware builds succeed in both configurations
- Unit tests now pass the compilation phase (linking issues are separate)
- Verified flashing both versions to HELIOSPRING flight controller:
  - **With `USE_SMITH_PREDICTOR`**: CLI shows Smith Predictor settings available
  - **Without `USE_SMITH_PREDICTOR`**: CLI shows no Smith Predictor settings (feature properly disabled)
- Not flight tested

**Resolves:** Unit test compilation blocker documented in `tmp/20251021_FIRMWARE_BUG_SMITH_PREDICTOR_DECLARATION.md`

