### PR TITLE
fix: pidCopyProfile silently rejected copy to Nth profile (PID_PROFILE_COUNT)

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -447,7 +447,7 @@ void pidInit(const pidProfile_t *pidProfile) {
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex) {
-    if ((dstPidProfileIndex < PID_PROFILE_COUNT - 1 && srcPidProfileIndex < PID_PROFILE_COUNT - 1) && dstPidProfileIndex != srcPidProfileIndex) {
+    if ((dstPidProfileIndex < PID_PROFILE_COUNT && srcPidProfileIndex < PID_PROFILE_COUNT) && dstPidProfileIndex != srcPidProfileIndex) {
         memcpy(pidProfilesMutable(dstPidProfileIndex), pidProfilesMutable(srcPidProfileIndex), sizeof(pidProfile_t));
     }
 }


### PR DESCRIPTION
TL;DR: fixes configurator's Copy profile values to profile 3

---

# Bug Report: pidCopyProfile Bounds Check Rejects Profile 3

## Issue
Copy to PID Profile 3 silently fails when profile count is 3 (boards with >64KB flash).

## Root Cause
**File**: `src/main/flight/pid.c` line 450

```c
// BROKEN (current):
if ((dstPidProfileIndex < PID_PROFILE_COUNT - 1 && srcPidProfileIndex < PID_PROFILE_COUNT - 1) && ...) {
```

**Problem**: 
- `PID_PROFILE_COUNT` = 3 (for HESP, STM32F405, >64KB flash)
- Valid 0-based indices: 0, 1, 2
- Old check: `< PID_PROFILE_COUNT - 1` = `< 2` → only allows 0, 1
- Profile 3 = index 2: `2 < 2` = **false** → copy operation silently rejected

## Solution
```c
// FIXED:
if ((dstPidProfileIndex < PID_PROFILE_COUNT && srcPidProfileIndex < PID_PROFILE_COUNT) && ...) {
```

**Impact**:
- Now correctly allows all valid indices: 0, 1, 2 (when `PID_PROFILE_COUNT` = 3)
- Configurator correctly sends `dst: 2` for "Profile 3" via MSP_COPY_PROFILE
- Firmware now accepts it

## Verification
- Tested: HESP board with 3 profiles, copy from profile 1 to profile 3 now succeeds
- Configurator: Already sends correct MSP values (verified in console logs)

## Affected Versions
- All versions where `PID_PROFILE_COUNT` ≥ 3 (affected boards: HESP, SX10, FLUX, any >64KB STM32)

## Boards Affected
- **HESP** (HELIOSPRING): 1024 KB flash → 3 profiles
- **SX10**: 1024 KB flash → 3 profiles  
- **FLUX**: 1024 KB flash → 3 profiles
- Any board with >64KB flash (per `make/mcu/STM32F4.mk` profile allocation)

## MSP Protocol
- Command: `MSP_COPY_PROFILE` (code 183)
- Payload: `[type, dstProfile, srcProfile]`
- Authenticator: Tested with API 1.54.0 on HESP

## Related
- Configurator already correctly populates 3-profile selectors
- `CONFIG.numProfiles` properly retrieved from `MSP_STATUS_EX`
- Copy dialog shows all non-current profiles (correct behavior)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed overly restrictive validation that prevented copying PID profiles in certain scenarios. Users can now copy profiles in situations that were previously blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->