### PR TITLE
refactor(bus): align naming with Betaflight 4.5-maintenance (phase 1 of N)

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -83,7 +83,7 @@ typedef struct gyroDev_s {
     sensorGyroReadFuncPtr readFn;                             // read 3 axis data function
     sensorGyroReadDataFuncPtr temperatureFn;                  // read temperature if available
     extiCallbackRec_t exti;
-    busDevice_t bus;
+    extDevice_t dev;
     float scale;                                            // scalefactor
     float gyroZero[XYZ_AXIS_COUNT];
     float gyroADC[XYZ_AXIS_COUNT];                        // gyro data after calibration and alignment
@@ -113,7 +113,7 @@ typedef struct accDev_s {
 #endif
     sensorAccInitFuncPtr initFn;                              // initialize function
     sensorAccReadFuncPtr readFn;                              // read 3 axis data function
-    busDevice_t bus;
+    extDevice_t dev;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     mpuDetectionResult_t mpuDetectionResult;

--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -400,9 +400,9 @@ uint8_t imuf9001SpiDetect(const gyroDev_t *gyro) {
     IOInit(IOGetByTag( IO_TAG(MPU_INT_EXTI) ), OWNER_MPU_EXTI, 0);
     IOConfigGPIO(IOGetByTag( IO_TAG(MPU_INT_EXTI) ), IOCFG_IPD);
     delayMicroseconds(100);
-    IOInit(gyro->bus.busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(gyro->bus.busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(gyro->bus.busdev_u.spi.csnPin);
+    IOInit(gyro->bus.busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(gyro->bus.busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(gyro->bus.busType_u.spi.csnPin);
     hardwareInitialised = true;
     for (int x = 0; x < 3; x++) {
         if (x) {

--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -217,7 +217,7 @@ FAST_CODE static int imuf9001SendReceiveCommand(const gyroDev_t *gyro, gyroComma
         delayMicroseconds(1000);
         if( IORead(IOGetByTag(IO_TAG(MPU_INT_EXTI))) ) { //IMU is ready to talk
             failCount -= 100;
-            if (imufSendReceiveSpiBlocking(&(gyro->bus), (uint8_t *)&command, (uint8_t *)reply, sizeof(imufCommand_t))) {
+            if (imufSendReceiveSpiBlocking(&(gyro->dev), (uint8_t *)&command, (uint8_t *)reply, sizeof(imufCommand_t))) {
                 crcCalc = getCrcImuf9001((uint32_t *)reply, 11);
                 //this is the only valid reply we'll get if we're in BL mode
                 if(crcCalc == reply->crc && (reply->command == IMUF_COMMAND_LISTENING || reply->command == BL_LISTENING)) { //this tells us the IMU was listening for a command, else we need to reset synbc
@@ -236,7 +236,7 @@ FAST_CODE static int imuf9001SendReceiveCommand(const gyroDev_t *gyro, gyroComma
                             //reset attempts
                             attempt = 100;
                             delayMicroseconds(1000); //give pin time to set
-                            imufSendReceiveSpiBlocking(&(gyro->bus), (uint8_t *)&command, (uint8_t *)reply, sizeof(imufCommand_t));
+                            imufSendReceiveSpiBlocking(&(gyro->dev), (uint8_t *)&command, (uint8_t *)reply, sizeof(imufCommand_t));
                             crcCalc = getCrcImuf9001((uint32_t *)reply, 11);
                             if(crcCalc == reply->crc && reply->command == commandToSend ) { //this tells us the IMU understood the last command
                                 return 1;
@@ -400,9 +400,9 @@ uint8_t imuf9001SpiDetect(const gyroDev_t *gyro) {
     IOInit(IOGetByTag( IO_TAG(MPU_INT_EXTI) ), OWNER_MPU_EXTI, 0);
     IOConfigGPIO(IOGetByTag( IO_TAG(MPU_INT_EXTI) ), IOCFG_IPD);
     delayMicroseconds(100);
-    IOInit(gyro->bus.busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(gyro->bus.busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(gyro->bus.busType_u.spi.csnPin);
+    IOInit(gyro->dev.busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(gyro->dev.busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(gyro->dev.busType_u.spi.csnPin);
     hardwareInitialised = true;
     for (int x = 0; x < 3; x++) {
         if (x) {

--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -197,7 +197,7 @@ void initImuf9001(void) {
 }
 
 FAST_CODE bool imufSendReceiveSpiBlocking(const busDevice_t *bus, uint8_t *dataTx, uint8_t *daRx, uint8_t length) {
-    spiBusTransfer(bus, dataTx, daRx, length);
+    spiReadWriteBuf(bus, dataTx, daRx, length);
     return true;
 }
 

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -281,7 +281,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, MPU6000_SPI_INSTANCE);
 #endif
 #ifdef MPU6000_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = mpu6000SpiDetect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -294,7 +294,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, MPU6500_SPI_INSTANCE);
 #endif
 #ifdef MPU6500_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = mpu6500SpiDetect(&gyro->bus);
     // some targets using MPU_9250_SPI, ICM_20608_SPI or ICM_20602_SPI state sensor is MPU_65xx_SPI
@@ -310,12 +310,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #error IMUF9001 is SPI only
 #endif
 #ifdef IMUF9001_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(IMUF9001_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(IMUF9001_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #else
 #error IMUF9001 must use a CS pin (IMUF9001_CS_PIN)
 #endif
 #ifdef IMUF9001_RST_PIN
-    gyro->bus.busdev_u.spi.rstPin = IOGetByTag(IO_TAG(IMUF9001_RST_PIN));
+    gyro->bus.busType_u.spi.rstPin = IOGetByTag(IO_TAG(IMUF9001_RST_PIN));
 #else
 #error IMUF9001 must use a RST pin (IMUF9001_RST_PIN)
 #endif
@@ -331,7 +331,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, MPU9250_SPI_INSTANCE);
 #endif
 #ifdef MPU9250_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = mpu9250SpiDetect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -345,7 +345,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, ICM20649_SPI_INSTANCE);
 #endif
 #ifdef ICM20649_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20649_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20649_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = icm20649SpiDetect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -358,7 +358,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, ICM20689_SPI_INSTANCE);
 #endif
 #ifdef ICM20689_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = icm20689SpiDetect(&gyro->bus);
     // icm20689SpiDetect detects ICM20602 and ICM20689
@@ -372,7 +372,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, ICM42605_SPI_INSTANCE);
 #endif
 #ifdef ICM42605_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42605_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42605_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = icm426xxSpiDetect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -385,7 +385,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, ICM42688P_SPI_INSTANCE);
 #endif
 #ifdef ICM42688P_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42688P_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42688P_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = icm426xxSpiDetect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -398,7 +398,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, BMI160_SPI_INSTANCE);
 #endif
 #ifdef BMI160_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = bmi160Detect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -411,7 +411,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     spiBusSetInstance(&gyro->bus, BMI270_SPI_INSTANCE);
 #endif
 #ifdef BMI270_CS_PIN
-    gyro->bus.busdev_u.spi.csnPin = gyro->bus.busdev_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI270_CS_PIN)) : gyro->bus.busdev_u.spi.csnPin;
+    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI270_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
 #endif
     sensor = bmi270Detect(&gyro->bus);
     if (sensor != MPU_NONE) {
@@ -427,13 +427,13 @@ void mpuDetect(gyroDev_t *gyro) {
     // MPU datasheet specifies 30ms.
     delay(35);
 #if defined(USE_I2C) && !defined(USE_DMA_SPI_DEVICE)
-    if (gyro->bus.bustype == BUS_TYPE_NONE) {
-        // if no bustype is selected try I2C first.
-        gyro->bus.bustype = BUS_TYPE_I2C;
+    if (gyro->bus.busType == BUS_TYPE_NONE) {
+        // if no busType is selected try I2C first.
+        gyro->bus.busType = BUS_TYPE_I2C;
     }
-    if (gyro->bus.bustype == BUS_TYPE_I2C) {
-        gyro->bus.busdev_u.i2c.device = MPU_I2C_INSTANCE;
-        gyro->bus.busdev_u.i2c.address = MPU_ADDRESS;
+    if (gyro->bus.busType == BUS_TYPE_I2C) {
+        gyro->bus.busType_u.i2c.device = MPU_I2C_INSTANCE;
+        gyro->bus.busType_u.i2c.address = MPU_ADDRESS;
         uint8_t sig = 0;
         bool ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_WHO_AM_I, &sig, 1);
         if (ack) {
@@ -457,7 +457,7 @@ void mpuDetect(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_SPI
-    gyro->bus.bustype = BUS_TYPE_SPI;
+    gyro->bus.busType = BUS_TYPE_SPI;
     detectSPISensorsAndUpdateDetectionResult(gyro);
 #endif
 }

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -89,7 +89,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro) {
     // See https://android.googlesource.com/kernel/msm.git/+/eaf36994a3992b8f918c18e4f7411e8b2320a35f/drivers/misc/mpu6050/mldl_cfg.c
     // determine product ID and revision
     uint8_t readBuffer[6];
-    bool ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_XA_OFFS_H, readBuffer, 6);
+    bool ack = busReadRegisterBuffer(&gyro->dev, MPU_RA_XA_OFFS_H, readBuffer, 6);
     uint8_t revision = ((readBuffer[5] & 0x01) << 2) | ((readBuffer[3] & 0x01) << 1) | (readBuffer[1] & 0x01);
     if (ack && revision) {
         // Congrats, these parts are better
@@ -104,7 +104,7 @@ static void mpu6050FindRevision(gyroDev_t *gyro) {
         }
     } else {
         uint8_t productId;
-        ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_PRODUCT_ID, &productId, 1);
+        ack = busReadRegisterBuffer(&gyro->dev, MPU_RA_PRODUCT_ID, &productId, 1);
         revision = productId & 0x0F;
         if (!ack || revision == 0) {
             failureMode(FAILURE_ACC_INCOMPATIBLE);
@@ -169,7 +169,7 @@ static void mpuIntExtiInit(gyroDev_t *gyro) {
 
 bool mpuAccRead(accDev_t *acc) {
     uint8_t data[6];
-    const bool ack = busReadRegisterBuffer(&acc->bus, MPU_RA_ACCEL_XOUT_H, data, 6);
+    const bool ack = busReadRegisterBuffer(&acc->dev, MPU_RA_ACCEL_XOUT_H, data, 6);
     if (!ack) {
         return false;
     }
@@ -247,7 +247,7 @@ FAST_CODE void mpuGyroDmaSpiReadFinish(gyroDev_t * gyro) {
 
 FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
     uint8_t data[6];
-    const bool ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_GYRO_XOUT_H, data, 6);
+    const bool ack = busReadRegisterBuffer(&gyro->dev, MPU_RA_GYRO_XOUT_H, data, 6);
     if (!ack) {
         return false;
     }
@@ -260,7 +260,7 @@ FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
 FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     uint8_t data[7];
-    const bool ack = spiBusTransfer(&gyro->bus, dataToSend, data, 7);
+    const bool ack = spiBusTransfer(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }
@@ -275,15 +275,15 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     UNUSED(gyro); // since there are FCs which have gyro on I2C but other devices on SPI
     uint8_t sensor = MPU_NONE;
     UNUSED(sensor);
-    // note, when USE_DUAL_GYRO is enabled the gyro->bus must already be initialised.
+    // note, when USE_DUAL_GYRO is enabled the gyro->dev must already be initialised.
 #ifdef USE_GYRO_SPI_MPU6000
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->bus, MPU6000_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, MPU6000_SPI_INSTANCE);
 #endif
 #ifdef MPU6000_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = mpu6000SpiDetect(&gyro->bus);
+    sensor = mpu6000SpiDetect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         return true;
@@ -291,12 +291,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_MPU6500
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->bus, MPU6500_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, MPU6500_SPI_INSTANCE);
 #endif
 #ifdef MPU6500_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = mpu6500SpiDetect(&gyro->bus);
+    sensor = mpu6500SpiDetect(&gyro->dev);
     // some targets using MPU_9250_SPI, ICM_20608_SPI or ICM_20602_SPI state sensor is MPU_65xx_SPI
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
@@ -305,17 +305,17 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_IMUF9001
 #ifdef IMUF9001_SPI_INSTANCE
-    spiBusSetInstance(&gyro->bus, IMUF9001_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, IMUF9001_SPI_INSTANCE);
 #else
 #error IMUF9001 is SPI only
 #endif
 #ifdef IMUF9001_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(IMUF9001_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(IMUF9001_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #else
 #error IMUF9001 must use a CS pin (IMUF9001_CS_PIN)
 #endif
 #ifdef IMUF9001_RST_PIN
-    gyro->bus.busType_u.spi.rstPin = IOGetByTag(IO_TAG(IMUF9001_RST_PIN));
+    gyro->dev.busType_u.spi.rstPin = IOGetByTag(IO_TAG(IMUF9001_RST_PIN));
 #else
 #error IMUF9001 must use a RST pin (IMUF9001_RST_PIN)
 #endif
@@ -328,12 +328,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef  USE_GYRO_SPI_MPU9250
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->bus, MPU9250_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, MPU9250_SPI_INSTANCE);
 #endif
 #ifdef MPU9250_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = mpu9250SpiDetect(&gyro->bus);
+    sensor = mpu9250SpiDetect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         gyro->mpuConfiguration.resetFn = mpu9250SpiResetGyro;
@@ -342,12 +342,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_ICM20649
 #ifdef ICM20649_SPI_INSTANCE
-    spiBusSetInstance(&gyro->bus, ICM20649_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, ICM20649_SPI_INSTANCE);
 #endif
 #ifdef ICM20649_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20649_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20649_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = icm20649SpiDetect(&gyro->bus);
+    sensor = icm20649SpiDetect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         return true;
@@ -355,12 +355,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_ICM20689
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->bus, ICM20689_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, ICM20689_SPI_INSTANCE);
 #endif
 #ifdef ICM20689_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = icm20689SpiDetect(&gyro->bus);
+    sensor = icm20689SpiDetect(&gyro->dev);
     // icm20689SpiDetect detects ICM20602 and ICM20689
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
@@ -369,12 +369,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_ICM42605
 #ifdef ICM42605_SPI_INSTANCE
-    spiBusSetInstance(&gyro->bus, ICM42605_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, ICM42605_SPI_INSTANCE);
 #endif
 #ifdef ICM42605_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42605_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42605_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = icm426xxSpiDetect(&gyro->bus);
+    sensor = icm426xxSpiDetect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         return true;
@@ -382,12 +382,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_ICM42688P
 #ifdef ICM42688P_SPI_INSTANCE
-    spiBusSetInstance(&gyro->bus, ICM42688P_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, ICM42688P_SPI_INSTANCE);
 #endif
 #ifdef ICM42688P_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42688P_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42688P_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = icm426xxSpiDetect(&gyro->bus);
+    sensor = icm426xxSpiDetect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         return true;
@@ -395,12 +395,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_ACCGYRO_BMI160
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->bus, BMI160_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, BMI160_SPI_INSTANCE);
 #endif
 #ifdef BMI160_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = bmi160Detect(&gyro->bus);
+    sensor = bmi160Detect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         return true;
@@ -408,12 +408,12 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_ACCGYRO_BMI270
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->bus, BMI270_SPI_INSTANCE);
+    spiBusSetInstance(&gyro->dev, BMI270_SPI_INSTANCE);
 #endif
 #ifdef BMI270_CS_PIN
-    gyro->bus.busType_u.spi.csnPin = gyro->bus.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI270_CS_PIN)) : gyro->bus.busType_u.spi.csnPin;
+    gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI270_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
 #endif
-    sensor = bmi270Detect(&gyro->bus);
+    sensor = bmi270Detect(&gyro->dev);
     if (sensor != MPU_NONE) {
         gyro->mpuDetectionResult.sensor = sensor;
         return true;
@@ -427,19 +427,19 @@ void mpuDetect(gyroDev_t *gyro) {
     // MPU datasheet specifies 30ms.
     delay(35);
 #if defined(USE_I2C) && !defined(USE_DMA_SPI_DEVICE)
-    if (gyro->bus.busType == BUS_TYPE_NONE) {
+    if (gyro->dev.busType == BUS_TYPE_NONE) {
         // if no busType is selected try I2C first.
-        gyro->bus.busType = BUS_TYPE_I2C;
+        gyro->dev.busType = BUS_TYPE_I2C;
     }
-    if (gyro->bus.busType == BUS_TYPE_I2C) {
-        gyro->bus.busType_u.i2c.device = MPU_I2C_INSTANCE;
-        gyro->bus.busType_u.i2c.address = MPU_ADDRESS;
+    if (gyro->dev.busType == BUS_TYPE_I2C) {
+        gyro->dev.busType_u.i2c.device = MPU_I2C_INSTANCE;
+        gyro->dev.busType_u.i2c.address = MPU_ADDRESS;
         uint8_t sig = 0;
-        bool ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_WHO_AM_I, &sig, 1);
+        bool ack = busReadRegisterBuffer(&gyro->dev, MPU_RA_WHO_AM_I, &sig, 1);
         if (ack) {
             // If an MPU3050 is connected sig will contain 0.
             uint8_t inquiryResult;
-            ack = busReadRegisterBuffer(&gyro->bus, MPU_RA_WHO_AM_I_LEGACY, &inquiryResult, 1);
+            ack = busReadRegisterBuffer(&gyro->dev, MPU_RA_WHO_AM_I_LEGACY, &inquiryResult, 1);
             inquiryResult &= MPU_INQUIRY_MASK;
             if (ack && inquiryResult == MPUx0x0_WHO_AM_I_CONST) {
                 gyro->mpuDetectionResult.sensor = MPU_3050;
@@ -457,7 +457,7 @@ void mpuDetect(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_SPI
-    gyro->bus.busType = BUS_TYPE_SPI;
+    gyro->dev.busType = BUS_TYPE_SPI;
     detectSPISensorsAndUpdateDetectionResult(gyro);
 #endif
 }

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -260,7 +260,7 @@ FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
 FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     uint8_t data[7];
-    const bool ack = spiBusTransfer(&gyro->dev, dataToSend, data, 7);
+    const bool ack = spiReadWriteBuf(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -427,11 +427,11 @@ void mpuDetect(gyroDev_t *gyro) {
     // MPU datasheet specifies 30ms.
     delay(35);
 #if defined(USE_I2C) && !defined(USE_DMA_SPI_DEVICE)
-    if (gyro->bus.bustype == BUSTYPE_NONE) {
+    if (gyro->bus.bustype == BUS_TYPE_NONE) {
         // if no bustype is selected try I2C first.
-        gyro->bus.bustype = BUSTYPE_I2C;
+        gyro->bus.bustype = BUS_TYPE_I2C;
     }
-    if (gyro->bus.bustype == BUSTYPE_I2C) {
+    if (gyro->bus.bustype == BUS_TYPE_I2C) {
         gyro->bus.busdev_u.i2c.device = MPU_I2C_INSTANCE;
         gyro->bus.busdev_u.i2c.address = MPU_ADDRESS;
         uint8_t sig = 0;
@@ -457,7 +457,7 @@ void mpuDetect(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_SPI
-    gyro->bus.bustype = BUSTYPE_SPI;
+    gyro->bus.bustype = BUS_TYPE_SPI;
     detectSPISensorsAndUpdateDetectionResult(gyro);
 #endif
 }

--- a/src/main/drivers/accgyro/accgyro_mpu3050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu3050.c
@@ -65,19 +65,19 @@ static uint8_t mpu3050GetDLPF(uint8_t lpf) {
 
 static void mpu3050Init(gyroDev_t *gyro) {
     delay(25); // datasheet page 13 says 20ms. other stuff could have been running meanwhile. but we'll be safe
-    const bool ack = busWriteRegister(&gyro->bus, MPU3050_SMPLRT_DIV, 0);
+    const bool ack = busWriteRegister(&gyro->dev, MPU3050_SMPLRT_DIV, 0);
     if (!ack) {
         failureMode(FAILURE_ACC_INIT);
     }
-    busWriteRegister(&gyro->bus, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | mpu3050GetDLPF(gyro->hardware_lpf));
-    busWriteRegister(&gyro->bus, MPU3050_INT_CFG, 0);
-    busWriteRegister(&gyro->bus, MPU3050_USER_CTRL, MPU3050_USER_RESET);
-    busWriteRegister(&gyro->bus, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
+    busWriteRegister(&gyro->dev, MPU3050_DLPF_FS_SYNC, MPU3050_FS_SEL_2000DPS | mpu3050GetDLPF(gyro->hardware_lpf));
+    busWriteRegister(&gyro->dev, MPU3050_INT_CFG, 0);
+    busWriteRegister(&gyro->dev, MPU3050_USER_CTRL, MPU3050_USER_RESET);
+    busWriteRegister(&gyro->dev, MPU3050_PWR_MGM, MPU3050_CLK_SEL_PLL_GX);
 }
 
 static bool mpu3050GyroRead(gyroDev_t *gyro) {
     uint8_t data[6];
-    const bool ack = busReadRegisterBuffer(&gyro->bus, MPU3050_GYRO_OUT, data, 6);
+    const bool ack = busReadRegisterBuffer(&gyro->dev, MPU3050_GYRO_OUT, data, 6);
     if (!ack) {
         return false;
     }
@@ -89,7 +89,7 @@ static bool mpu3050GyroRead(gyroDev_t *gyro) {
 
 static bool mpu3050ReadTemperature(gyroDev_t *gyro, int16_t *tempData) {
     uint8_t buf[2];
-    if (!busReadRegisterBuffer(&gyro->bus, MPU3050_TEMP_OUT, buf, 2)) {
+    if (!busReadRegisterBuffer(&gyro->dev, MPU3050_TEMP_OUT, buf, 2)) {
         return false;
     }
     *tempData = 35 + ((int32_t)(buf[0] << 8 | buf[1]) + 13200) / 280;

--- a/src/main/drivers/accgyro/accgyro_mpu6050.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6050.c
@@ -73,20 +73,20 @@ bool mpu6050AccDetect(accDev_t *acc) {
 
 static void mpu6050GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
+    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x80);      //PWR_MGMT_1    -- DEVICE_RESET 1
     delay(100);
-    busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
-    busWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
+    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0x03); //PWR_MGMT_1    -- SLEEP 0; CYCLE 0; TEMP_DIS 0; CLKSEL 3 (PLL with Z Gyro reference)
+    busWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); //SMPLRT_DIV    -- SMPLRT_DIV = 0  Sample Rate = Gyroscope Output Rate / (1 + SMPLRT_DIV)
     delay(15); //PLL Settling time when changing CLKSEL is max 10ms.  Use 15ms to be sure
-    busWriteRegister(&gyro->bus, MPU_RA_CONFIG, mpuGyroDLPF(gyro)); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
-    busWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
+    busWriteRegister(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro)); //CONFIG        -- EXT_SYNC_SET 0 (disable input pin for data sync) ; default DLPF_CFG = 0 => ACC bandwidth = 260Hz  GYRO bandwidth = 256Hz)
+    busWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);   //GYRO_CONFIG   -- FS_SEL = 3: Full scale set to 2000 deg/sec
     // ACC Init stuff.
     // Accel scale 8g (4096 LSB/g)
-    busWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
-    busWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG,
+    busWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    busWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG,
                      0 << 7 | 0 << 6 | 0 << 5 | 0 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0); // INT_PIN_CFG   -- INT_LEVEL_HIGH, INT_OPEN_DIS, LATCH_INT_DIS, INT_RD_CLEAR_DIS, FSYNC_INT_LEVEL_HIGH, FSYNC_INT_DIS, I2C_BYPASS_EN, CLOCK_DIS
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    busWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    busWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
 }
 

--- a/src/main/drivers/accgyro/accgyro_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_mpu6500.c
@@ -56,31 +56,31 @@ void mpu6500GyroInit(gyroDev_t *gyro) {
         gyro_range = gyro->gyro_high_fsr ? ICM_HIGH_RANGE_FSR_4000DPS : ICM_HIGH_RANGE_FSR_2000DPS;
         accel_range = ICM_HIGH_RANGE_FSR_16G;
     }
-    busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
+    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU6500_BIT_RESET);
     delay(100);
-    busWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, 0x07);
+    busWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x07);
     delay(100);
-    busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, 0);
+    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
     delay(100);
-    busWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    busWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    busWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, gyro_range << 3 | mpuGyroFCHOICE(gyro));
+    busWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, gyro_range << 3 | mpuGyroFCHOICE(gyro));
     delay(15);
-    busWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, accel_range << 3);
+    busWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, accel_range << 3);
     delay(15);
-    busWriteRegister(&gyro->bus, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
+    busWriteRegister(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
     delay(15);
-    busWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
+    busWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
     delay(100);
     // Data ready interrupt configuration
 #ifdef USE_MPU9250_MAG
-    busWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    busWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #else
-    busWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
+    busWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);  // INT_ANYRD_2CLEAR
 #endif
     delay(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    busWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
+    busWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU6500_BIT_RAW_RDY_EN); // RAW_RDY_EN interrupt enable
 #endif
     delay(15);
 }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -244,9 +244,9 @@ bool bmi160AccRead(accDev_t *acc) {
     };
     uint8_t bmi160_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
-    IOLo(acc->bus.busType_u.spi.csnPin);
-    spiTransfer(acc->bus.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(acc->bus.busType_u.spi.csnPin);
+    IOLo(acc->dev.busType_u.spi.csnPin);
+    spiTransfer(acc->dev.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(acc->dev.busType_u.spi.csnPin);
     acc->ADCRaw[X] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_YOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_YOUT_L]);
     acc->ADCRaw[Z] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_ZOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_ZOUT_L]);
@@ -267,9 +267,9 @@ bool bmi160GyroRead(gyroDev_t *gyro) {
     };
     uint8_t bmi160_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
-    IOLo(gyro->bus.busType_u.spi.csnPin);
-    spiTransfer(gyro->bus.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->bus.busType_u.spi.csnPin);
+    IOLo(gyro->dev.busType_u.spi.csnPin);
+    spiTransfer(gyro->dev.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->dev.busType_u.spi.csnPin);
     gyro->gyroADCRaw[X] = (int16_t)((bmi160_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi160_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_YOUT_L]);
     gyro->gyroADCRaw[Z] = (int16_t)((bmi160_rx_buf[IDX_GYRO_ZOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_ZOUT_L]);
@@ -278,18 +278,18 @@ bool bmi160GyroRead(gyroDev_t *gyro) {
 
 
 void bmi160SpiGyroInit(gyroDev_t *gyro) {
-    BMI160_Init(&gyro->bus);
+    BMI160_Init(&gyro->dev);
     bmi160IntExtiInit(gyro);
 }
 
 void bmi160SpiAccInit(accDev_t *acc) {
-    BMI160_Init(&acc->bus);
+    BMI160_Init(&acc->dev);
     acc->acc_1G = 512 * 8;
 }
 
 
 bool bmi160SpiAccDetect(accDev_t *acc) {
-    if (bmi160Detect(&acc->bus) == MPU_NONE) {
+    if (bmi160Detect(&acc->dev) == MPU_NONE) {
         return false;
     }
     acc->initFn = bmi160SpiAccInit;
@@ -299,7 +299,7 @@ bool bmi160SpiAccDetect(accDev_t *acc) {
 
 
 bool bmi160SpiGyroDetect(gyroDev_t *gyro) {
-    if (bmi160Detect(&gyro->bus) == MPU_NONE) {
+    if (bmi160Detect(&gyro->dev) == MPU_NONE) {
         return false;
     }
     gyro->initFn = bmi160SpiGyroInit;

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -102,10 +102,10 @@ uint8_t bmi160Detect(const busDevice_t *bus) {
 #endif
     spiSetDivisor(bus->busType_u.spi.instance, BMI160_SPI_DIVISOR);
     /* Read this address to activate SPI (see p. 84) */
-    spiBusReadRegister(bus, 0x7F);
+    spiReadReg(bus, 0x7F);
     delay(100); // Give SPI some time to start up
     /* Check the chip ID */
-    if (spiBusReadRegister(bus, BMI160_REG_CHIPID) != 0xd1) {
+    if (spiReadReg(bus, BMI160_REG_CHIPID) != 0xd1) {
         return MPU_NONE;
     }
     BMI160Detected = true;
@@ -139,37 +139,37 @@ static void BMI160_Init(const busDevice_t *bus) {
  */
 static int32_t BMI160_Config(const busDevice_t *bus) {
     // Set normal power mode for gyro and accelerometer
-    spiBusWriteRegister(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_GYR_NORMAL);
+    spiWriteReg(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_GYR_NORMAL);
     delay(100); // can take up to 80ms
-    spiBusWriteRegister(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_ACC_NORMAL);
+    spiWriteReg(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_ACC_NORMAL);
     delay(5); // can take up to 3.8ms
     // Verify that normal power mode was entered
-    uint8_t pmu_status = spiBusReadRegister(bus, BMI160_REG_PMU_STAT);
+    uint8_t pmu_status = spiReadReg(bus, BMI160_REG_PMU_STAT);
     if ((pmu_status & 0x3C) != 0x14) {
         return -3;
     }
     // Set odr and ranges
     // Set acc_us = 0 acc_bwp = 0b010 so only the first filter stage is used
-    spiBusWriteRegister(bus, BMI160_REG_ACC_CONF, 0x20 | BMI160_ODR_800_Hz);
+    spiWriteReg(bus, BMI160_REG_ACC_CONF, 0x20 | BMI160_ODR_800_Hz);
     delay(1);
     // Set gyr_bwp = 0b010 so only the first filter stage is used
-    spiBusWriteRegister(bus, BMI160_REG_GYR_CONF, 0x20 | BMI160_ODR_3200_Hz);
+    spiWriteReg(bus, BMI160_REG_GYR_CONF, 0x20 | BMI160_ODR_3200_Hz);
     delay(1);
-    spiBusWriteRegister(bus, BMI160_REG_ACC_RANGE, BMI160_RANGE_8G);
+    spiWriteReg(bus, BMI160_REG_ACC_RANGE, BMI160_RANGE_8G);
     delay(1);
-    spiBusWriteRegister(bus, BMI160_REG_GYR_RANGE, BMI160_RANGE_2000DPS);
+    spiWriteReg(bus, BMI160_REG_GYR_RANGE, BMI160_RANGE_2000DPS);
     delay(1);
     // Enable offset compensation
-    uint8_t val = spiBusReadRegister(bus, BMI160_REG_OFFSET_0);
-    spiBusWriteRegister(bus, BMI160_REG_OFFSET_0, val | 0xC0);
+    uint8_t val = spiReadReg(bus, BMI160_REG_OFFSET_0);
+    spiWriteReg(bus, BMI160_REG_OFFSET_0, val | 0xC0);
     // Enable data ready interrupt
-    spiBusWriteRegister(bus, BMI160_REG_INT_EN1, BMI160_INT_EN1_DRDY);
+    spiWriteReg(bus, BMI160_REG_INT_EN1, BMI160_INT_EN1_DRDY);
     delay(1);
     // Enable INT1 pin
-    spiBusWriteRegister(bus, BMI160_REG_INT_OUT_CTRL, BMI160_INT_OUT_CTRL_INT1_CONFIG);
+    spiWriteReg(bus, BMI160_REG_INT_OUT_CTRL, BMI160_INT_OUT_CTRL_INT1_CONFIG);
     delay(1);
     // Map data ready interrupt to INT1 pin
-    spiBusWriteRegister(bus, BMI160_REG_INT_MAP1, BMI160_REG_INT_MAP1_INT1_DRDY);
+    spiWriteReg(bus, BMI160_REG_INT_MAP1, BMI160_REG_INT_MAP1_INT1_DRDY);
     delay(1);
     return 0;
 }
@@ -177,12 +177,12 @@ static int32_t BMI160_Config(const busDevice_t *bus) {
 static int32_t BMI160_do_foc(const busDevice_t *bus) {
     // assume sensor is mounted on top
     uint8_t val = 0x7D;;
-    spiBusWriteRegister(bus, BMI160_REG_FOC_CONF, val);
+    spiWriteReg(bus, BMI160_REG_FOC_CONF, val);
     // Start FOC
-    spiBusWriteRegister(bus, BMI160_REG_CMD, BMI160_CMD_START_FOC);
+    spiWriteReg(bus, BMI160_REG_CMD, BMI160_CMD_START_FOC);
     // Wait for FOC to complete
     for (int i = 0; i < 50; i++) {
-        val = spiBusReadRegister(bus, BMI160_REG_STATUS);
+        val = spiReadReg(bus, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_FOC_RDY) {
             break;
         }
@@ -192,12 +192,12 @@ static int32_t BMI160_do_foc(const busDevice_t *bus) {
         return -3;
     }
     // Program NVM
-    val = spiBusReadRegister(bus, BMI160_REG_CONF);
-    spiBusWriteRegister(bus, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN);
-    spiBusWriteRegister(bus, BMI160_REG_CMD, BMI160_CMD_PROG_NVM);
+    val = spiReadReg(bus, BMI160_REG_CONF);
+    spiWriteReg(bus, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN);
+    spiWriteReg(bus, BMI160_REG_CMD, BMI160_CMD_PROG_NVM);
     // Wait for NVM programming to complete
     for (int i = 0; i < 50; i++) {
-        val = spiBusReadRegister(bus, BMI160_REG_STATUS);
+        val = spiReadReg(bus, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_NVM_RDY) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -96,11 +96,11 @@ uint8_t bmi160Detect(const busDevice_t *bus) {
         return BMI_160_SPI;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busdev_u.spi.instance, BMI160_SPI_DIVISOR);
+    spiSetDivisor(bus->busType_u.spi.instance, BMI160_SPI_DIVISOR);
     /* Read this address to activate SPI (see p. 84) */
     spiBusReadRegister(bus, 0x7F);
     delay(100); // Give SPI some time to start up
@@ -244,9 +244,9 @@ bool bmi160AccRead(accDev_t *acc) {
     };
     uint8_t bmi160_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
-    IOLo(acc->bus.busdev_u.spi.csnPin);
-    spiTransfer(acc->bus.busdev_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(acc->bus.busdev_u.spi.csnPin);
+    IOLo(acc->bus.busType_u.spi.csnPin);
+    spiTransfer(acc->bus.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(acc->bus.busType_u.spi.csnPin);
     acc->ADCRaw[X] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_YOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_YOUT_L]);
     acc->ADCRaw[Z] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_ZOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_ZOUT_L]);
@@ -267,9 +267,9 @@ bool bmi160GyroRead(gyroDev_t *gyro) {
     };
     uint8_t bmi160_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
-    IOLo(gyro->bus.busdev_u.spi.csnPin);
-    spiTransfer(gyro->bus.busdev_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->bus.busdev_u.spi.csnPin);
+    IOLo(gyro->bus.busType_u.spi.csnPin);
+    spiTransfer(gyro->bus.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->bus.busType_u.spi.csnPin);
     gyro->gyroADCRaw[X] = (int16_t)((bmi160_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi160_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_YOUT_L]);
     gyro->gyroADCRaw[Z] = (int16_t)((bmi160_rx_buf[IDX_GYRO_ZOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_ZOUT_L]);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -150,7 +150,7 @@ static uint8_t bmi270RegisterRead(const busDevice_t *bus, bmi270Register_e regis
 {
     uint8_t data[2] = { 0, 0 };
 
-    if (spiBusReadRegisterBuffer(bus, registerId, data, 2)) {
+    if (spiReadRegBuf(bus, registerId, data, 2)) {
         return data[1];
     } else {
         return 0;
@@ -159,7 +159,7 @@ static uint8_t bmi270RegisterRead(const busDevice_t *bus, bmi270Register_e regis
 
 static void bmi270RegisterWrite(const busDevice_t *bus, bmi270Register_e registerId, uint8_t value, unsigned delayMs)
 {
-    spiBusWriteRegister(bus, registerId, value);
+    spiWriteReg(bus, registerId, value);
     if (delayMs) {
         delay(delayMs);
     }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -221,7 +221,7 @@ static uint8_t getBmiOsrMode()
 
 static void bmi270Config(const gyroDev_t *gyro)
 {
-    const busDevice_t *bus = &gyro->bus;
+    const busDevice_t *bus = &gyro->dev;
 
     // If running in hardware_lpf experimental mode then switch to FIFO-based,
     // 6.4KHz sampling, unfiltered data vs. the default 3.2KHz with hardware filtering
@@ -326,9 +326,9 @@ static bool bmi270AccRead(accDev_t *acc)
     uint8_t bmi270_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
 
-    IOLo(acc->bus.busType_u.spi.csnPin);
-    spiTransfer(acc->bus.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(acc->bus.busType_u.spi.csnPin);
+    IOLo(acc->dev.busType_u.spi.csnPin);
+    spiTransfer(acc->dev.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(acc->dev.busType_u.spi.csnPin);
 
     acc->ADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_YOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_YOUT_L]);
@@ -354,9 +354,9 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
     uint8_t bmi270_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
 
-    IOLo(gyro->bus.busType_u.spi.csnPin);
-    spiTransfer(gyro->bus.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->bus.busType_u.spi.csnPin);
+    IOLo(gyro->dev.busType_u.spi.csnPin);
+    spiTransfer(gyro->dev.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->dev.busType_u.spi.csnPin);
 
     gyro->gyroADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_YOUT_L]);
@@ -389,9 +389,9 @@ static bool bmi270GyroReadFifo(gyroDev_t *gyro)
     // Burst read the FIFO length followed by the next 6 bytes containing the gyro axis data for
     // the first sample in the queue. It's possible for the FIFO to be empty so we need to check the
     // length before using the sample.
-    IOLo(gyro->bus.busType_u.spi.csnPin);
-    spiTransfer(gyro->bus.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->bus.busType_u.spi.csnPin);
+    IOLo(gyro->dev.busType_u.spi.csnPin);
+    spiTransfer(gyro->dev.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->dev.busType_u.spi.csnPin);
 
     int fifoLength = (uint16_t)((bmi270_rx_buf[IDX_FIFO_LENGTH_H] << 8) | bmi270_rx_buf[IDX_FIFO_LENGTH_L]);
 
@@ -423,7 +423,7 @@ static bool bmi270GyroReadFifo(gyroDev_t *gyro)
     // would end up in a lock state of always re-reading the same partial or invalid sample.
     if (fifoLength > 0) {
         // Partial or additional frames left - flush the FIFO
-        bmi270RegisterWrite(&gyro->bus, BMI270_REG_CMD, BMI270_VAL_CMD_FIFOFLUSH, 0);
+        bmi270RegisterWrite(&gyro->dev, BMI270_REG_CMD, BMI270_VAL_CMD_FIFOFLUSH, 0);
     }
 
     return dataRead;
@@ -494,6 +494,6 @@ bool bmi270SpiGyroDetect(gyroDev_t *gyro)
 // watermark reason as an idication of gyro data ready.
 uint8_t bmi270InterruptStatus(gyroDev_t *gyro)
 {
-    return bmi270RegisterRead(&gyro->bus, BMI270_REG_INT_STATUS_1);
+    return bmi270RegisterRead(&gyro->dev, BMI270_REG_INT_STATUS_1);
 }
 #endif // USE_ACCGYRO_BMI270

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -169,21 +169,21 @@ static void bmi270RegisterWrite(const busDevice_t *bus, bmi270Register_e registe
 // Device switches initializes as I2C and switches to SPI on a low to high CS transition
 static void bmi270EnableSPI(const busDevice_t *bus)
 {
-    IOLo(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
     delay(1);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOHi(bus->busType_u.spi.csnPin);
     delay(10);
 }
 
 uint8_t bmi270Detect(const busDevice_t *bus)
 {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
 
-    spiSetDivisor(bus->busdev_u.spi.instance, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
+    spiSetDivisor(bus->busType_u.spi.instance, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
     bmi270EnableSPI(bus);
 
     if (bmi270RegisterRead(bus, BMI270_REG_CHIP_ID) == BMI270_CHIP_ID) {
@@ -199,10 +199,10 @@ static void bmi270UploadConfig(const busDevice_t *bus)
     bmi270RegisterWrite(bus, BMI270_REG_INIT_CTRL, 0, 1);
 
     // Transfer the config file
-    IOLo(bus->busdev_u.spi.csnPin);
-    spiTransferByte(bus->busdev_u.spi.instance, BMI270_REG_INIT_DATA);
-    spiTransfer(bus->busdev_u.spi.instance, bmi270_maximum_fifo_config_file, NULL, sizeof(bmi270_maximum_fifo_config_file));
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
+    spiTransferByte(bus->busType_u.spi.instance, BMI270_REG_INIT_DATA);
+    spiTransfer(bus->busType_u.spi.instance, bmi270_maximum_fifo_config_file, NULL, sizeof(bmi270_maximum_fifo_config_file));
+    IOHi(bus->busType_u.spi.csnPin);
 
     delay(10);
     bmi270RegisterWrite(bus, BMI270_REG_INIT_CTRL, 1, 1);
@@ -326,9 +326,9 @@ static bool bmi270AccRead(accDev_t *acc)
     uint8_t bmi270_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
 
-    IOLo(acc->bus.busdev_u.spi.csnPin);
-    spiTransfer(acc->bus.busdev_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(acc->bus.busdev_u.spi.csnPin);
+    IOLo(acc->bus.busType_u.spi.csnPin);
+    spiTransfer(acc->bus.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(acc->bus.busType_u.spi.csnPin);
 
     acc->ADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_YOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_YOUT_L]);
@@ -354,9 +354,9 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
     uint8_t bmi270_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
 
-    IOLo(gyro->bus.busdev_u.spi.csnPin);
-    spiTransfer(gyro->bus.busdev_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->bus.busdev_u.spi.csnPin);
+    IOLo(gyro->bus.busType_u.spi.csnPin);
+    spiTransfer(gyro->bus.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->bus.busType_u.spi.csnPin);
 
     gyro->gyroADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_YOUT_L]);
@@ -389,9 +389,9 @@ static bool bmi270GyroReadFifo(gyroDev_t *gyro)
     // Burst read the FIFO length followed by the next 6 bytes containing the gyro axis data for
     // the first sample in the queue. It's possible for the FIFO to be empty so we need to check the
     // length before using the sample.
-    IOLo(gyro->bus.busdev_u.spi.csnPin);
-    spiTransfer(gyro->bus.busdev_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->bus.busdev_u.spi.csnPin);
+    IOLo(gyro->bus.busType_u.spi.csnPin);
+    spiTransfer(gyro->bus.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    IOHi(gyro->bus.busType_u.spi.csnPin);
 
     int fifoLength = (uint16_t)((bmi270_rx_buf[IDX_FIFO_LENGTH_H] << 8) | bmi270_rx_buf[IDX_FIFO_LENGTH_L]);
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -43,19 +43,19 @@ static void icm20649SpiInit(const busDevice_t *bus) {
         return;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
     // all registers can be read/written at full speed (7MHz +-10%)
     // TODO verify that this works at 9MHz and 10MHz on non F7
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
 uint8_t icm20649SpiDetect(const busDevice_t *bus) {
     icm20649SpiInit(bus);
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     spiBusWriteRegister(bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
     spiBusWriteRegister(bus, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
@@ -83,7 +83,7 @@ void icm20649AccInit(accDev_t *acc) {
     // 2,048 LSB/g 16g
     // 1,024 LSB/g 30g
     acc->acc_1G = acc->acc_high_fsr ? 1024 : 2048;
-    spiSetDivisor(acc->bus.busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(acc->bus.busType_u.spi.instance, SPI_CLOCK_STANDARD);
     spiBusWriteRegister(&acc->bus, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
     delay(15);
     const uint8_t acc_fsr = acc->acc_high_fsr ? ICM20649_FSR_30G : ICM20649_FSR_16G;
@@ -105,7 +105,7 @@ bool icm20649SpiAccDetect(accDev_t *acc) {
 
 void icm20649GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
     spiBusWriteRegister(&gyro->bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
     spiBusWriteRegister(&gyro->bus, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -56,14 +56,14 @@ static void icm20649SpiInit(const busDevice_t *bus) {
 uint8_t icm20649SpiDetect(const busDevice_t *bus) {
     icm20649SpiInit(bus);
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
-    spiBusWriteRegister(bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
+    spiWriteReg(bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
-    spiBusWriteRegister(bus, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
+    spiWriteReg(bus, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiBusReadRegister(bus, ICM20649_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(bus, ICM20649_RA_WHO_AM_I);
         if (whoAmI == ICM20649_WHO_AM_I_CONST) {
             icmDetected = ICM_20649_SPI;
         } else {
@@ -84,12 +84,12 @@ void icm20649AccInit(accDev_t *acc) {
     // 1,024 LSB/g 30g
     acc->acc_1G = acc->acc_high_fsr ? 1024 : 2048;
     spiSetDivisor(acc->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD);
-    spiBusWriteRegister(&acc->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
+    spiWriteReg(&acc->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
     delay(15);
     const uint8_t acc_fsr = acc->acc_high_fsr ? ICM20649_FSR_30G : ICM20649_FSR_16G;
-    spiBusWriteRegister(&acc->dev, ICM20649_RA_ACCEL_CONFIG, acc_fsr << 1);
+    spiWriteReg(&acc->dev, ICM20649_RA_ACCEL_CONFIG, acc_fsr << 1);
     delay(15);
-    spiBusWriteRegister(&acc->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // back to bank 0
+    spiWriteReg(&acc->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // back to bank 0
     delay(15);
 }
 
@@ -106,13 +106,13 @@ bool icm20649SpiAccDetect(accDev_t *acc) {
 void icm20649GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
+    spiWriteReg(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
+    spiWriteReg(&gyro->dev, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
     delay(100);
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_PWR_MGMT_1, INV_CLK_PLL);
+    spiWriteReg(&gyro->dev, ICM20649_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
+    spiWriteReg(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
     delay(15);
     const uint8_t gyro_fsr = gyro->gyro_high_fsr ? ICM20649_FSR_4000DPS : ICM20649_FSR_2000DPS;
     // If hardware_lpf is either GYRO_HARDWARE_LPF_NORMAL or GYRO_HARDWARE_LPF_EXPERIMENTAL then the
@@ -122,18 +122,18 @@ void icm20649GyroInit(gyroDev_t *gyro) {
     // the ICM20649 only has a single 9KHz DLPF cutoff.
     uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_1100_Hz ? 0 : 1; // deactivate GYRO_FCHOICE for sample rates over 1kHz (opposite of other invensense chips)
     raGyroConfigData |= gyro_fsr << 1;
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_GYRO_CONFIG_1, raGyroConfigData);
+    spiWriteReg(&gyro->dev, ICM20649_RA_GYRO_CONFIG_1, raGyroConfigData);
     delay(15);
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_GYRO_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
+    spiWriteReg(&gyro->dev, ICM20649_RA_GYRO_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
     delay(100);
     // Data ready interrupt configuration
     // back to bank 0
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4);
+    spiWriteReg(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4);
     delay(15);
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_INT_PIN_CFG, 0x11);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    spiWriteReg(&gyro->dev, ICM20649_RA_INT_PIN_CFG, 0x11);  // INT_ANYRD_2CLEAR, BYPASS_EN
     delay(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiBusWriteRegister(&gyro->dev, ICM20649_RA_INT_ENABLE_1, 0x01);
+    spiWriteReg(&gyro->dev, ICM20649_RA_INT_ENABLE_1, 0x01);
 #endif
 }
 
@@ -151,7 +151,7 @@ bool icm20649SpiGyroDetect(gyroDev_t *gyro) {
 bool icm20649GyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {ICM20649_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     uint8_t data[7];
-    const bool ack = spiBusTransfer(&gyro->dev, dataToSend, data, 7);
+    const bool ack = spiReadWriteBuf(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }
@@ -163,7 +163,7 @@ bool icm20649GyroReadSPI(gyroDev_t *gyro) {
 
 bool icm20649AccRead(accDev_t *acc) {
     uint8_t data[6];
-    const bool ack = spiBusReadRegisterBuffer(&acc->dev, ICM20649_RA_ACCEL_XOUT_H, data, 6);
+    const bool ack = spiReadRegBuf(&acc->dev, ICM20649_RA_ACCEL_XOUT_H, data, 6);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -83,13 +83,13 @@ void icm20649AccInit(accDev_t *acc) {
     // 2,048 LSB/g 16g
     // 1,024 LSB/g 30g
     acc->acc_1G = acc->acc_high_fsr ? 1024 : 2048;
-    spiSetDivisor(acc->bus.busType_u.spi.instance, SPI_CLOCK_STANDARD);
-    spiBusWriteRegister(&acc->bus, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
+    spiSetDivisor(acc->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiBusWriteRegister(&acc->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
     delay(15);
     const uint8_t acc_fsr = acc->acc_high_fsr ? ICM20649_FSR_30G : ICM20649_FSR_16G;
-    spiBusWriteRegister(&acc->bus, ICM20649_RA_ACCEL_CONFIG, acc_fsr << 1);
+    spiBusWriteRegister(&acc->dev, ICM20649_RA_ACCEL_CONFIG, acc_fsr << 1);
     delay(15);
-    spiBusWriteRegister(&acc->bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // back to bank 0
+    spiBusWriteRegister(&acc->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // back to bank 0
     delay(15);
 }
 
@@ -105,14 +105,14 @@ bool icm20649SpiAccDetect(accDev_t *acc) {
 
 void icm20649GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
     delay(100);
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_PWR_MGMT_1, INV_CLK_PLL);
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
     delay(15);
     const uint8_t gyro_fsr = gyro->gyro_high_fsr ? ICM20649_FSR_4000DPS : ICM20649_FSR_2000DPS;
     // If hardware_lpf is either GYRO_HARDWARE_LPF_NORMAL or GYRO_HARDWARE_LPF_EXPERIMENTAL then the
@@ -122,18 +122,18 @@ void icm20649GyroInit(gyroDev_t *gyro) {
     // the ICM20649 only has a single 9KHz DLPF cutoff.
     uint8_t raGyroConfigData = gyro->gyroRateKHz > GYRO_RATE_1100_Hz ? 0 : 1; // deactivate GYRO_FCHOICE for sample rates over 1kHz (opposite of other invensense chips)
     raGyroConfigData |= gyro_fsr << 1;
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_GYRO_CONFIG_1, raGyroConfigData);
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_GYRO_CONFIG_1, raGyroConfigData);
     delay(15);
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_GYRO_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_GYRO_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
     delay(100);
     // Data ready interrupt configuration
     // back to bank 0
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_REG_BANK_SEL, 0 << 4);
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4);
     delay(15);
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_INT_PIN_CFG, 0x11);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_INT_PIN_CFG, 0x11);  // INT_ANYRD_2CLEAR, BYPASS_EN
     delay(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiBusWriteRegister(&gyro->bus, ICM20649_RA_INT_ENABLE_1, 0x01);
+    spiBusWriteRegister(&gyro->dev, ICM20649_RA_INT_ENABLE_1, 0x01);
 #endif
 }
 
@@ -151,7 +151,7 @@ bool icm20649SpiGyroDetect(gyroDev_t *gyro) {
 bool icm20649GyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {ICM20649_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     uint8_t data[7];
-    const bool ack = spiBusTransfer(&gyro->bus, dataToSend, data, 7);
+    const bool ack = spiBusTransfer(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }
@@ -163,7 +163,7 @@ bool icm20649GyroReadSPI(gyroDev_t *gyro) {
 
 bool icm20649AccRead(accDev_t *acc) {
     uint8_t data[6];
-    const bool ack = spiBusReadRegisterBuffer(&acc->bus, ICM20649_RA_ACCEL_XOUT_H, data, 6);
+    const bool ack = spiBusReadRegisterBuffer(&acc->dev, ICM20649_RA_ACCEL_XOUT_H, data, 6);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -43,17 +43,17 @@ static void icm20689SpiInit(const busDevice_t *bus) {
         return;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
 uint8_t icm20689SpiDetect(const busDevice_t *bus) {
     icm20689SpiInit(bus);
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     spiBusWriteRegister(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
@@ -84,7 +84,7 @@ uint8_t icm20689SpiDetect(const busDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 
@@ -107,7 +107,7 @@ bool icm20689SpiAccDetect(accDev_t *acc) {
 
 void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
     spiBusWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, 0x03);
@@ -131,7 +131,7 @@ void icm20689GyroInit(gyroDev_t *gyro) {
 #ifdef USE_MPU_DATA_READY_SIGNAL
     spiBusWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 
 bool icm20689SpiGyroDetect(gyroDev_t *gyro) {

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -54,12 +54,12 @@ static void icm20689SpiInit(const busDevice_t *bus) {
 uint8_t icm20689SpiDetect(const busDevice_t *bus) {
     icm20689SpiInit(bus);
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
-    spiBusWriteRegister(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiBusReadRegister(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM20601_WHO_AM_I_CONST:
             icmDetected = ICM_20601_SPI;
@@ -108,28 +108,28 @@ bool icm20689SpiAccDetect(accDev_t *acc) {
 void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
+    spiWriteReg(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
     delay(100);
-//    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
+//    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
 //    delay(100);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
+    spiWriteReg(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
     delay(15);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    spiWriteReg(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
+    spiWriteReg(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
     delay(15);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
+    spiWriteReg(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
     delay(100);
     // Data ready interrupt configuration
-//    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
+//    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
     delay(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -107,31 +107,31 @@ bool icm20689SpiAccDetect(accDev_t *acc) {
 
 void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, 0x03);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
     delay(100);
-//    spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, 0);
+//    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
 //    delay(100);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delay(15);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
+    spiBusWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
     delay(15);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delay(15);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
+    spiBusWriteRegister(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
     delay(15);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
+    spiBusWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
     delay(100);
     // Data ready interrupt configuration
-//    spiBusWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    spiBusWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
+//    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
     delay(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiBusWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 
 bool icm20689SpiGyroDetect(gyroDev_t *gyro) {

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -159,17 +159,17 @@ static void icm426xxSpiInit(const busDevice_t *bus) {
         return;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
 uint8_t icm426xxSpiDetect(const busDevice_t *bus) {
     icm426xxSpiInit(bus);
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     spiBusWriteRegister(bus, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
@@ -194,7 +194,7 @@ uint8_t icm426xxSpiDetect(const busDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 
@@ -254,7 +254,7 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, spiCalculateDivider(ICM426XX_MAX_SPI_CLK_HZ));
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, spiCalculateDivider(ICM426XX_MAX_SPI_CLK_HZ));
 
     gyro->accDataReg = ICM426XX_RA_ACCEL_DATA_X1;
     gyro->gyroDataReg = ICM426XX_RA_GYRO_DATA_X1;

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -206,7 +206,7 @@ bool icm426xxAccRead(accDev_t *acc)
 {
     uint8_t data[6];
 
-    const bool ack = busReadRegisterBuffer(&acc->bus, ICM426XX_RA_ACCEL_DATA_X1, data, 6);
+    const bool ack = busReadRegisterBuffer(&acc->dev, ICM426XX_RA_ACCEL_DATA_X1, data, 6);
     if (!ack) {
         return false;
     }
@@ -235,26 +235,26 @@ static aafConfig_t getGyroAafConfig(const mpuSensor_e, const aafConfig_e);
 
 static void turnGyroAccOff(const gyroDev_t *gyro)
 {
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_GYRO_ACCEL_MODE_OFF);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_GYRO_ACCEL_MODE_OFF);
 }
 
 // Turn on gyro and acc on in Low Noise mode
 static void turnGyroAccOn(const gyroDev_t *gyro)
 {
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_TEMP_DISABLE_OFF | ICM426XX_PWR_MGMT0_ACCEL_MODE_LN | ICM426XX_PWR_MGMT0_GYRO_MODE_LN);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_TEMP_DISABLE_OFF | ICM426XX_PWR_MGMT0_ACCEL_MODE_LN | ICM426XX_PWR_MGMT0_GYRO_MODE_LN);
     delay(1);
 }
 
 static void setUserBank(const gyroDev_t *gyro, const uint8_t user_bank)
 {
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_REG_BANK_SEL, user_bank & 7);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_REG_BANK_SEL, user_bank & 7);
 }
 
 void icm426xxGyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, spiCalculateDivider(ICM426XX_MAX_SPI_CLK_HZ));
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, spiCalculateDivider(ICM426XX_MAX_SPI_CLK_HZ));
 
     gyro->accDataReg = ICM426XX_RA_ACCEL_DATA_X1;
     gyro->gyroDataReg = ICM426XX_RA_GYRO_DATA_X1;
@@ -268,40 +268,40 @@ void icm426xxGyroInit(gyroDev_t *gyro)
     const mpuSensor_e gyroModel = gyro->mpuDetectionResult.sensor;
     aafConfig_t aafConfig = getGyroAafConfig(gyroModel, gyroConfig()->gyro_hardware_lpf);
     setUserBank(gyro, ICM426XX_BANK_SELECT1);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_GYRO_CONFIG_STATIC3, aafConfig.delt);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_GYRO_CONFIG_STATIC4, aafConfig.deltSqr & 0xFF);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_GYRO_CONFIG_STATIC5, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC3, aafConfig.delt);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC4, aafConfig.deltSqr & 0xFF);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC5, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
 
     // Configure acc Anti-Alias Filter for 1kHz sample rate (see tasks.c)
     aafConfig = getGyroAafConfig(gyroModel, AAF_CONFIG_258HZ);
     setUserBank(gyro, ICM426XX_BANK_SELECT2);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_ACCEL_CONFIG_STATIC2, aafConfig.delt << 1);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_ACCEL_CONFIG_STATIC3, aafConfig.deltSqr & 0xFF);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_ACCEL_CONFIG_STATIC4, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC2, aafConfig.delt << 1);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC3, aafConfig.deltSqr & 0xFF);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC4, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
 
     // Configure gyro and acc UI Filters
     setUserBank(gyro, ICM426XX_BANK_SELECT0);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_GYRO_ACCEL_CONFIG0, ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM426XX_GYRO_UI_FILT_BW_LOW_LATENCY);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_ACCEL_CONFIG0, ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM426XX_GYRO_UI_FILT_BW_LOW_LATENCY);
 
     // Configure interrupt pin
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_INT_CONFIG, ICM426XX_INT1_MODE_PULSED | ICM426XX_INT1_DRIVE_CIRCUIT_PP | ICM426XX_INT1_POLARITY_ACTIVE_HIGH);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_INT_CONFIG0, ICM426XX_UI_DRDY_INT_CLEAR_ON_SBR);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG, ICM426XX_INT1_MODE_PULSED | ICM426XX_INT1_DRIVE_CIRCUIT_PP | ICM426XX_INT1_POLARITY_ACTIVE_HIGH);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG0, ICM426XX_UI_DRDY_INT_CLEAR_ON_SBR);
 
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_INT_SOURCE0, ICM426XX_UI_DRDY_INT1_EN_ENABLED);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_SOURCE0, ICM426XX_UI_DRDY_INT1_EN_ENABLED);
 
-    uint8_t intConfig1Value = spiBusReadRegister(&gyro->bus, ICM426XX_RA_INT_CONFIG1);
+    uint8_t intConfig1Value = spiBusReadRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG1);
     // Datasheet says: "User should change setting to 0 from default setting of 1, for proper INT1 and INT2 pin operation"
     intConfig1Value &= ~(1 << ICM426XX_INT_ASYNC_RESET_BIT);
     intConfig1Value |= (ICM426XX_INT_TPULSE_DURATION_8 | ICM426XX_INT_TDEASSERT_DISABLED);
 
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_INT_CONFIG1, intConfig1Value);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG1, intConfig1Value);
 
     // Disable AFSR to prevent stalls in gyro output
     // ICM426XX_INTF_CONFIG1 location in user bank 0
-    uint8_t intfConfig1Value = spiBusReadRegister(&gyro->bus, ICM426XX_INTF_CONFIG1);
+    uint8_t intfConfig1Value = spiBusReadRegister(&gyro->dev, ICM426XX_INTF_CONFIG1);
     intfConfig1Value &= ~ICM426XX_INTF_CONFIG1_AFSR_MASK;
     intfConfig1Value |= ICM426XX_INTF_CONFIG1_AFSR_DISABLE;
-    spiBusWriteRegister(&gyro->bus, ICM426XX_INTF_CONFIG1, intfConfig1Value);
+    spiBusWriteRegister(&gyro->dev, ICM426XX_INTF_CONFIG1, intfConfig1Value);
 
     // Turn on gyro and acc on again so ODR and FSR can be configured
     turnGyroAccOn(gyro);
@@ -317,11 +317,11 @@ void icm426xxGyroInit(gyroDev_t *gyro)
     }
 
     STATIC_ASSERT(INV_FSR_2000DPS == 3, INV_FSR_2000DPS_must_be_3_to_generate_correct_value);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_GYRO_CONFIG0, (3 - INV_FSR_2000DPS) << 5 | (odrConfig & 0x0F));
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG0, (3 - INV_FSR_2000DPS) << 5 | (odrConfig & 0x0F));
     delay(15);
 
     STATIC_ASSERT(INV_FSR_16G == 3, INV_FSR_16G_must_be_3_to_generate_correct_value);
-    spiBusWriteRegister(&gyro->bus, ICM426XX_RA_ACCEL_CONFIG0, (3 - INV_FSR_16G) << 5 | (odrConfig & 0x0F));
+    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG0, (3 - INV_FSR_16G) << 5 | (odrConfig & 0x0F));
     delay(15);
 }
 
@@ -335,7 +335,7 @@ bool icm426xxGyroReadSPI(gyroDev_t *gyro)
     //uint8_t data[7];
     STATIC_DMA_DATA_AUTO uint8_t data[7];
 
-    const bool ack = spiBusTransfer(&gyro->bus, dataToSend, data, 7);
+    const bool ack = spiBusTransfer(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -170,12 +170,12 @@ static void icm426xxSpiInit(const busDevice_t *bus) {
 uint8_t icm426xxSpiDetect(const busDevice_t *bus) {
     icm426xxSpiInit(bus);
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
-    spiBusWriteRegister(bus, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);
+    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiBusReadRegister(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM42605_WHO_AM_I_CONST:
             icmDetected = ICM_42605_SPI;
@@ -235,19 +235,19 @@ static aafConfig_t getGyroAafConfig(const mpuSensor_e, const aafConfig_e);
 
 static void turnGyroAccOff(const gyroDev_t *gyro)
 {
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_GYRO_ACCEL_MODE_OFF);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_GYRO_ACCEL_MODE_OFF);
 }
 
 // Turn on gyro and acc on in Low Noise mode
 static void turnGyroAccOn(const gyroDev_t *gyro)
 {
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_TEMP_DISABLE_OFF | ICM426XX_PWR_MGMT0_ACCEL_MODE_LN | ICM426XX_PWR_MGMT0_GYRO_MODE_LN);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_PWR_MGMT0, ICM426XX_PWR_MGMT0_TEMP_DISABLE_OFF | ICM426XX_PWR_MGMT0_ACCEL_MODE_LN | ICM426XX_PWR_MGMT0_GYRO_MODE_LN);
     delay(1);
 }
 
 static void setUserBank(const gyroDev_t *gyro, const uint8_t user_bank)
 {
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_REG_BANK_SEL, user_bank & 7);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_REG_BANK_SEL, user_bank & 7);
 }
 
 void icm426xxGyroInit(gyroDev_t *gyro)
@@ -268,40 +268,40 @@ void icm426xxGyroInit(gyroDev_t *gyro)
     const mpuSensor_e gyroModel = gyro->mpuDetectionResult.sensor;
     aafConfig_t aafConfig = getGyroAafConfig(gyroModel, gyroConfig()->gyro_hardware_lpf);
     setUserBank(gyro, ICM426XX_BANK_SELECT1);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC3, aafConfig.delt);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC4, aafConfig.deltSqr & 0xFF);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC5, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
+    spiWriteReg(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC3, aafConfig.delt);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC4, aafConfig.deltSqr & 0xFF);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_GYRO_CONFIG_STATIC5, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
 
     // Configure acc Anti-Alias Filter for 1kHz sample rate (see tasks.c)
     aafConfig = getGyroAafConfig(gyroModel, AAF_CONFIG_258HZ);
     setUserBank(gyro, ICM426XX_BANK_SELECT2);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC2, aafConfig.delt << 1);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC3, aafConfig.deltSqr & 0xFF);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC4, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
+    spiWriteReg(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC2, aafConfig.delt << 1);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC3, aafConfig.deltSqr & 0xFF);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG_STATIC4, (aafConfig.deltSqr >> 8) | (aafConfig.bitshift << 4));
 
     // Configure gyro and acc UI Filters
     setUserBank(gyro, ICM426XX_BANK_SELECT0);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_ACCEL_CONFIG0, ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM426XX_GYRO_UI_FILT_BW_LOW_LATENCY);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_GYRO_ACCEL_CONFIG0, ICM426XX_ACCEL_UI_FILT_BW_LOW_LATENCY | ICM426XX_GYRO_UI_FILT_BW_LOW_LATENCY);
 
     // Configure interrupt pin
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG, ICM426XX_INT1_MODE_PULSED | ICM426XX_INT1_DRIVE_CIRCUIT_PP | ICM426XX_INT1_POLARITY_ACTIVE_HIGH);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG0, ICM426XX_UI_DRDY_INT_CLEAR_ON_SBR);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_INT_CONFIG, ICM426XX_INT1_MODE_PULSED | ICM426XX_INT1_DRIVE_CIRCUIT_PP | ICM426XX_INT1_POLARITY_ACTIVE_HIGH);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_INT_CONFIG0, ICM426XX_UI_DRDY_INT_CLEAR_ON_SBR);
 
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_SOURCE0, ICM426XX_UI_DRDY_INT1_EN_ENABLED);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_INT_SOURCE0, ICM426XX_UI_DRDY_INT1_EN_ENABLED);
 
-    uint8_t intConfig1Value = spiBusReadRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG1);
+    uint8_t intConfig1Value = spiReadReg(&gyro->dev, ICM426XX_RA_INT_CONFIG1);
     // Datasheet says: "User should change setting to 0 from default setting of 1, for proper INT1 and INT2 pin operation"
     intConfig1Value &= ~(1 << ICM426XX_INT_ASYNC_RESET_BIT);
     intConfig1Value |= (ICM426XX_INT_TPULSE_DURATION_8 | ICM426XX_INT_TDEASSERT_DISABLED);
 
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_INT_CONFIG1, intConfig1Value);
+    spiWriteReg(&gyro->dev, ICM426XX_RA_INT_CONFIG1, intConfig1Value);
 
     // Disable AFSR to prevent stalls in gyro output
     // ICM426XX_INTF_CONFIG1 location in user bank 0
-    uint8_t intfConfig1Value = spiBusReadRegister(&gyro->dev, ICM426XX_INTF_CONFIG1);
+    uint8_t intfConfig1Value = spiReadReg(&gyro->dev, ICM426XX_INTF_CONFIG1);
     intfConfig1Value &= ~ICM426XX_INTF_CONFIG1_AFSR_MASK;
     intfConfig1Value |= ICM426XX_INTF_CONFIG1_AFSR_DISABLE;
-    spiBusWriteRegister(&gyro->dev, ICM426XX_INTF_CONFIG1, intfConfig1Value);
+    spiWriteReg(&gyro->dev, ICM426XX_INTF_CONFIG1, intfConfig1Value);
 
     // Turn on gyro and acc on again so ODR and FSR can be configured
     turnGyroAccOn(gyro);
@@ -317,11 +317,11 @@ void icm426xxGyroInit(gyroDev_t *gyro)
     }
 
     STATIC_ASSERT(INV_FSR_2000DPS == 3, INV_FSR_2000DPS_must_be_3_to_generate_correct_value);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_GYRO_CONFIG0, (3 - INV_FSR_2000DPS) << 5 | (odrConfig & 0x0F));
+    spiWriteReg(&gyro->dev, ICM426XX_RA_GYRO_CONFIG0, (3 - INV_FSR_2000DPS) << 5 | (odrConfig & 0x0F));
     delay(15);
 
     STATIC_ASSERT(INV_FSR_16G == 3, INV_FSR_16G_must_be_3_to_generate_correct_value);
-    spiBusWriteRegister(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG0, (3 - INV_FSR_16G) << 5 | (odrConfig & 0x0F));
+    spiWriteReg(&gyro->dev, ICM426XX_RA_ACCEL_CONFIG0, (3 - INV_FSR_16G) << 5 | (odrConfig & 0x0F));
     delay(15);
 }
 
@@ -335,7 +335,7 @@ bool icm426xxGyroReadSPI(gyroDev_t *gyro)
     //uint8_t data[7];
     STATIC_DMA_DATA_AUTO uint8_t data[7];
 
-    const bool ack = spiBusTransfer(&gyro->dev, dataToSend, data, 7);
+    const bool ack = spiReadWriteBuf(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -104,7 +104,7 @@ void mpu6000SpiGyroInit(gyroDev_t *gyro) {
     mpu6000AccAndGyroInit(gyro);
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Accel and Gyro DLPF Setting
-    spiBusWriteRegister(&gyro->dev, MPU6000_CONFIG, mpuGyroDLPF(gyro));
+    spiWriteReg(&gyro->dev, MPU6000_CONFIG, mpuGyroDLPF(gyro));
     delayMicroseconds(1);
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
     mpuGyroRead(gyro);
@@ -124,11 +124,11 @@ uint8_t mpu6000SpiDetect(const busDevice_t *bus) {
     IOHi(bus->busType_u.spi.csnPin);
 #endif
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
-    spiBusWriteRegister(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     uint8_t attemptsRemaining = 5;
     do {
         delay(150);
-        const uint8_t whoAmI = spiBusReadRegister(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
         if (whoAmI == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -136,7 +136,7 @@ uint8_t mpu6000SpiDetect(const busDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    const uint8_t productID = spiBusReadRegister(bus, MPU_RA_PRODUCT_ID);
+    const uint8_t productID = spiReadReg(bus, MPU_RA_PRODUCT_ID);
     /* look for a product ID we recognise */
     // verify product revision
     switch (productID) {
@@ -163,32 +163,32 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro) {
     }
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Device Reset
-    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    spiWriteReg(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
     // Clock Source PPL with Z axis gyro reference
-    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
     // Disable Primary I2C Interface
-    spiBusWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    spiWriteReg(&gyro->dev, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_2, 0x00);
+    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    spiBusWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
+    spiWriteReg(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
     delayMicroseconds(15);
     // Gyro +/- 1000 DPS Full Scale
-    spiBusWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    spiWriteReg(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
     // Accel +/- 16 G Full Scale
-    spiBusWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    spiWriteReg(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delayMicroseconds(15);
-    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -102,11 +102,11 @@ static bool mpuSpi6000InitDone = false;
 void mpu6000SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     mpu6000AccAndGyroInit(gyro);
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Accel and Gyro DLPF Setting
-    spiBusWriteRegister(&gyro->bus, MPU6000_CONFIG, mpuGyroDLPF(gyro));
+    spiBusWriteRegister(&gyro->dev, MPU6000_CONFIG, mpuGyroDLPF(gyro));
     delayMicroseconds(1);
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
     mpuGyroRead(gyro);
     if (((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) {
         failureMode(FAILURE_GYRO_INIT_FAILED);
@@ -161,37 +161,37 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro) {
     if (mpuSpi6000InitDone) {
         return;
     }
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Device Reset
-    spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, BIT_GYRO | BIT_ACC | BIT_TEMP);
     delay(150);
     // Clock Source PPL with Z axis gyro reference
-    spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU_CLK_SEL_PLLGYROZ);
     delayMicroseconds(15);
     // Disable Primary I2C Interface
-    spiBusWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, BIT_I2C_IF_DIS);
     delayMicroseconds(15);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_2, 0x00);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_2, 0x00);
     delayMicroseconds(15);
     // Accel Sample Rate 1kHz
     // Gyroscope Output Rate =  1kHz when the DLPF is enabled
-    spiBusWriteRegister(&gyro->bus, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
     delayMicroseconds(15);
     // Gyro +/- 1000 DPS Full Scale
-    spiBusWriteRegister(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3);
     delayMicroseconds(15);
     // Accel +/- 16 G Full Scale
-    spiBusWriteRegister(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
     delayMicroseconds(15);
-    spiBusWriteRegister(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
+    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR
     delayMicroseconds(15);
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiBusWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
     mpuSpi6000InitDone = true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -102,11 +102,11 @@ static bool mpuSpi6000InitDone = false;
 void mpu6000SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     mpu6000AccAndGyroInit(gyro);
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Accel and Gyro DLPF Setting
     spiBusWriteRegister(&gyro->bus, MPU6000_CONFIG, mpuGyroDLPF(gyro));
     delayMicroseconds(1);
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
     mpuGyroRead(gyro);
     if (((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) {
         failureMode(FAILURE_GYRO_INIT_FAILED);
@@ -119,11 +119,11 @@ void mpu6000SpiAccInit(accDev_t *acc) {
 
 uint8_t mpu6000SpiDetect(const busDevice_t *bus) {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     spiBusWriteRegister(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     uint8_t attemptsRemaining = 5;
     do {
@@ -161,7 +161,7 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro) {
     if (mpuSpi6000InitDone) {
         return;
     }
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Device Reset
     spiBusWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
@@ -191,7 +191,7 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro) {
     spiBusWriteRegister(&gyro->bus, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
     mpuSpi6000InitDone = true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -50,7 +50,7 @@ static void mpu6500SpiInit(const busDevice_t *bus) {
 
 uint8_t mpu6500SpiDetect(const busDevice_t *bus) {
     mpu6500SpiInit(bus);
-    const uint8_t whoAmI = spiBusReadRegister(bus, MPU_RA_WHO_AM_I);
+    const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
     uint8_t mpuDetected = MPU_NONE;
     switch (whoAmI) {
     case MPU6500_WHO_AM_I_CONST:
@@ -90,7 +90,7 @@ void mpu6500SpiGyroInit(gyroDev_t *gyro) {
     delayMicroseconds(1);
     mpu6500GyroInit(gyro);
     // Disable Primary I2C Interface
-    spiBusWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    spiWriteReg(&gyro->dev, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
     spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -41,11 +41,11 @@
 
 static void mpu6500SpiInit(const busDevice_t *bus) {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_FAST);
 }
 
 uint8_t mpu6500SpiDetect(const busDevice_t *bus) {
@@ -86,13 +86,13 @@ void mpu6500SpiAccInit(accDev_t *acc) {
 }
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro) {
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_SLOW);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_SLOW);
     delayMicroseconds(1);
     mpu6500GyroInit(gyro);
     // Disable Primary I2C Interface
     spiBusWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -86,13 +86,13 @@ void mpu6500SpiAccInit(accDev_t *acc) {
 }
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro) {
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_SLOW);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_SLOW);
     delayMicroseconds(1);
     mpu6500GyroInit(gyro);
     // Disable Primary I2C Interface
-    spiBusWriteRegister(&gyro->bus, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
+    spiBusWriteRegister(&gyro->dev, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -148,7 +148,7 @@ uint8_t mpu9250SpiDetect(const busDevice_t *bus) {
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t in = spiBusReadRegister(bus, MPU_RA_WHO_AM_I);
+        const uint8_t in = spiReadReg(bus, MPU_RA_WHO_AM_I);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -52,21 +52,21 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro);
 static bool mpuSpi9250InitDone = false;
 
 bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data) {
-    IOLo(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
     delayMicroseconds(1);
-    spiTransferByte(bus->busdev_u.spi.instance, reg);
-    spiTransferByte(bus->busdev_u.spi.instance, data);
-    IOHi(bus->busdev_u.spi.csnPin);
+    spiTransferByte(bus->busType_u.spi.instance, reg);
+    spiTransferByte(bus->busType_u.spi.instance, data);
+    IOHi(bus->busType_u.spi.csnPin);
     delayMicroseconds(1);
     return true;
 }
 
 static bool mpu9250SpiSlowReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
-    IOLo(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
     delayMicroseconds(1);
-    spiTransferByte(bus->busdev_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(bus->busdev_u.spi.instance, NULL, data, length);
-    IOHi(bus->busdev_u.spi.csnPin);
+    spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(bus->busType_u.spi.instance, NULL, data, length);
+    IOHi(bus->busType_u.spi.csnPin);
     delayMicroseconds(1);
     return true;
 }
@@ -86,11 +86,11 @@ void mpu9250SpiResetGyro(void) {
 void mpu9250SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     mpu9250AccAndGyroInit(gyro);
-    spiResetErrorCounter(gyro->bus.busdev_u.spi.instance);
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
+    spiResetErrorCounter(gyro->bus.busType_u.spi.instance);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
     mpuGyroRead(gyro);
-    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(gyro->bus.busdev_u.spi.instance) != 0) {
-        spiResetErrorCounter(gyro->bus.busdev_u.spi.instance);
+    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(gyro->bus.busType_u.spi.instance) != 0) {
+        spiResetErrorCounter(gyro->bus.busType_u.spi.instance);
         failureMode(FAILURE_GYRO_INIT_FAILED);
     }
 }
@@ -121,7 +121,7 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     if (mpuSpi9250InitDone) {
         return;
     }
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed for writing to slow registers
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed for writing to slow registers
     mpu9250SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
     mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
@@ -133,17 +133,17 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 #if defined(USE_MPU_DATA_READY_SIGNAL)
     mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
-    spiSetDivisor(gyro->bus.busdev_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);
     mpuSpi9250InitDone = true; //init done
 }
 
 uint8_t mpu9250SpiDetect(const busDevice_t *bus) {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busdev_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     mpu9250SpiWriteRegister(bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     uint8_t attemptsRemaining = 20;
     do {
@@ -156,7 +156,7 @@ uint8_t mpu9250SpiDetect(const busDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(bus->busdev_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_FAST);
     return MPU_9250_SPI;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -86,11 +86,11 @@ void mpu9250SpiResetGyro(void) {
 void mpu9250SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     mpu9250AccAndGyroInit(gyro);
-    spiResetErrorCounter(gyro->bus.busType_u.spi.instance);
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
+    spiResetErrorCounter(gyro->dev.busType_u.spi.instance);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
     mpuGyroRead(gyro);
-    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(gyro->bus.busType_u.spi.instance) != 0) {
-        spiResetErrorCounter(gyro->bus.busType_u.spi.instance);
+    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(gyro->dev.busType_u.spi.instance) != 0) {
+        spiResetErrorCounter(gyro->dev.busType_u.spi.instance);
         failureMode(FAILURE_GYRO_INIT_FAILED);
     }
 }
@@ -121,19 +121,19 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     if (mpuSpi9250InitDone) {
         return;
     }
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed for writing to slow registers
-    mpu9250SpiWriteRegister(&gyro->bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed for writing to slow registers
+    mpu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 1 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
 #if defined(USE_MPU_DATA_READY_SIGNAL)
-    mpu9250SpiWriteRegisterVerify(&gyro->bus, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
+    mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
-    spiSetDivisor(gyro->bus.busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
     mpuSpi9250InitDone = true; //init done
 }
 

--- a/src/main/drivers/barometer/barometer.h
+++ b/src/main/drivers/barometer/barometer.h
@@ -28,7 +28,7 @@ typedef void (*baroOpFuncPtr)(struct baroDev_s *baro);                       // 
 typedef void (*baroCalculateFuncPtr)(int32_t *pressure, int32_t *temperature); // baro calculation (filled params are pressure and temperature)
 
 typedef struct baroDev_s {
-    busDevice_t busdev;
+    extDevice_t dev;
     uint16_t ut_delay;
     uint16_t up_delay;
     baroOpFuncPtr start_ut;

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -180,7 +180,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
     UNUSED(config);
 #endif
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
-    busDevice_t *busdev = &baro->busdev;
+    busDevice_t *busdev = &baro->dev;
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for BMP085
         busdev->busType_u.i2c.address = BMP085_I2C_ADDR;
@@ -265,7 +265,7 @@ static void bmp085_start_ut(baroDev_t *baro) {
 #if defined(BARO_EOC_GPIO)
     isConversionComplete = false;
 #endif
-    busWriteRegister(&baro->busdev, BMP085_CTRL_MEAS_REG, BMP085_T_MEASURE);
+    busWriteRegister(&baro->dev, BMP085_CTRL_MEAS_REG, BMP085_T_MEASURE);
 }
 
 static void bmp085_get_ut(baroDev_t *baro) {
@@ -276,7 +276,7 @@ static void bmp085_get_ut(baroDev_t *baro) {
         return;
     }
 #endif
-    busReadRegisterBuffer(&baro->busdev, BMP085_ADC_OUT_MSB_REG, data, 2);
+    busReadRegisterBuffer(&baro->dev, BMP085_ADC_OUT_MSB_REG, data, 2);
     bmp085_ut = (data[0] << 8) | data[1];
 }
 
@@ -286,7 +286,7 @@ static void bmp085_start_up(baroDev_t *baro) {
 #if defined(BARO_EOC_GPIO)
     isConversionComplete = false;
 #endif
-    busWriteRegister(&baro->busdev, BMP085_CTRL_MEAS_REG, ctrl_reg_data);
+    busWriteRegister(&baro->dev, BMP085_CTRL_MEAS_REG, ctrl_reg_data);
 }
 
 /** read out up for pressure conversion
@@ -301,7 +301,7 @@ static void bmp085_get_up(baroDev_t *baro) {
         return;
     }
 #endif
-    busReadRegisterBuffer(&baro->busdev, BMP085_ADC_OUT_MSB_REG, data, 3);
+    busReadRegisterBuffer(&baro->dev, BMP085_ADC_OUT_MSB_REG, data, 3);
     bmp085_up = (((uint32_t) data[0] << 16) | ((uint32_t) data[1] << 8) | (uint32_t) data[2])
                 >> (8 - bmp085.oversampling_setting);
 }

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -181,7 +181,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
 #endif
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
     busDevice_t *busdev = &baro->busdev;
-    if ((busdev->bustype == BUSTYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
         // Default address for BMP085
         busdev->busdev_u.i2c.address = BMP085_I2C_ADDR;
         defaultAddressApplied = true;

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -181,9 +181,9 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
 #endif
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
     busDevice_t *busdev = &baro->busdev;
-    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for BMP085
-        busdev->busdev_u.i2c.address = BMP085_I2C_ADDR;
+        busdev->busType_u.i2c.address = BMP085_I2C_ADDR;
         defaultAddressApplied = true;
     }
     ack = busReadRegisterBuffer(busdev, BMP085_CHIP_ID__REG, &data, 1); /* read Chip Id */
@@ -215,7 +215,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
 #endif
     BMP085_OFF;
     if (defaultAddressApplied) {
-        busdev->busdev_u.i2c.address = 0;
+        busdev->busType_u.i2c.address = 0;
     }
     return false;
 }

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -77,7 +77,7 @@ void bmp280BusDeinit(busDevice_t *busdev) {
 
 bool bmp280Detect(baroDev_t *baro) {
     delay(20);
-    busDevice_t *busdev = &baro->busdev;
+    busDevice_t *busdev = &baro->dev;
     bool defaultAddressApplied = false;
     bmp280BusInit(busdev);
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
@@ -122,13 +122,13 @@ static void bmp280_get_ut(baroDev_t *baro) {
 static void bmp280_start_up(baroDev_t *baro) {
     // start measurement
     // set oversampling + power mode (forced), and start sampling
-    busWriteRegister(&baro->busdev, BMP280_CTRL_MEAS_REG, BMP280_MODE);
+    busWriteRegister(&baro->dev, BMP280_CTRL_MEAS_REG, BMP280_MODE);
 }
 
 static void bmp280_get_up(baroDev_t *baro) {
     uint8_t data[BMP280_DATA_FRAME_SIZE];
     // read data from sensor
-    busReadRegisterBuffer(&baro->busdev, BMP280_PRESSURE_MSB_REG, data, BMP280_DATA_FRAME_SIZE);
+    busReadRegisterBuffer(&baro->dev, BMP280_PRESSURE_MSB_REG, data, BMP280_DATA_FRAME_SIZE);
     bmp280_up = (int32_t)((((uint32_t)(data[0])) << 12) | (((uint32_t)(data[1])) << 4) | ((uint32_t)data[2] >> 4));
     bmp280_ut = (int32_t)((((uint32_t)(data[3])) << 12) | (((uint32_t)(data[4])) << 4) | ((uint32_t)data[5] >> 4));
 }

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -54,11 +54,11 @@ STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature
 
 void bmp280BusInit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (busdev->bustype == BUS_TYPE_SPI) {
-        IOHi(busdev->busdev_u.spi.csnPin); // Disable
-        IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
-        IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
+    if (busdev->busType == BUS_TYPE_SPI) {
+        IOHi(busdev->busType_u.spi.csnPin); // Disable
+        IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
     UNUSED(busdev);
@@ -67,8 +67,8 @@ void bmp280BusInit(busDevice_t *busdev) {
 
 void bmp280BusDeinit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (busdev->bustype == BUS_TYPE_SPI) {
-        spiPreinitCsByIO(busdev->busdev_u.spi.csnPin);
+    if (busdev->busType == BUS_TYPE_SPI) {
+        spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
     }
 #else
     UNUSED(busdev);
@@ -80,16 +80,16 @@ bool bmp280Detect(baroDev_t *baro) {
     busDevice_t *busdev = &baro->busdev;
     bool defaultAddressApplied = false;
     bmp280BusInit(busdev);
-    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for BMP280
-        busdev->busdev_u.i2c.address = BMP280_I2C_ADDR;
+        busdev->busType_u.i2c.address = BMP280_I2C_ADDR;
         defaultAddressApplied = true;
     }
     busReadRegisterBuffer(busdev, BMP280_CHIP_ID_REG, &bmp280_chip_id, 1);  /* read Chip Id */
     if (bmp280_chip_id != BMP280_DEFAULT_CHIP_ID) {
         bmp280BusDeinit(busdev);
         if (defaultAddressApplied) {
-            busdev->busdev_u.i2c.address = 0;
+            busdev->busType_u.i2c.address = 0;
         }
         return false;
     }

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -54,7 +54,7 @@ STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature
 
 void bmp280BusInit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         IOHi(busdev->busdev_u.spi.csnPin); // Disable
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
@@ -67,7 +67,7 @@ void bmp280BusInit(busDevice_t *busdev) {
 
 void bmp280BusDeinit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         spiPreinitCsByIO(busdev->busdev_u.spi.csnPin);
     }
 #else
@@ -80,7 +80,7 @@ bool bmp280Detect(baroDev_t *baro) {
     busDevice_t *busdev = &baro->busdev;
     bool defaultAddressApplied = false;
     bmp280BusInit(busdev);
-    if ((busdev->bustype == BUSTYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
         // Default address for BMP280
         busdev->busdev_u.i2c.address = BMP280_I2C_ADDR;
         defaultAddressApplied = true;

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -242,10 +242,10 @@ static void lps_calculate(int32_t *pressure, int32_t *temperature) {
 bool lpsDetect(baroDev_t *baro) {
     //Detect
     busDevice_t *busdev = &baro->busdev;
-    IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
-    IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
-    IOHi(busdev->busdev_u.spi.csnPin); // Disable
-    spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
+    IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+    IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+    IOHi(busdev->busType_u.spi.csnPin); // Disable
+    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
     uint8_t temp = 0x00;
     lpsReadCommand(&baro->busdev, LPS_WHO_AM_I, &temp, 1);
     if (temp != LPS25_ID && temp != LPS22_ID && temp != LPS33_ID && temp != LPS35_ID) {

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -190,17 +190,17 @@ static uint32_t rawP = 0;
 static uint16_t rawT = 0;
 
 bool lpsWriteCommand(busDevice_t *busdev, uint8_t cmd, uint8_t byte) {
-    return spiBusWriteRegister(busdev, cmd, byte);
+    return spiWriteReg(busdev, cmd, byte);
 }
 
 bool lpsReadCommand(busDevice_t *busdev, uint8_t cmd, uint8_t *data, uint8_t len) {
-    return spiBusReadRegisterBuffer(busdev, cmd | 0x80 | 0x40, data, len);
+    return spiReadRegBuf(busdev, cmd | 0x80 | 0x40, data, len);
 }
 
 bool lpsWriteVerify(busDevice_t *busdev, uint8_t cmd, uint8_t byte) {
     uint8_t temp = 0xff;
-    spiBusWriteRegister(busdev, cmd, byte);
-    spiBusReadRegisterBuffer(busdev, cmd, &temp, 1);
+    spiWriteReg(busdev, cmd, byte);
+    spiReadRegBuf(busdev, cmd, &temp, 1);
     if (byte == temp) return true;
     return false;
 }

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -221,10 +221,10 @@ static void lps_nothing(baroDev_t *baro) {
 
 static void lps_read(baroDev_t *baro) {
     uint8_t status = 0x00;
-    lpsReadCommand(&baro->busdev, LPS_STATUS, &status, 1);
+    lpsReadCommand(&baro->dev, LPS_STATUS, &status, 1);
     if (status & 0x03) {
         uint8_t temp[5];
-        lpsReadCommand(&baro->busdev, LPS_OUT_XL, temp, 5);
+        lpsReadCommand(&baro->dev, LPS_OUT_XL, temp, 5);
         /* Build the raw data */
         rawP = temp[0] | (temp[1] << 8) | (temp[2] << 16) | ((temp[2] & 0x80) ? 0xff000000 : 0);
         rawT = (temp[4] << 8) | temp[3];
@@ -241,13 +241,13 @@ static void lps_calculate(int32_t *pressure, int32_t *temperature) {
 
 bool lpsDetect(baroDev_t *baro) {
     //Detect
-    busDevice_t *busdev = &baro->busdev;
+    busDevice_t *busdev = &baro->dev;
     IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
     IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
     IOHi(busdev->busType_u.spi.csnPin); // Disable
     spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
     uint8_t temp = 0x00;
-    lpsReadCommand(&baro->busdev, LPS_WHO_AM_I, &temp, 1);
+    lpsReadCommand(&baro->dev, LPS_WHO_AM_I, &temp, 1);
     if (temp != LPS25_ID && temp != LPS22_ID && temp != LPS33_ID && temp != LPS35_ID) {
         return false;
     }

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -92,7 +92,7 @@ bool ms5611Detect(baroDev_t *baro) {
     int i;
     bool defaultAddressApplied = false;
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
-    busDevice_t *busdev = &baro->busdev;
+    busDevice_t *busdev = &baro->dev;
     ms5611BusInit(busdev);
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for MS5611
@@ -172,19 +172,19 @@ static uint32_t ms5611_read_adc(busDevice_t *busdev) {
 }
 
 static void ms5611_start_ut(baroDev_t *baro) {
-    busWriteRegister(&baro->busdev, CMD_ADC_CONV + CMD_ADC_D2 + ms5611_osr, 1); // D2 (temperature) conversion start!
+    busWriteRegister(&baro->dev, CMD_ADC_CONV + CMD_ADC_D2 + ms5611_osr, 1); // D2 (temperature) conversion start!
 }
 
 static void ms5611_get_ut(baroDev_t *baro) {
-    ms5611_ut = ms5611_read_adc(&baro->busdev);
+    ms5611_ut = ms5611_read_adc(&baro->dev);
 }
 
 static void ms5611_start_up(baroDev_t *baro) {
-    busWriteRegister(&baro->busdev, CMD_ADC_CONV + CMD_ADC_D1 + ms5611_osr, 1); // D1 (pressure) conversion start!
+    busWriteRegister(&baro->dev, CMD_ADC_CONV + CMD_ADC_D1 + ms5611_osr, 1); // D1 (pressure) conversion start!
 }
 
 static void ms5611_get_up(baroDev_t *baro) {
-    ms5611_up = ms5611_read_adc(&baro->busdev);
+    ms5611_up = ms5611_read_adc(&baro->dev);
 }
 
 STATIC_UNIT_TESTED void ms5611_calculate(int32_t *pressure, int32_t *temperature) {

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -66,7 +66,7 @@ static uint8_t ms5611_osr = CMD_ADC_4096;
 
 void ms5611BusInit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         IOHi(busdev->busdev_u.spi.csnPin); // Disable
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
@@ -79,7 +79,7 @@ void ms5611BusInit(busDevice_t *busdev) {
 
 void ms5611BusDeinit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         spiPreinitCsByIO(busdev->busdev_u.spi.csnPin);
     }
 #else
@@ -94,7 +94,7 @@ bool ms5611Detect(baroDev_t *baro) {
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
     busDevice_t *busdev = &baro->busdev;
     ms5611BusInit(busdev);
-    if ((busdev->bustype == BUSTYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
         // Default address for MS5611
         busdev->busdev_u.i2c.address = MS5611_I2C_ADDR;
         defaultAddressApplied = true;

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -66,11 +66,11 @@ static uint8_t ms5611_osr = CMD_ADC_4096;
 
 void ms5611BusInit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (busdev->bustype == BUS_TYPE_SPI) {
-        IOHi(busdev->busdev_u.spi.csnPin); // Disable
-        IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
-        IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
+    if (busdev->busType == BUS_TYPE_SPI) {
+        IOHi(busdev->busType_u.spi.csnPin); // Disable
+        IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
     UNUSED(busdev);
@@ -79,8 +79,8 @@ void ms5611BusInit(busDevice_t *busdev) {
 
 void ms5611BusDeinit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (busdev->bustype == BUS_TYPE_SPI) {
-        spiPreinitCsByIO(busdev->busdev_u.spi.csnPin);
+    if (busdev->busType == BUS_TYPE_SPI) {
+        spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
     }
 #else
     UNUSED(busdev);
@@ -94,9 +94,9 @@ bool ms5611Detect(baroDev_t *baro) {
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
     busDevice_t *busdev = &baro->busdev;
     ms5611BusInit(busdev);
-    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for MS5611
-        busdev->busdev_u.i2c.address = MS5611_I2C_ADDR;
+        busdev->busType_u.i2c.address = MS5611_I2C_ADDR;
         defaultAddressApplied = true;
     }
     if (!busReadRegisterBuffer(busdev, CMD_PROM_RD, &sig, 1) || sig == 0xFF) {
@@ -123,7 +123,7 @@ fail:
     ;
     ms5611BusDeinit(busdev);
     if (defaultAddressApplied) {
-        busdev->busdev_u.i2c.address = 0;
+        busdev->busType_u.i2c.address = 0;
     }
     return false;
 }

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -139,7 +139,7 @@ bool qmp6988Detect(baroDev_t *baro) {
     uint16_t lb = 0, hb = 0;
     uint32_t lw = 0, hw = 0, temp1, temp2;
     delay(20);
-    busDevice_t *busdev = &baro->busdev;
+    busDevice_t *busdev = &baro->dev;
     bool defaultAddressApplied = false;
     qmp6988BusInit(busdev);
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
@@ -246,13 +246,13 @@ static void qmp6988_get_ut(baroDev_t *baro) {
 
 static void qmp6988_start_up(baroDev_t *baro) {
     // start measurement
-    busWriteRegister(&baro->busdev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);
+    busWriteRegister(&baro->dev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);
 }
 
 static void qmp6988_get_up(baroDev_t *baro) {
     uint8_t data[QMP6988_DATA_FRAME_SIZE];
     // read data from sensor
-    busReadRegisterBuffer(&baro->busdev, QMP6988_PRESSURE_MSB_REG, data, QMP6988_DATA_FRAME_SIZE);
+    busReadRegisterBuffer(&baro->dev, QMP6988_PRESSURE_MSB_REG, data, QMP6988_DATA_FRAME_SIZE);
     qmp6988_up = (int32_t)((((uint32_t)(data[0])) << 16) | (((uint32_t)(data[1])) << 8) | ((uint32_t)data[2] ));
     qmp6988_ut = (int32_t)((((uint32_t)(data[3])) << 16) | (((uint32_t)(data[4])) << 8) | ((uint32_t)data[5]));
 }

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -99,11 +99,11 @@ STATIC_UNIT_TESTED void qmp6988_calculate(int32_t *pressure, int32_t *temperatur
 
 void qmp6988BusInit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (busdev->bustype == BUS_TYPE_SPI) {
-        IOHi(busdev->busdev_u.spi.csnPin);
-        IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
-        IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    if (busdev->busType == BUS_TYPE_SPI) {
+        IOHi(busdev->busType_u.spi.csnPin);
+        IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     }
 #else
     UNUSED(busdev);
@@ -112,10 +112,10 @@ void qmp6988BusInit(busDevice_t *busdev) {
 
 void qmp6988BusDeinit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (busdev->bustype == BUS_TYPE_SPI) {
-        IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_IPU);
-        IORelease(busdev->busdev_u.spi.csnPin);
-        IOInit(busdev->busdev_u.spi.csnPin, OWNER_SPI_PREINIT, 0);
+    if (busdev->busType == BUS_TYPE_SPI) {
+        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_IPU);
+        IORelease(busdev->busType_u.spi.csnPin);
+        IOInit(busdev->busType_u.spi.csnPin, OWNER_SPI_PREINIT, 0);
     }
 #else
     UNUSED(busdev);
@@ -142,15 +142,15 @@ bool qmp6988Detect(baroDev_t *baro) {
     busDevice_t *busdev = &baro->busdev;
     bool defaultAddressApplied = false;
     qmp6988BusInit(busdev);
-    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
-        busdev->busdev_u.i2c.address = QMP6988_I2C_ADDR;
+    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
+        busdev->busType_u.i2c.address = QMP6988_I2C_ADDR;
         defaultAddressApplied = true;
     }
     busReadRegisterBuffer(busdev, QMP6988_CHIP_ID_REG, &qmp6988_chip_id, 1);  /* read Chip Id */
     if (qmp6988_chip_id != QMP6988_DEFAULT_CHIP_ID) {
         qmp6988BusDeinit(busdev);
         if (defaultAddressApplied) {
-            busdev->busdev_u.i2c.address = 0;
+            busdev->busType_u.i2c.address = 0;
         }
         return false;
     }

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -99,7 +99,7 @@ STATIC_UNIT_TESTED void qmp6988_calculate(int32_t *pressure, int32_t *temperatur
 
 void qmp6988BusInit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         IOHi(busdev->busdev_u.spi.csnPin);
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
@@ -112,7 +112,7 @@ void qmp6988BusInit(busDevice_t *busdev) {
 
 void qmp6988BusDeinit(busDevice_t *busdev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_IPU);
         IORelease(busdev->busdev_u.spi.csnPin);
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_SPI_PREINIT, 0);
@@ -142,7 +142,7 @@ bool qmp6988Detect(baroDev_t *baro) {
     busDevice_t *busdev = &baro->busdev;
     bool defaultAddressApplied = false;
     qmp6988BusInit(busdev);
-    if ((busdev->bustype == BUSTYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
+    if ((busdev->bustype == BUS_TYPE_I2C) && (busdev->busdev_u.i2c.address == 0)) {
         busdev->busdev_u.i2c.address = QMP6988_I2C_ADDR;
         defaultAddressApplied = true;
     }

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -37,11 +37,11 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
 #endif
     switch (busdev->bustype) {
 #ifdef USE_SPI
-    case BUSTYPE_SPI:
+    case BUS_TYPE_SPI:
         return spiBusWriteRegister(busdev, reg & 0x7f, data);
 #endif
 #ifdef USE_I2C
-    case BUSTYPE_I2C:
+    case BUS_TYPE_I2C:
         return i2cBusWriteRegister(busdev, reg, data);
 #endif
     default:
@@ -61,11 +61,11 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
 #endif
     switch (busdev->bustype) {
 #ifdef USE_SPI
-    case BUSTYPE_SPI:
+    case BUS_TYPE_SPI:
         return spiBusReadRegisterBuffer(busdev, reg | 0x80, data, length);
 #endif
 #ifdef USE_I2C
-    case BUSTYPE_I2C:
+    case BUS_TYPE_I2C:
         return i2cBusReadRegisterBuffer(busdev, reg, data, length);
 #endif
     default:

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -29,7 +29,7 @@
 
 bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
-    return spiBusWriteRegister(busdev, reg & 0x7f, data);
+    return spiWriteReg(busdev, reg & 0x7f, data);
 #else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(reg);
@@ -38,7 +38,7 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
     switch (busdev->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        return spiBusWriteRegister(busdev, reg & 0x7f, data);
+        return spiWriteReg(busdev, reg & 0x7f, data);
 #endif
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
@@ -52,7 +52,7 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
 
 bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
-    return spiBusReadRegisterBuffer(busdev, reg | 0x80, data, length);
+    return spiReadRegBuf(busdev, reg | 0x80, data, length);
 #else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(reg);
@@ -62,7 +62,7 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
     switch (busdev->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        return spiBusReadRegisterBuffer(busdev, reg | 0x80, data, length);
+        return spiReadRegBuf(busdev, reg | 0x80, data, length);
 #endif
 #ifdef USE_I2C
     case BUS_TYPE_I2C:

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -35,7 +35,7 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
     UNUSED(reg);
     UNUSED(data);
 #endif
-    switch (busdev->bustype) {
+    switch (busdev->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
         return spiBusWriteRegister(busdev, reg & 0x7f, data);
@@ -59,7 +59,7 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
     UNUSED(data);
     UNUSED(length);
 #endif
-    switch (busdev->bustype) {
+    switch (busdev->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
         return spiBusReadRegisterBuffer(busdev, reg | 0x80, data, length);

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -64,3 +64,10 @@ void targetBusInit(void);
 bool busWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
 bool busReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t busReadRegister(const busDevice_t *bus, uint8_t reg);
+
+// Betaflight paste-and-tweak alias. In BF master, extDevice_t is a separate
+// per-device struct pointing at a shared busDevice_s. EmuFlight has not yet
+// split the bus resource from the device; extDevice_t is a typedef so driver
+// code written against BF signatures compiles against our combined struct.
+// Splitting the shared-bus resource is a future refactor stage.
+typedef busDevice_t extDevice_t;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -26,10 +26,10 @@
 #include "drivers/io_types.h"
 
 typedef enum {
-    BUSTYPE_NONE = 0,
-    BUSTYPE_I2C,
-    BUSTYPE_SPI,
-    BUSTYPE_MPU_SLAVE // Slave I2C on SPI master
+    BUS_TYPE_NONE = 0,
+    BUS_TYPE_I2C,
+    BUS_TYPE_SPI,
+    BUS_TYPE_MPU_SLAVE // Slave I2C on SPI master
 } busType_e;
 
 typedef struct busDevice_s {

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -33,9 +33,9 @@ typedef enum {
 } busType_e;
 
 typedef struct busDevice_s {
-    busType_e bustype;
+    busType_e busType;
     union {
-        struct deviceSpi_s {
+        struct busSpi_s {
             SPI_TypeDef *instance;
 #if defined(USE_HAL_DRIVER)
             SPI_HandleTypeDef* handle; // cached here for efficiency
@@ -46,15 +46,15 @@ typedef struct busDevice_s {
             IO_t rstPin;
 #endif
         } spi;
-        struct deviceI2C_s {
+        struct busI2C_s {
             I2CDevice device;
             uint8_t address;
         } i2c;
-        struct deviceMpuSlave_s {
+        struct busMpuSlave_s {
             const struct busDevice_s *master;
             uint8_t address;
         } mpuSlave;
-    } busdev_u;
+    } busType_u;
 } busDevice_t;
 
 #ifdef TARGET_BUS_INIT

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -30,16 +30,16 @@
 #include "drivers/bus_i2c.h"
 
 bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
-    return i2cWrite(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, data);
+    return i2cWrite(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, data);
 }
 
 bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
-    return i2cRead(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, length, data);
+    return i2cRead(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, length, data);
 }
 
 uint8_t i2cBusReadRegister(const busDevice_t *busdev, uint8_t reg) {
     uint8_t data;
-    i2cRead(busdev->busdev_u.i2c.device, busdev->busdev_u.i2c.address, reg, 1, &data);
+    i2cRead(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, 1, &data);
     return data;
 }
 #endif

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -248,7 +248,7 @@ FAST_CODE uint8_t spiBusReadRegister(const busDevice_t *bus, uint8_t reg) {
 }
 
 void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance) {
-    bus->bustype = BUSTYPE_SPI;
+    bus->bustype = BUS_TYPE_SPI;
     bus->busdev_u.spi.instance = instance;
 }
 

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -117,27 +117,27 @@ uint32_t spiTimeoutUserCallback(SPI_TypeDef *instance) {
 
 FAST_CODE bool spiBusTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busdev_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         memcpy(dmaTxBuffer, (uint8_t *)txData, length);
         dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, length, 1);
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busdev_u.spi.csnPin);
+                IOHi(bus->busType_u.spi.csnPin);
                 return false;
             }
         }
         memcpy((uint8_t *)rxData, dmaRxBuffer, length);
     } else {
-        IOLo(bus->busdev_u.spi.csnPin);
-        spiTransfer(bus->busdev_u.spi.instance, txData, rxData, length);
-        IOHi(bus->busdev_u.spi.csnPin);
+        IOLo(bus->busType_u.spi.csnPin);
+        spiTransfer(bus->busType_u.spi.instance, txData, rxData, length);
+        IOHi(bus->busType_u.spi.csnPin);
     }
 #else
-    IOLo(bus->busdev_u.spi.csnPin);
-    spiTransfer(bus->busdev_u.spi.instance, txData, rxData, length);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
+    spiTransfer(bus->busType_u.spi.instance, txData, rxData, length);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
     return true;
 }
@@ -159,7 +159,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance) {
 
 FAST_CODE bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busdev_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         dmaTxBuffer[0] = reg;
         dmaTxBuffer[1] = data;
@@ -167,89 +167,89 @@ FAST_CODE bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t 
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busdev_u.spi.csnPin);
+                IOHi(bus->busType_u.spi.csnPin);
                 return false;
             }
         }
     } else {
-        IOLo(bus->busdev_u.spi.csnPin);
-        spiTransferByte(bus->busdev_u.spi.instance, reg);
-        spiTransferByte(bus->busdev_u.spi.instance, data);
-        IOHi(bus->busdev_u.spi.csnPin);
+        IOLo(bus->busType_u.spi.csnPin);
+        spiTransferByte(bus->busType_u.spi.instance, reg);
+        spiTransferByte(bus->busType_u.spi.instance, data);
+        IOHi(bus->busType_u.spi.csnPin);
     }
 #else
-    IOLo(bus->busdev_u.spi.csnPin);
-    spiTransferByte(bus->busdev_u.spi.instance, reg);
-    spiTransferByte(bus->busdev_u.spi.instance, data);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
+    spiTransferByte(bus->busType_u.spi.instance, reg);
+    spiTransferByte(bus->busType_u.spi.instance, data);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
     return true;
 }
 
 FAST_CODE bool spiBusReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busdev_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         dmaTxBuffer[0] = reg | 0x80;
         dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, length + 1, 1);
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busdev_u.spi.csnPin);
+                IOHi(bus->busType_u.spi.csnPin);
                 return false;
             }
         }
         memcpy(data, dmaRxBuffer + 1, length);
     } else {
-        IOLo(bus->busdev_u.spi.csnPin);
-        spiTransferByte(bus->busdev_u.spi.instance, reg | 0x80); // read transaction
-        spiTransfer(bus->busdev_u.spi.instance, NULL, data, length);
-        IOHi(bus->busdev_u.spi.csnPin);
+        IOLo(bus->busType_u.spi.csnPin);
+        spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
+        spiTransfer(bus->busType_u.spi.instance, NULL, data, length);
+        IOHi(bus->busType_u.spi.csnPin);
     }
 #else
-    IOLo(bus->busdev_u.spi.csnPin);
-    spiTransferByte(bus->busdev_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(bus->busdev_u.spi.instance, NULL, data, length);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
+    spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(bus->busType_u.spi.instance, NULL, data, length);
+    IOHi(bus->busType_u.spi.csnPin);
 #endif
     return true;
 }
 
 FAST_CODE uint8_t spiBusReadRegister(const busDevice_t *bus, uint8_t reg) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busdev_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         dmaTxBuffer[0] = reg | 0x80;
         dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, 2, 1);
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busdev_u.spi.csnPin);
+                IOHi(bus->busType_u.spi.csnPin);
                 return 0;
             }
         }
         return dmaRxBuffer[1];
     } else {
         uint8_t data;
-        IOLo(bus->busdev_u.spi.csnPin);
-        spiTransferByte(bus->busdev_u.spi.instance, reg | 0x80); // read transaction
-        spiTransfer(bus->busdev_u.spi.instance, NULL, &data, 1);
-        IOHi(bus->busdev_u.spi.csnPin);
+        IOLo(bus->busType_u.spi.csnPin);
+        spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
+        spiTransfer(bus->busType_u.spi.instance, NULL, &data, 1);
+        IOHi(bus->busType_u.spi.csnPin);
         return data;
     }
 #else
     uint8_t data;
-    IOLo(bus->busdev_u.spi.csnPin);
-    spiTransferByte(bus->busdev_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(bus->busdev_u.spi.instance, NULL, &data, 1);
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
+    spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(bus->busType_u.spi.instance, NULL, &data, 1);
+    IOHi(bus->busType_u.spi.csnPin);
     return data;
 #endif
 }
 
 void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance) {
-    bus->bustype = BUS_TYPE_SPI;
-    bus->busdev_u.spi.instance = instance;
+    bus->busType = BUS_TYPE_SPI;
+    bus->busType_u.spi.instance = instance;
 }
 
 // icm42688p and bmi270 porting

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -115,7 +115,7 @@ uint32_t spiTimeoutUserCallback(SPI_TypeDef *instance) {
 }
 
 
-FAST_CODE bool spiBusTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length) {
+FAST_CODE bool spiReadWriteBuf(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -157,7 +157,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance) {
     }
 }
 
-FAST_CODE bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data) {
+FAST_CODE bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -186,7 +186,7 @@ FAST_CODE bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t 
     return true;
 }
 
-FAST_CODE bool spiBusReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
+FAST_CODE bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -215,7 +215,7 @@ FAST_CODE bool spiBusReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uin
     return true;
 }
 
-FAST_CODE uint8_t spiBusReadRegister(const busDevice_t *bus, uint8_t reg) {
+FAST_CODE uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -274,10 +274,10 @@ uint16_t spiCalculateDivider(uint32_t freq)
 }
 
 // Wait for bus to become free, then read a byte of data where the register is bitwise OR'ed with 0x80
-// EmuFlight codebase is old.  Bitwise or 0x80 is redundant here as spiBusReadRegister already contains such.
+// EmuFlight codebase is old.  Bitwise or 0x80 is redundant here as spiReadReg already contains such.
 uint8_t spiReadRegMsk(const busDevice_t *bus, uint8_t reg)
 {
-    return spiBusReadRegister(bus, reg | 0x80);
+    return spiReadReg(bus, reg | 0x80);
 }
 
 #endif

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -112,11 +112,11 @@ void spiResetErrorCounter(SPI_TypeDef *instance);
 SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
 SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
-bool spiBusTransfer(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length);
+bool spiReadWriteBuf(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length);
 
-bool spiBusWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool spiBusReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t spiBusReadRegister(const busDevice_t *bus, uint8_t reg);
+bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
+bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
+uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg);
 void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance);
 
 struct spiPinConfig_s;

--- a/src/main/drivers/compass/compass.h
+++ b/src/main/drivers/compass/compass.h
@@ -28,7 +28,7 @@ typedef struct magDev_s {
     sensorMagInitFuncPtr init;                              // initialize function
     sensorMagReadFuncPtr read;                              // read 3 axis data function
     extiCallbackRec_t exti;
-    busDevice_t busdev;
+    extDevice_t dev;
     sensor_align_e magAlign;
     ioTag_t magIntExtiTag;
     int16_t magGain[3];

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -226,7 +226,7 @@ restart:
 
 static bool ak8963ReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *buf, uint8_t len) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (busdev->bustype == BUSTYPE_MPU_SLAVE) {
+    if (busdev->bustype == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveReadRegisterBuffer(busdev, reg, buf, len);
     }
 #endif
@@ -235,7 +235,7 @@ static bool ak8963ReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uin
 
 static bool ak8963WriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (busdev->bustype == BUSTYPE_MPU_SLAVE) {
+    if (busdev->bustype == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveWriteRegister(busdev, reg, data);
     }
 #endif
@@ -262,13 +262,13 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     const busDevice_t *busdev = &mag->busdev;
     switch (busdev->bustype) {
 #if defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_AK8963)
-    case BUSTYPE_I2C:
-    case BUSTYPE_SPI:
+    case BUS_TYPE_I2C:
+    case BUS_TYPE_SPI:
         ack = ak8963DirectReadData(busdev, buf);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    case BUSTYPE_MPU_SLAVE:
+    case BUS_TYPE_MPU_SLAVE:
         ack = ak8963SlaveReadData(busdev, buf);
         break;
 #endif
@@ -311,12 +311,12 @@ static bool ak8963Init(magDev_t *mag) {
 void ak8963BusInit(const busDevice_t *busdev) {
     switch (busdev->bustype) {
 #ifdef USE_MAG_AK8963
-    case BUSTYPE_I2C:
+    case BUS_TYPE_I2C:
         UNUSED(busdev);
         break;
 #endif
 #ifdef USE_MAG_SPI_AK8963
-    case BUSTYPE_SPI:
+    case BUS_TYPE_SPI:
         IOHi(busdev->busdev_u.spi.csnPin);                                                  // Disable
         IOInit(busdev->busdev_u.spi.csnPin, OWNER_COMPASS_CS, 0);
         IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
@@ -324,7 +324,7 @@ void ak8963BusInit(const busDevice_t *busdev) {
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    case BUSTYPE_MPU_SLAVE:
+    case BUS_TYPE_MPU_SLAVE:
         rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
         // initialze I2C master via SPI bus
         ak8963SpiWriteRegisterDelay(busdev->busdev_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
@@ -340,17 +340,17 @@ void ak8963BusInit(const busDevice_t *busdev) {
 void ak8963BusDeInit(const busDevice_t *busdev) {
     switch (busdev->bustype) {
 #ifdef USE_MAG_AK8963
-    case BUSTYPE_I2C:
+    case BUS_TYPE_I2C:
         UNUSED(busdev);
         break;
 #endif
 #ifdef USE_MAG_SPI_AK8963
-    case BUSTYPE_SPI:
+    case BUS_TYPE_SPI:
         spiPreinitCsByIO(busdev->busdev_u.spi.csnPin);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    case BUSTYPE_MPU_SLAVE:
+    case BUS_TYPE_MPU_SLAVE:
         ak8963SpiWriteRegisterDelay(busdev->busdev_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);
         break;
 #endif
@@ -362,7 +362,7 @@ void ak8963BusDeInit(const busDevice_t *busdev) {
 bool ak8963Detect(magDev_t *mag) {
     uint8_t sig = 0;
     busDevice_t *busdev = &mag->busdev;
-    if ((busdev->bustype == BUSTYPE_I2C || busdev->bustype == BUSTYPE_MPU_SLAVE) && busdev->busdev_u.mpuSlave.address == 0) {
+    if ((busdev->bustype == BUS_TYPE_I2C || busdev->bustype == BUS_TYPE_MPU_SLAVE) && busdev->busdev_u.mpuSlave.address == 0) {
         busdev->busdev_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
     }
     ak8963BusInit(busdev);

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -101,7 +101,7 @@
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
 
 static bool ak8963SpiWriteRegisterDelay(const busDevice_t *bus, uint8_t reg, uint8_t data) {
-    spiBusWriteRegister(bus, reg, data);
+    spiWriteReg(bus, reg, data);
     delayMicroseconds(10);
     return true;
 }
@@ -113,7 +113,7 @@ static bool ak8963SlaveReadRegisterBuffer(const busDevice_t *slavedev, uint8_t r
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);     // read number of bytes
     delay(4);
     __disable_irq();
-    bool ack = spiBusReadRegisterBuffer(bus, MPU_RA_EXT_SENS_DATA_00, buf, len);            // read I2C
+    bool ack = spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, buf, len);            // read I2C
     __enable_irq();
     return ack;
 }
@@ -168,7 +168,7 @@ static bool ak8963SlaveCompleteRead(const busDevice_t *slavedev, uint8_t *buf) {
         delayMicroseconds(timeRemaining);
     }
     queuedRead.waiting = false;
-    spiBusReadRegisterBuffer(bus, MPU_RA_EXT_SENS_DATA_00, buf, queuedRead.len);            // read I2C buffer
+    spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, buf, queuedRead.len);            // read I2C buffer
     return true;
 }
 

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -107,8 +107,8 @@ static bool ak8963SpiWriteRegisterDelay(const busDevice_t *bus, uint8_t reg, uin
 }
 
 static bool ak8963SlaveReadRegisterBuffer(const busDevice_t *slavedev, uint8_t reg, uint8_t *buf, uint8_t len) {
-    const busDevice_t *bus = slavedev->busdev_u.mpuSlave.master;
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busdev_u.mpuSlave.address | READ_FLAG); // set I2C slave address for read
+    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG); // set I2C slave address for read
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);     // read number of bytes
     delay(4);
@@ -119,8 +119,8 @@ static bool ak8963SlaveReadRegisterBuffer(const busDevice_t *slavedev, uint8_t r
 }
 
 static bool ak8963SlaveWriteRegister(const busDevice_t *slavedev, uint8_t reg, uint8_t data) {
-    const busDevice_t *bus = slavedev->busdev_u.mpuSlave.master;
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busdev_u.mpuSlave.address); // set I2C slave address for write
+    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address); // set I2C slave address for write
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_DO, data);                             // set I2C sLave value
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (1 & 0x0F) | I2C_SLV0_EN);       // write 1 byte
@@ -139,9 +139,9 @@ static bool ak8963SlaveStartRead(const busDevice_t *slavedev, uint8_t reg, uint8
     if (queuedRead.waiting) {
         return false;
     }
-    const busDevice_t *bus = slavedev->busdev_u.mpuSlave.master;
+    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
     queuedRead.len = len;
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busdev_u.mpuSlave.address | READ_FLAG);  // set I2C slave address for read
+    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG);  // set I2C slave address for read
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);    // read number of bytes
     queuedRead.readStartedAt = micros();
@@ -163,7 +163,7 @@ static uint32_t ak8963SlaveQueuedReadTimeRemaining(void) {
 
 static bool ak8963SlaveCompleteRead(const busDevice_t *slavedev, uint8_t *buf) {
     uint32_t timeRemaining = ak8963SlaveQueuedReadTimeRemaining();
-    const busDevice_t *bus = slavedev->busdev_u.mpuSlave.master;
+    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
     if (timeRemaining > 0) {
         delayMicroseconds(timeRemaining);
     }
@@ -226,7 +226,7 @@ restart:
 
 static bool ak8963ReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *buf, uint8_t len) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (busdev->bustype == BUS_TYPE_MPU_SLAVE) {
+    if (busdev->busType == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveReadRegisterBuffer(busdev, reg, buf, len);
     }
 #endif
@@ -235,7 +235,7 @@ static bool ak8963ReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uin
 
 static bool ak8963WriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (busdev->bustype == BUS_TYPE_MPU_SLAVE) {
+    if (busdev->busType == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveWriteRegister(busdev, reg, data);
     }
 #endif
@@ -260,7 +260,7 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     bool ack = false;
     uint8_t buf[7];
     const busDevice_t *busdev = &mag->busdev;
-    switch (busdev->bustype) {
+    switch (busdev->busType) {
 #if defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_AK8963)
     case BUS_TYPE_I2C:
     case BUS_TYPE_SPI:
@@ -309,7 +309,7 @@ static bool ak8963Init(magDev_t *mag) {
 }
 
 void ak8963BusInit(const busDevice_t *busdev) {
-    switch (busdev->bustype) {
+    switch (busdev->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
         UNUSED(busdev);
@@ -317,19 +317,19 @@ void ak8963BusInit(const busDevice_t *busdev) {
 #endif
 #ifdef USE_MAG_SPI_AK8963
     case BUS_TYPE_SPI:
-        IOHi(busdev->busdev_u.spi.csnPin);                                                  // Disable
-        IOInit(busdev->busdev_u.spi.csnPin, OWNER_COMPASS_CS, 0);
-        IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+        IOHi(busdev->busType_u.spi.csnPin);                                                  // Disable
+        IOInit(busdev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
+        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
         rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
         // initialze I2C master via SPI bus
-        ak8963SpiWriteRegisterDelay(busdev->busdev_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
-        ak8963SpiWriteRegisterDelay(busdev->busdev_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz
-        ak8963SpiWriteRegisterDelay(busdev->busdev_u.mpuSlave.master, MPU_RA_USER_CTRL, 0x30);   // I2C master mode, SPI mode only
+        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
+        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz
+        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_USER_CTRL, 0x30);   // I2C master mode, SPI mode only
         break;
 #endif
     default:
@@ -338,7 +338,7 @@ void ak8963BusInit(const busDevice_t *busdev) {
 }
 
 void ak8963BusDeInit(const busDevice_t *busdev) {
-    switch (busdev->bustype) {
+    switch (busdev->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
         UNUSED(busdev);
@@ -346,12 +346,12 @@ void ak8963BusDeInit(const busDevice_t *busdev) {
 #endif
 #ifdef USE_MAG_SPI_AK8963
     case BUS_TYPE_SPI:
-        spiPreinitCsByIO(busdev->busdev_u.spi.csnPin);
+        spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
-        ak8963SpiWriteRegisterDelay(busdev->busdev_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);
+        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);
         break;
 #endif
     default:
@@ -362,8 +362,8 @@ void ak8963BusDeInit(const busDevice_t *busdev) {
 bool ak8963Detect(magDev_t *mag) {
     uint8_t sig = 0;
     busDevice_t *busdev = &mag->busdev;
-    if ((busdev->bustype == BUS_TYPE_I2C || busdev->bustype == BUS_TYPE_MPU_SLAVE) && busdev->busdev_u.mpuSlave.address == 0) {
-        busdev->busdev_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
+    if ((busdev->busType == BUS_TYPE_I2C || busdev->busType == BUS_TYPE_MPU_SLAVE) && busdev->busType_u.mpuSlave.address == 0) {
+        busdev->busType_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
     }
     ak8963BusInit(busdev);
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL2, CNTL2_SOFT_RESET);                    // reset MAG

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -259,7 +259,7 @@ static int16_t parseMag(uint8_t *raw, int16_t gain) {
 static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     bool ack = false;
     uint8_t buf[7];
-    const busDevice_t *busdev = &mag->busdev;
+    const busDevice_t *busdev = &mag->dev;
     switch (busdev->busType) {
 #if defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_AK8963)
     case BUS_TYPE_I2C:
@@ -292,7 +292,7 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
 static bool ak8963Init(magDev_t *mag) {
     uint8_t asa[3];
     uint8_t status;
-    const busDevice_t *busdev = &mag->busdev;
+    const busDevice_t *busdev = &mag->dev;
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down before entering fuse mode
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_FUSE_ROM);                 // Enter Fuse ROM access mode
     ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ASAX, asa, sizeof(asa));                // Read the x-, y-, and z-axis calibration values
@@ -361,7 +361,7 @@ void ak8963BusDeInit(const busDevice_t *busdev) {
 
 bool ak8963Detect(magDev_t *mag) {
     uint8_t sig = 0;
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     if ((busdev->busType == BUS_TYPE_I2C || busdev->busType == BUS_TYPE_MPU_SLAVE) && busdev->busType_u.mpuSlave.address == 0) {
         busdev->busType_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
     }

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -135,8 +135,8 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
 bool ak8975Detect(magDev_t *mag) {
     uint8_t sig = 0;
     busDevice_t *busdev = &mag->busdev;
-    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
-        busdev->busdev_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
+    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
+        busdev->busType_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_WIA, &sig, 1);
     if (!ack || sig != AK8975_DEVICE_ID) // 0x48 / 01001000 / 'H'

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -80,7 +80,7 @@
 static bool ak8975Init(magDev_t *mag) {
     uint8_t asa[3];
     uint8_t status;
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down before entering fuse mode
     delay(20);
     busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_FUSE_ROM); // Enter Fuse ROM access mode
@@ -109,7 +109,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
     bool ack;
     uint8_t status;
     uint8_t buf[6];
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST1, &status, 1);
     if (!ack || (status & ST1_REG_DATA_READY) == 0) {
         return false;
@@ -134,7 +134,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
 
 bool ak8975Detect(magDev_t *mag) {
     uint8_t sig = 0;
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
         busdev->busType_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
     }

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -135,7 +135,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
 bool ak8975Detect(magDev_t *mag) {
     uint8_t sig = 0;
     busDevice_t *busdev = &mag->busdev;
-    if (busdev->bustype == BUSTYPE_I2C && busdev->busdev_u.i2c.address == 0) {
+    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
         busdev->busdev_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_WIA, &sig, 1);

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -183,10 +183,10 @@ static void hmc5883lConfigureDataReadyInterruptHandling(magDev_t* mag) {
 
 #ifdef USE_MAG_SPI_HMC5883
 static void hmc5883SpiInit(busDevice_t *busdev) {
-    IOHi(busdev->busdev_u.spi.csnPin); // Disable
-    IOInit(busdev->busdev_u.spi.csnPin, OWNER_COMPASS_CS, 0);
-    IOConfigGPIO(busdev->busdev_u.spi.csnPin, IOCFG_OUT_PP);
-    spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    IOHi(busdev->busType_u.spi.csnPin); // Disable
+    IOInit(busdev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
+    IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 #endif
 
@@ -218,13 +218,13 @@ bool hmc5883lDetect(magDev_t* mag) {
     busDevice_t *busdev = &mag->busdev;
     uint8_t sig = 0;
 #ifdef USE_MAG_SPI_HMC5883
-    if (busdev->bustype == BUS_TYPE_SPI) {
+    if (busdev->busType == BUS_TYPE_SPI) {
         hmc5883SpiInit(&mag->busdev);
     }
 #endif
 #ifdef USE_MAG_HMC5883
-    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
-        busdev->busdev_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
+    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
+        busdev->busType_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
     }
 #endif
     bool ack = busReadRegisterBuffer(&mag->busdev, HMC58X3_REG_IDA, &sig, 1);

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -192,7 +192,7 @@ static void hmc5883SpiInit(busDevice_t *busdev) {
 
 static bool hmc5883lRead(magDev_t *mag, int16_t *magData) {
     uint8_t buf[6];
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     bool ack = busReadRegisterBuffer(busdev, HMC58X3_REG_DATA, buf, 6);
     if (!ack) {
         return false;
@@ -204,7 +204,7 @@ static bool hmc5883lRead(magDev_t *mag, int16_t *magData) {
 }
 
 static bool hmc5883lInit(magDev_t *mag) {
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     // leave test mode
     busWriteRegister(busdev, HMC58X3_REG_CONFA, HMC_CONFA_8_SAMLES | HMC_CONFA_DOR_15HZ | HMC_CONFA_NORMAL);    // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode
     busWriteRegister(busdev, HMC58X3_REG_CONFB, HMC_CONFB_GAIN_1_3GA);                                          // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
@@ -215,11 +215,11 @@ static bool hmc5883lInit(magDev_t *mag) {
 }
 
 bool hmc5883lDetect(magDev_t* mag) {
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     uint8_t sig = 0;
 #ifdef USE_MAG_SPI_HMC5883
     if (busdev->busType == BUS_TYPE_SPI) {
-        hmc5883SpiInit(&mag->busdev);
+        hmc5883SpiInit(&mag->dev);
     }
 #endif
 #ifdef USE_MAG_HMC5883
@@ -227,7 +227,7 @@ bool hmc5883lDetect(magDev_t* mag) {
         busdev->busType_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
     }
 #endif
-    bool ack = busReadRegisterBuffer(&mag->busdev, HMC58X3_REG_IDA, &sig, 1);
+    bool ack = busReadRegisterBuffer(&mag->dev, HMC58X3_REG_IDA, &sig, 1);
     if (!ack || sig != HMC5883_DEVICE_ID) {
         return false;
     }

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -218,12 +218,12 @@ bool hmc5883lDetect(magDev_t* mag) {
     busDevice_t *busdev = &mag->busdev;
     uint8_t sig = 0;
 #ifdef USE_MAG_SPI_HMC5883
-    if (busdev->bustype == BUSTYPE_SPI) {
+    if (busdev->bustype == BUS_TYPE_SPI) {
         hmc5883SpiInit(&mag->busdev);
     }
 #endif
 #ifdef USE_MAG_HMC5883
-    if (busdev->bustype == BUSTYPE_I2C && busdev->busdev_u.i2c.address == 0) {
+    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
         busdev->busdev_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
     }
 #endif

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -103,7 +103,7 @@
 
 static bool lis3mdlRead(magDev_t * mag, int16_t *magData) {
     uint8_t buf[6];
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     bool ack = busReadRegisterBuffer(busdev, LIS3MDL_REG_OUT_X_L, buf, 6);
     if (!ack) {
         return false;
@@ -115,7 +115,7 @@ static bool lis3mdlRead(magDev_t * mag, int16_t *magData) {
 }
 
 static bool lis3mdlInit(magDev_t *mag) {
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG2, LIS3MDL_FS_4GAUSS);
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG1, LIS3MDL_TEMP_EN | LIS3MDL_OM_ULTRA_HI_PROF | LIS3MDL_DO_80);
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG5, LIS3MDL_BDU);
@@ -126,12 +126,12 @@ static bool lis3mdlInit(magDev_t *mag) {
 }
 
 bool lis3mdlDetect(magDev_t * mag) {
-    busDevice_t *busdev = &mag->busdev;
+    busDevice_t *busdev = &mag->dev;
     uint8_t sig = 0;
     if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
         busdev->busType_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
     }
-    bool ack = busReadRegisterBuffer(&mag->busdev, LIS3MDL_REG_WHO_AM_I, &sig, 1);
+    bool ack = busReadRegisterBuffer(&mag->dev, LIS3MDL_REG_WHO_AM_I, &sig, 1);
     if (!ack || sig != LIS3MDL_DEVICE_ID) {
         return false;
     }

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -128,7 +128,7 @@ static bool lis3mdlInit(magDev_t *mag) {
 bool lis3mdlDetect(magDev_t * mag) {
     busDevice_t *busdev = &mag->busdev;
     uint8_t sig = 0;
-    if (busdev->bustype == BUSTYPE_I2C && busdev->busdev_u.i2c.address == 0) {
+    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
         busdev->busdev_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(&mag->busdev, LIS3MDL_REG_WHO_AM_I, &sig, 1);

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -128,8 +128,8 @@ static bool lis3mdlInit(magDev_t *mag) {
 bool lis3mdlDetect(magDev_t * mag) {
     busDevice_t *busdev = &mag->busdev;
     uint8_t sig = 0;
-    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
-        busdev->busdev_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
+    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
+        busdev->busType_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(&mag->busdev, LIS3MDL_REG_WHO_AM_I, &sig, 1);
     if (!ack || sig != LIS3MDL_DEVICE_ID) {

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -108,8 +108,8 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
 
 bool qmc5883lDetect(magDev_t *magDev) {
     busDevice_t *busdev = &magDev->busdev;
-    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
-        busdev->busdev_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
+    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
+        busdev->busType_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
     }
     // Must write reset first  - don't care about the result
     busWriteRegister(busdev, QMC5883L_REG_CONF2, QMC5883L_RST);

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -108,7 +108,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
 
 bool qmc5883lDetect(magDev_t *magDev) {
     busDevice_t *busdev = &magDev->busdev;
-    if (busdev->bustype == BUSTYPE_I2C && busdev->busdev_u.i2c.address == 0) {
+    if (busdev->bustype == BUS_TYPE_I2C && busdev->busdev_u.i2c.address == 0) {
         busdev->busdev_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
     }
     // Must write reset first  - don't care about the result

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -75,7 +75,7 @@
 static bool qmc5883lInit(magDev_t *magDev) {
     UNUSED(magDev);
     bool ack = true;
-    busDevice_t *busdev = &magDev->busdev;
+    busDevice_t *busdev = &magDev->dev;
     ack = ack && busWriteRegister(busdev, 0x0B, 0x01);
     ack = ack && busWriteRegister(busdev, QMC5883L_REG_CONF1, QMC5883L_MODE_CONTINUOUS | QMC5883L_ODR_200HZ | QMC5883L_OSR_512 | QMC5883L_RNG_8G);
     if (!ack) {
@@ -91,7 +91,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
     magData[X] = 0;
     magData[Y] = 0;
     magData[Z] = 0;
-    busDevice_t *busdev = &magDev->busdev;
+    busDevice_t *busdev = &magDev->dev;
     bool ack = busReadRegisterBuffer(busdev, QMC5883L_REG_STATUS, &status, 1);
     if (!ack || (status & 0x04) == 0) {
         return false;
@@ -107,7 +107,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
 }
 
 bool qmc5883lDetect(magDev_t *magDev) {
-    busDevice_t *busdev = &magDev->busdev;
+    busDevice_t *busdev = &magDev->dev;
     if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
         busdev->busType_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
     }

--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -174,7 +174,7 @@ static const uint8_t multiWiiFont[][5] = { // Refer to "Times New Roman" Font Da
 };
 
 static bool i2c_OLED_send_cmd(busDevice_t *bus, uint8_t command) {
-    return i2cWrite(bus->busdev_u.i2c.device, bus->busdev_u.i2c.address, 0x80, command);
+    return i2cWrite(bus->busType_u.i2c.device, bus->busType_u.i2c.address, 0x80, command);
 }
 
 static bool i2c_OLED_send_cmdarray(busDevice_t *bus, const uint8_t *commands, size_t len) {
@@ -187,7 +187,7 @@ static bool i2c_OLED_send_cmdarray(busDevice_t *bus, const uint8_t *commands, si
 }
 
 static bool i2c_OLED_send_byte(busDevice_t *bus, uint8_t val) {
-    return i2cWrite(bus->busdev_u.i2c.device, bus->busdev_u.i2c.address, 0x40, val);
+    return i2cWrite(bus->busType_u.i2c.device, bus->busType_u.i2c.address, 0x40, val);
 }
 
 void i2c_OLED_clear_display_quick(busDevice_t *bus) {

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -45,26 +45,26 @@ static flashDevice_t flashDevice;
 bool flashInit(const flashConfig_t *flashConfig) {
     busdev = &busInstance;
     if (flashConfig->csTag) {
-        busdev->busdev_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
+        busdev->busType_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
     } else {
         return false;
     }
-    if (!IOIsFreeOrPreinit(busdev->busdev_u.spi.csnPin)) {
+    if (!IOIsFreeOrPreinit(busdev->busType_u.spi.csnPin)) {
         return false;
     }
-    busdev->bustype = BUS_TYPE_SPI;
+    busdev->busType = BUS_TYPE_SPI;
     SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(flashConfig->spiDevice));
     if (!instance) {
         return false;
     }
     spiBusSetInstance(busdev, instance);
-    IOInit(busdev->busdev_u.spi.csnPin, OWNER_FLASH_CS, 0);
-    IOConfigGPIO(busdev->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(busdev->busdev_u.spi.csnPin);
+    IOInit(busdev->busType_u.spi.csnPin, OWNER_FLASH_CS, 0);
+    IOConfigGPIO(busdev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(busdev->busType_u.spi.csnPin);
 #ifndef FLASH_SPI_SHARED
     //Maximum speed for standard READ command is 20mHz, other commands tolerate 25mHz
-    //spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_FAST);
-    spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD * 2);
+    //spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD * 2);
 #endif
     flashDevice.busdev = busdev;
     const uint8_t out[] = { SPIFLASH_INSTRUCTION_RDID, 0, 0, 0 };

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -75,7 +75,7 @@ bool flashInit(const flashConfig_t *flashConfig) {
     uint8_t in[4];
     in[1] = 0;
     // Clearing the CS bit terminates the command early so we don't have to read the chip UID:
-    spiBusTransfer(busdev, out, in, sizeof(out));
+    spiReadWriteBuf(busdev, out, in, sizeof(out));
     // Manufacturer, memory type, and capacity
     uint32_t chipID = (in[1] << 16) | (in[2] << 8) | (in[3]);
 #ifdef USE_FLASH_M25P16

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -52,7 +52,7 @@ bool flashInit(const flashConfig_t *flashConfig) {
     if (!IOIsFreeOrPreinit(busdev->busdev_u.spi.csnPin)) {
         return false;
     }
-    busdev->bustype = BUSTYPE_SPI;
+    busdev->bustype = BUS_TYPE_SPI;
     SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(flashConfig->spiDevice));
     if (!instance) {
         return false;

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -66,7 +66,7 @@ bool flashInit(const flashConfig_t *flashConfig) {
     //spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_FAST);
     spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD * 2);
 #endif
-    flashDevice.busdev = busdev;
+    flashDevice.dev = busdev;
     const uint8_t out[] = { SPIFLASH_INSTRUCTION_RDID, 0, 0, 0 };
     delay(50); // short delay required after initialisation of SPI device instance.
     /* Just in case transfer fails and writes nothing, so we don't try to verify the ID against random garbage

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -72,8 +72,7 @@ bool flashInit(const flashConfig_t *flashConfig) {
     /* Just in case transfer fails and writes nothing, so we don't try to verify the ID against random garbage
      * from the stack:
      */
-    uint8_t in[4];
-    in[1] = 0;
+    uint8_t in[4] = { 0 };
     // Clearing the CS bit terminates the command early so we don't have to read the chip UID:
     spiReadWriteBuf(busdev, out, in, sizeof(out));
     // Manufacturer, memory type, and capacity

--- a/src/main/drivers/flash_impl.h
+++ b/src/main/drivers/flash_impl.h
@@ -29,7 +29,7 @@
 struct flashVTable_s;
 
 typedef struct flashDevice_s {
-    busDevice_t *busdev;
+    extDevice_t *dev;
     const struct flashVTable_s *vTable;
     flashGeometry_t geometry;
     uint32_t currentWriteAddress;

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -80,18 +80,18 @@ STATIC_ASSERT(M25P16_PAGESIZE < FLASH_MAX_PAGE_SIZE, M25P16_PAGESIZE_too_small);
 const flashVTable_t m25p16_vTable;
 
 static void m25p16_disable(busDevice_t *bus) {
-    IOHi(bus->busdev_u.spi.csnPin);
+    IOHi(bus->busType_u.spi.csnPin);
     __NOP();
 }
 
 static void m25p16_enable(busDevice_t *bus) {
     __NOP();
-    IOLo(bus->busdev_u.spi.csnPin);
+    IOLo(bus->busType_u.spi.csnPin);
 }
 
 static void m25p16_transfer(busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int len) {
     m25p16_enable(bus);
-    spiTransfer(bus->busdev_u.spi.instance, txData, rxData, len);
+    spiTransfer(bus->busType_u.spi.instance, txData, rxData, len);
     m25p16_disable(bus);
 }
 
@@ -100,7 +100,7 @@ static void m25p16_transfer(busDevice_t *bus, const uint8_t *txData, uint8_t *rx
  */
 static void m25p16_performOneByteCommand(busDevice_t *bus, uint8_t command) {
     m25p16_enable(bus);
-    spiTransferByte(bus->busdev_u.spi.instance, command);
+    spiTransferByte(bus->busType_u.spi.instance, command);
     m25p16_disable(bus);
 }
 
@@ -230,8 +230,8 @@ static void m25p16_pageProgramContinue(flashDevice_t *fdevice, const uint8_t *da
     m25p16_waitForReady(fdevice, DEFAULT_TIMEOUT_MILLIS);
     m25p16_writeEnable(fdevice);
     m25p16_enable(fdevice->busdev);
-    spiTransfer(fdevice->busdev->busdev_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
-    spiTransfer(fdevice->busdev->busdev_u.spi.instance, data, NULL, length);
+    spiTransfer(fdevice->busdev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
+    spiTransfer(fdevice->busdev->busType_u.spi.instance, data, NULL, length);
     m25p16_disable(fdevice->busdev);
     fdevice->currentWriteAddress += length;
 }
@@ -276,8 +276,8 @@ static int m25p16_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *b
         return 0;
     }
     m25p16_enable(fdevice->busdev);
-    spiTransfer(fdevice->busdev->busdev_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
-    spiTransfer(fdevice->busdev->busdev_u.spi.instance, NULL, buffer, length);
+    spiTransfer(fdevice->busdev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
+    spiTransfer(fdevice->busdev->busType_u.spi.instance, NULL, buffer, length);
     m25p16_disable(fdevice->busdev);
     return length;
 }

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -109,7 +109,7 @@ static void m25p16_performOneByteCommand(busDevice_t *bus, uint8_t command) {
  * a write like program and erase.
  */
 static void m25p16_writeEnable(flashDevice_t *fdevice) {
-    m25p16_performOneByteCommand(fdevice->busdev, M25P16_INSTRUCTION_WRITE_ENABLE);
+    m25p16_performOneByteCommand(fdevice->dev, M25P16_INSTRUCTION_WRITE_ENABLE);
     // Assume that we're about to do some writing, so the device is just about to become busy
     fdevice->couldBeBusy = true;
 }
@@ -123,7 +123,7 @@ static uint8_t m25p16_readStatus(busDevice_t *bus) {
 
 static bool m25p16_isReady(flashDevice_t *fdevice) {
     // If couldBeBusy is false, don't bother to poll the flash chip for its status
-    fdevice->couldBeBusy = fdevice->couldBeBusy && ((m25p16_readStatus(fdevice->busdev) & M25P16_STATUS_FLAG_WRITE_IN_PROGRESS) != 0);
+    fdevice->couldBeBusy = fdevice->couldBeBusy && ((m25p16_readStatus(fdevice->dev) & M25P16_STATUS_FLAG_WRITE_IN_PROGRESS) != 0);
     return !fdevice->couldBeBusy;
 }
 
@@ -186,7 +186,7 @@ bool m25p16_detect(flashDevice_t *fdevice, uint32_t chipID) {
     fdevice->geometry.totalSize = fdevice->geometry.sectorSize * fdevice->geometry.sectors;
     if (fdevice->geometry.totalSize > 16 * 1024 * 1024) {
         fdevice->isLargeFlash = true;
-        m25p16_performOneByteCommand(fdevice->busdev, W25Q256_INSTRUCTION_ENTER_4BYTE_ADDRESS_MODE);
+        m25p16_performOneByteCommand(fdevice->dev, W25Q256_INSTRUCTION_ENTER_4BYTE_ADDRESS_MODE);
     }
     fdevice->couldBeBusy = true; // Just for luck we'll assume the chip could be busy even though it isn't specced to be
     fdevice->vTable = &m25p16_vTable;
@@ -210,13 +210,13 @@ static void m25p16_eraseSector(flashDevice_t *fdevice, uint32_t address) {
     m25p16_setCommandAddress(&out[1], address, fdevice->isLargeFlash);
     m25p16_waitForReady(fdevice, SECTOR_ERASE_TIMEOUT_MILLIS);
     m25p16_writeEnable(fdevice);
-    m25p16_transfer(fdevice->busdev, out, NULL, sizeof(out));
+    m25p16_transfer(fdevice->dev, out, NULL, sizeof(out));
 }
 
 static void m25p16_eraseCompletely(flashDevice_t *fdevice) {
     m25p16_waitForReady(fdevice, BULK_ERASE_TIMEOUT_MILLIS);
     m25p16_writeEnable(fdevice);
-    m25p16_performOneByteCommand(fdevice->busdev, M25P16_INSTRUCTION_BULK_ERASE);
+    m25p16_performOneByteCommand(fdevice->dev, M25P16_INSTRUCTION_BULK_ERASE);
 }
 
 static void m25p16_pageProgramBegin(flashDevice_t *fdevice, uint32_t address) {
@@ -229,10 +229,10 @@ static void m25p16_pageProgramContinue(flashDevice_t *fdevice, const uint8_t *da
     m25p16_setCommandAddress(&command[1], fdevice->currentWriteAddress, fdevice->isLargeFlash);
     m25p16_waitForReady(fdevice, DEFAULT_TIMEOUT_MILLIS);
     m25p16_writeEnable(fdevice);
-    m25p16_enable(fdevice->busdev);
-    spiTransfer(fdevice->busdev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
-    spiTransfer(fdevice->busdev->busType_u.spi.instance, data, NULL, length);
-    m25p16_disable(fdevice->busdev);
+    m25p16_enable(fdevice->dev);
+    spiTransfer(fdevice->dev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
+    spiTransfer(fdevice->dev->busType_u.spi.instance, data, NULL, length);
+    m25p16_disable(fdevice->dev);
     fdevice->currentWriteAddress += length;
 }
 
@@ -275,10 +275,10 @@ static int m25p16_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *b
     if (!m25p16_waitForReady(fdevice, DEFAULT_TIMEOUT_MILLIS)) {
         return 0;
     }
-    m25p16_enable(fdevice->busdev);
-    spiTransfer(fdevice->busdev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
-    spiTransfer(fdevice->busdev->busType_u.spi.instance, NULL, buffer, length);
-    m25p16_disable(fdevice->busdev);
+    m25p16_enable(fdevice->dev);
+    spiTransfer(fdevice->dev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
+    spiTransfer(fdevice->dev->busType_u.spi.instance, NULL, buffer, length);
+    m25p16_disable(fdevice->dev);
     return length;
 }
 

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -73,7 +73,7 @@ static bool w25m_isReady(flashDevice_t *fdevice) {
     UNUSED(fdevice);
     for (int die = 0 ; die < dieCount ; die++) {
         if (dieDevice[die].couldBeBusy) {
-            w25m_dieSelect(fdevice->busdev, die);
+            w25m_dieSelect(fdevice->dev, die);
             if (!dieDevice[die].vTable->isReady(&dieDevice[die])) {
                 return false;
             }
@@ -98,8 +98,8 @@ bool w25m_detect(flashDevice_t *fdevice, uint32_t chipID) {
         // W25Q256 x 2
         dieCount = 2;
         for (int die = 0 ; die < dieCount ; die++) {
-            w25m_dieSelect(fdevice->busdev, die);
-            dieDevice[die].busdev = fdevice->busdev;
+            w25m_dieSelect(fdevice->dev, die);
+            dieDevice[die].dev = fdevice->dev;
             m25p16_detect(&dieDevice[die], JEDEC_ID_WINBOND_W25Q256);
         }
         fdevice->geometry.flashType = FLASH_TYPE_NOR;
@@ -124,13 +124,13 @@ bool w25m_detect(flashDevice_t *fdevice, uint32_t chipID) {
 
 void w25m_eraseSector(flashDevice_t *fdevice, uint32_t address) {
     int dieNumber = address / dieSize;
-    w25m_dieSelect(fdevice->busdev, dieNumber);
+    w25m_dieSelect(fdevice->dev, dieNumber);
     dieDevice[dieNumber].vTable->eraseSector(&dieDevice[dieNumber], address % dieSize);
 }
 
 void w25m_eraseCompletely(flashDevice_t *fdevice) {
     for (int dieNumber = 0 ; dieNumber < dieCount ; dieNumber++) {
-        w25m_dieSelect(fdevice->busdev, dieNumber);
+        w25m_dieSelect(fdevice->dev, dieNumber);
         dieDevice[dieNumber].vTable->eraseCompletely(&dieDevice[dieNumber]);
     }
 }
@@ -141,7 +141,7 @@ static int currentWriteDie;
 void w25m_pageProgramBegin(flashDevice_t *fdevice, uint32_t address) {
     UNUSED(fdevice);
     currentWriteDie = address / dieSize;
-    w25m_dieSelect(fdevice->busdev, currentWriteDie);
+    w25m_dieSelect(fdevice->dev, currentWriteDie);
     currentWriteAddress = address % dieSize;
     dieDevice[currentWriteDie].vTable->pageProgramBegin(&dieDevice[currentWriteDie], currentWriteAddress);
 }
@@ -172,7 +172,7 @@ int w25m_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *buffer, in
         int dieNumber = address / dieSize;
         uint32_t dieAddress = address % dieSize;
         tlen = MIN(dieAddress + rlen, dieSize) - dieAddress;
-        w25m_dieSelect(fdevice->busdev, dieNumber);
+        w25m_dieSelect(fdevice->dev, dieNumber);
         rbytes = dieDevice[dieNumber].vTable->readBytes(&dieDevice[dieNumber], dieAddress, buffer, tlen);
         if (!rbytes) {
             return 0;

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -65,7 +65,7 @@ static void w25m_dieSelect(busDevice_t *busdev, int die) {
         return;
     }
     uint8_t command[2] = { W25M_INSTRUCTION_SOFTWARE_DIE_SELECT, die };
-    spiBusTransfer(busdev, command, NULL, 2);
+    spiReadWriteBuf(busdev, command, NULL, 2);
     activeDie = die;
 }
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -175,15 +175,15 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-#define __spiBusTransactionBegin(busdev)        {spiSetDivisor((busdev)->busdev_u.spi.instance, max7456SpiClock);IOLo((busdev)->busdev_u.spi.csnPin);}
+#define __spiBusTransactionBegin(busdev)        {spiSetDivisor((busdev)->busType_u.spi.instance, max7456SpiClock);IOLo((busdev)->busType_u.spi.csnPin);}
 #else
-#define __spiBusTransactionBegin(busdev)        IOLo((busdev)->busdev_u.spi.csnPin)
+#define __spiBusTransactionBegin(busdev)        IOLo((busdev)->busType_u.spi.csnPin)
 #endif
 
 #ifdef MAX7456_RESTORE_CLK
-#define __spiBusTransactionEnd(busdev)       {IOHi((busdev)->busdev_u.spi.csnPin);spiSetDivisor((busdev)->busdev_u.spi.instance, MAX7456_RESTORE_CLK);}
+#define __spiBusTransactionEnd(busdev)       {IOHi((busdev)->busType_u.spi.csnPin);spiSetDivisor((busdev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
 #else
-#define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busdev_u.spi.csnPin)
+#define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busType_u.spi.csnPin)
 #endif
 
 #ifndef MAX7456_SPI_CLK
@@ -228,11 +228,11 @@ static uint8_t max7456DeviceType;
 static void max7456DrawScreenSlow(void);
 
 static uint8_t max7456Send(uint8_t add, uint8_t data) {
-    spiTransferByte(busdev->busdev_u.spi.instance, add);
+    spiTransferByte(busdev->busType_u.spi.instance, add);
 #ifdef USE_NBD7456
     delayMicroseconds(10);
 #endif
-    return spiTransferByte(busdev->busdev_u.spi.instance, data);
+    return spiTransferByte(busdev->busType_u.spi.instance, data);
 }
 
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -250,7 +250,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
 #endif
     // Common to both channels
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(busdev->busdev_u.spi.instance->DR));
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(busdev->busType_u.spi.instance->DR));
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
@@ -289,7 +289,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
     // Enable SPI TX/RX request
     __spiBusTransactionBegin(busdev);
     dmaTransactionInProgress = true;
-    SPI_I2S_DMACmd(busdev->busdev_u.spi.instance,
+    SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                    SPI_I2S_DMAReq_Rx |
 #endif
@@ -302,16 +302,16 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         DMA_Cmd(MAX7456_DMA_CHANNEL_RX, DISABLE);
 #endif
         // Make sure SPI DMA transfer is complete
-        while (SPI_I2S_GetFlagStatus (busdev->busdev_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
-        while (SPI_I2S_GetFlagStatus (busdev->busdev_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
+        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
+        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
-        while (SPI_I2S_GetFlagStatus(busdev->busdev_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            busdev->busdev_u.spi.instance->DR;
+        while (SPI_I2S_GetFlagStatus(busdev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
+            busdev->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-        SPI_I2S_DMACmd(busdev->busdev_u.spi.instance,
+        SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                        SPI_I2S_DMAReq_Rx |
 #endif
@@ -388,17 +388,17 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     if (!max7456Config->csTag) {
         return false;
     }
-    busdev->busdev_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
-    if (!IOIsFreeOrPreinit(busdev->busdev_u.spi.csnPin)) {
+    busdev->busType_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
+    if (!IOIsFreeOrPreinit(busdev->busType_u.spi.csnPin)) {
         return false;
     }
-    IOInit(busdev->busdev_u.spi.csnPin, OWNER_OSD_CS, 0);
-    IOConfigGPIO(busdev->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(busdev->busdev_u.spi.csnPin);
+    IOInit(busdev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
+    IOConfigGPIO(busdev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(busdev->busType_u.spi.csnPin);
     spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
-    spiSetDivisor(busdev->busdev_u.spi.instance, MAX7456_SPI_CLK * 2);
+    spiSetDivisor(busdev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
     max7456Send(MAX7456ADD_CMAL, (1 << 6)); // CA[8] bit
     if (max7456Send(MAX7456ADD_CMAL | MAX7456ADD_READ, 0xff) & (1 << 6)) {
         max7456DeviceType = MAX7456_DEVICE_TYPE_AT;
@@ -425,7 +425,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
 #endif
-    spiSetDivisor(busdev->busdev_u.spi.instance, max7456SpiClock);
+    spiSetDivisor(busdev->busType_u.spi.instance, max7456SpiClock);
     // force soft reset on Max7456
     __spiBusTransactionBegin(busdev);
     max7456Send(MAX7456ADD_VM0, MAX7456_RESET);
@@ -580,10 +580,10 @@ void max7456DrawScreen(void) {
 #ifdef USE_NBD7456
             for(int k = 0; k < buff_len; k++) {
                 delayMicroseconds(5);
-                spiTransferByte(busdev->busdev_u.spi.instance, spiBuff[k]);
+                spiTransferByte(busdev->busType_u.spi.instance, spiBuff[k]);
             }
 #else // USE_NBD7456
-            spiTransfer(busdev->busdev_u.spi.instance, spiBuff, NULL, buff_len);
+            spiTransfer(busdev->busType_u.spi.instance, spiBuff, NULL, buff_len);
 #endif
             __spiBusTransactionEnd(busdev);
 #endif // MAX7456_DMA_CHANNEL_TX

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -175,15 +175,15 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-#define __spiBusTransactionBegin(busdev)        {spiSetDivisor((busdev)->busdev_u.spi.instance, max7456SpiClock);IOLo((busdev)->busdev_u.spi.csnPin);}
+#define __spiBusTransactionBegin(busdev)        {spiSetDivisor((busdev)->busType_u.spi.instance, max7456SpiClock);IOLo((busdev)->busType_u.spi.csnPin);}
 #else
-#define __spiBusTransactionBegin(busdev)        IOLo((busdev)->busdev_u.spi.csnPin)
+#define __spiBusTransactionBegin(busdev)        IOLo((busdev)->busType_u.spi.csnPin)
 #endif
 
 #ifdef MAX7456_RESTORE_CLK
-#define __spiBusTransactionEnd(busdev)       {IOHi((busdev)->busdev_u.spi.csnPin);spiSetDivisor((busdev)->busdev_u.spi.instance, MAX7456_RESTORE_CLK);}
+#define __spiBusTransactionEnd(busdev)       {IOHi((busdev)->busType_u.spi.csnPin);spiSetDivisor((busdev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
 #else
-#define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busdev_u.spi.csnPin)
+#define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busType_u.spi.csnPin)
 #endif
 
 #ifndef MAX7456_SPI_CLK
@@ -228,9 +228,9 @@ static uint8_t max7456DeviceType;
 static void max7456DrawScreenSlow(void);
 
 static uint8_t max7456Send(uint8_t add, uint8_t data) {
-    spiTransferByte(busdev->busdev_u.spi.instance, add);
+    spiTransferByte(busdev->busType_u.spi.instance, add);
     delayMicroseconds(10);
-    return spiTransferByte(busdev->busdev_u.spi.instance, data);
+    return spiTransferByte(busdev->busType_u.spi.instance, data);
 }
 
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -248,7 +248,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
 #endif
     // Common to both channels
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(busdev->busdev_u.spi.instance->DR));
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(busdev->busType_u.spi.instance->DR));
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
@@ -287,7 +287,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
     // Enable SPI TX/RX request
     __spiBusTransactionBegin(busdev);
     dmaTransactionInProgress = true;
-    SPI_I2S_DMACmd(busdev->busdev_u.spi.instance,
+    SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                    SPI_I2S_DMAReq_Rx |
 #endif
@@ -300,16 +300,16 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         DMA_Cmd(MAX7456_DMA_CHANNEL_RX, DISABLE);
 #endif
         // Make sure SPI DMA transfer is complete
-        while (SPI_I2S_GetFlagStatus (busdev->busdev_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
-        while (SPI_I2S_GetFlagStatus (busdev->busdev_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
+        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
+        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
-        while (SPI_I2S_GetFlagStatus(busdev->busdev_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            busdev->busdev_u.spi.instance->DR;
+        while (SPI_I2S_GetFlagStatus(busdev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
+            busdev->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-        SPI_I2S_DMACmd(busdev->busdev_u.spi.instance,
+        SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                        SPI_I2S_DMAReq_Rx |
 #endif
@@ -386,17 +386,17 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     if (!max7456Config->csTag) {
         return false;
     }
-    busdev->busdev_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
-    if (!IOIsFreeOrPreinit(busdev->busdev_u.spi.csnPin)) {
+    busdev->busType_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
+    if (!IOIsFreeOrPreinit(busdev->busType_u.spi.csnPin)) {
         return false;
     }
-    IOInit(busdev->busdev_u.spi.csnPin, OWNER_OSD_CS, 0);
-    IOConfigGPIO(busdev->busdev_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(busdev->busdev_u.spi.csnPin);
+    IOInit(busdev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
+    IOConfigGPIO(busdev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(busdev->busType_u.spi.csnPin);
     spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
-    spiSetDivisor(busdev->busdev_u.spi.instance, MAX7456_SPI_CLK * 2);
+    spiSetDivisor(busdev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
     max7456Send(MAX7456ADD_CMAL, (1 << 6)); // CA[8] bit
     if (max7456Send(MAX7456ADD_CMAL | MAX7456ADD_READ, 0xff) & (1 << 6)) {
         max7456DeviceType = MAX7456_DEVICE_TYPE_AT;
@@ -423,7 +423,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
 #endif
-    spiSetDivisor(busdev->busdev_u.spi.instance, max7456SpiClock);
+    spiSetDivisor(busdev->busType_u.spi.instance, max7456SpiClock);
     // force soft reset on Max7456
     __spiBusTransactionBegin(busdev);
     max7456Send(MAX7456ADD_VM0, MAX7456_RESET);
@@ -573,12 +573,12 @@ void max7456DrawScreen(void) {
             max7456SendDma(spiBuff, NULL, buff_len);
 #else
             // __spiBusTransactionBegin(busdev);
-            // spiTransfer(busdev->busdev_u.spi.instance, spiBuff, NULL, buff_len);
+            // spiTransfer(busdev->busType_u.spi.instance, spiBuff, NULL, buff_len);
             // __spiBusTransactionEnd(busdev);
             __spiBusTransactionBegin(busdev);
             for(int k = 0; k < buff_len; k++) {
                 delayMicroseconds(5);
-                spiTransferByte(busdev->busdev_u.spi.instance, spiBuff[k]);
+                spiTransferByte(busdev->busType_u.spi.instance, spiBuff[k]);
             }
             __spiBusTransactionEnd(busdev);
 #endif // MAX7456_DMA_CHANNEL_TX

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -44,8 +44,8 @@
 static busDevice_t rxSpiDevice;
 static busDevice_t *busdev = &rxSpiDevice;
 
-#define DISABLE_RX()    {IOHi(busdev->busdev_u.spi.csnPin);}
-#define ENABLE_RX()     {IOLo(busdev->busdev_u.spi.csnPin);}
+#define DISABLE_RX()    {IOHi(busdev->busType_u.spi.csnPin);}
+#define ENABLE_RX()     {IOLo(busdev->busType_u.spi.csnPin);}
 
 bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig) {
     if (!rxSpiConfig->spibus) {
@@ -55,14 +55,14 @@ bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig) {
     const IO_t rxCsPin = IOGetByTag(rxSpiConfig->csnTag);
     IOInit(rxCsPin, OWNER_RX_SPI_CS, 0);
     IOConfigGPIO(rxCsPin, SPI_IO_CS_CFG);
-    busdev->busdev_u.spi.csnPin = rxCsPin;
+    busdev->busType_u.spi.csnPin = rxCsPin;
     DISABLE_RX();
-    spiSetDivisor(busdev->busdev_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return true;
 }
 
 uint8_t rxSpiTransferByte(uint8_t data) {
-    return spiTransferByte(busdev->busdev_u.spi.instance, data);
+    return spiTransferByte(busdev->busType_u.spi.instance, data);
 }
 
 uint8_t rxSpiWriteByte(uint8_t data) {

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -601,8 +601,8 @@ void dashboardUpdate(timeUs_t currentTimeUs) {
 
 void dashboardInit(void) {
     static busDevice_t dashBoardBus;
-    dashBoardBus.busdev_u.i2c.device = I2C_CFG_TO_DEV(dashboardConfig()->device);
-    dashBoardBus.busdev_u.i2c.address = dashboardConfig()->address;
+    dashBoardBus.busType_u.i2c.device = I2C_CFG_TO_DEV(dashboardConfig()->device);
+    dashBoardBus.busType_u.i2c.address = dashboardConfig()->address;
     bus = &dashBoardBus;
     delay(200);
     resetDisplay();

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -366,7 +366,7 @@ retry:
 bool accInit(void) {
     memset(&acc, 0, sizeof(acc));
     // copy over the common gyro mpu settings
-    acc.dev.bus = *gyroSensorBus();
+    acc.dev.dev = *gyroSensorBus();
     acc.dev.mpuDetectionResult = *gyroMpuDetectionResult();
     acc.dev.acc_high_fsr = accelerometerConfig()->acc_high_fsr;
 #ifdef USE_DUAL_GYRO

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -151,16 +151,16 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse) {
     switch (barometerConfig()->baro_bustype) {
     case BUS_TYPE_I2C:
 #ifdef USE_I2C
-        dev->busdev.bustype = BUS_TYPE_I2C;
-        dev->busdev.busdev_u.i2c.device = I2C_CFG_TO_DEV(barometerConfig()->baro_i2c_device);
-        dev->busdev.busdev_u.i2c.address = barometerConfig()->baro_i2c_address;
+        dev->busdev.busType = BUS_TYPE_I2C;
+        dev->busdev.busType_u.i2c.device = I2C_CFG_TO_DEV(barometerConfig()->baro_i2c_device);
+        dev->busdev.busType_u.i2c.address = barometerConfig()->baro_i2c_address;
 #endif
         break;
     case BUS_TYPE_SPI:
 #ifdef USE_SPI
-        dev->busdev.bustype = BUS_TYPE_SPI;
+        dev->busdev.busType = BUS_TYPE_SPI;
         spiBusSetInstance(&dev->busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(barometerConfig()->baro_spi_device)));
-        dev->busdev.busdev_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
+        dev->busdev.busType_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
 #endif
         break;
     default:

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -92,39 +92,39 @@ void pgResetFn_barometerConfig(barometerConfig_t *barometerConfig) {
 #endif
 #endif
 #if defined(DEFAULT_BARO_SPI_BMP280)
-    barometerConfig->baro_bustype = BUSTYPE_SPI;
+    barometerConfig->baro_bustype = BUS_TYPE_SPI;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(BMP280_SPI_INSTANCE));
     barometerConfig->baro_spi_csn = IO_TAG(BMP280_CS_PIN);
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
 #elif defined(DEFAULT_BARO_SPI_MS5611)
-    barometerConfig->baro_bustype = BUSTYPE_SPI;
+    barometerConfig->baro_bustype = BUS_TYPE_SPI;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(MS5611_SPI_INSTANCE));
     barometerConfig->baro_spi_csn = IO_TAG(MS5611_CS_PIN);
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
 #elif defined(DEFAULT_BARO_SPI_QMP6988)
-    barometerConfig->baro_bustype = BUSTYPE_SPI;
+    barometerConfig->baro_bustype = BUS_TYPE_SPI;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(QMP6988_SPI_INSTANCE));
     barometerConfig->baro_spi_csn = IO_TAG(QMP6988_CS_PIN);
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
 #elif defined(DEFAULT_BARO_SPI_LPS)
-    barometerConfig->baro_bustype = BUSTYPE_SPI;
+    barometerConfig->baro_bustype = BUS_TYPE_SPI;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(LPS_SPI_INSTANCE));
     barometerConfig->baro_spi_csn = IO_TAG(LPS_CS_PIN);
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
 #elif defined(DEFAULT_BARO_MS5611) || defined(DEFAULT_BARO_BMP280) || defined(DEFAULT_BARO_BMP085)||defined(DEFAULT_BARO_QMP6988)
     // All I2C devices shares a default config with address = 0 (per device default)
-    barometerConfig->baro_bustype = BUSTYPE_I2C;
+    barometerConfig->baro_bustype = BUS_TYPE_I2C;
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(BARO_I2C_INSTANCE);
     barometerConfig->baro_i2c_address = 0;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
     barometerConfig->baro_spi_csn = IO_TAG_NONE;
 #else
     barometerConfig->baro_hardware = BARO_NONE;
-    barometerConfig->baro_bustype = BUSTYPE_NONE;
+    barometerConfig->baro_bustype = BUS_TYPE_NONE;
     barometerConfig->baro_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     barometerConfig->baro_i2c_address = 0;
     barometerConfig->baro_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
@@ -149,16 +149,16 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse) {
     UNUSED(dev);
 #endif
     switch (barometerConfig()->baro_bustype) {
-    case BUSTYPE_I2C:
+    case BUS_TYPE_I2C:
 #ifdef USE_I2C
-        dev->busdev.bustype = BUSTYPE_I2C;
+        dev->busdev.bustype = BUS_TYPE_I2C;
         dev->busdev.busdev_u.i2c.device = I2C_CFG_TO_DEV(barometerConfig()->baro_i2c_device);
         dev->busdev.busdev_u.i2c.address = barometerConfig()->baro_i2c_address;
 #endif
         break;
-    case BUSTYPE_SPI:
+    case BUS_TYPE_SPI:
 #ifdef USE_SPI
-        dev->busdev.bustype = BUSTYPE_SPI;
+        dev->busdev.bustype = BUS_TYPE_SPI;
         spiBusSetInstance(&dev->busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(barometerConfig()->baro_spi_device)));
         dev->busdev.busdev_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
 #endif

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -151,16 +151,16 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse) {
     switch (barometerConfig()->baro_bustype) {
     case BUS_TYPE_I2C:
 #ifdef USE_I2C
-        dev->busdev.busType = BUS_TYPE_I2C;
-        dev->busdev.busType_u.i2c.device = I2C_CFG_TO_DEV(barometerConfig()->baro_i2c_device);
-        dev->busdev.busType_u.i2c.address = barometerConfig()->baro_i2c_address;
+        dev->dev.busType = BUS_TYPE_I2C;
+        dev->dev.busType_u.i2c.device = I2C_CFG_TO_DEV(barometerConfig()->baro_i2c_device);
+        dev->dev.busType_u.i2c.address = barometerConfig()->baro_i2c_address;
 #endif
         break;
     case BUS_TYPE_SPI:
 #ifdef USE_SPI
-        dev->busdev.busType = BUS_TYPE_SPI;
-        spiBusSetInstance(&dev->busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(barometerConfig()->baro_spi_device)));
-        dev->busdev.busType_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
+        dev->dev.busType = BUS_TYPE_SPI;
+        spiBusSetInstance(&dev->dev, spiInstanceByDevice(SPI_CFG_TO_DEV(barometerConfig()->baro_spi_device)));
+        dev->dev.busType_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
 #endif
         break;
     default:

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -76,7 +76,7 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig) {
 // 2. I2C devices are will be handled by address = 0 (per device default).
 // 3. Slave I2C device on SPI gyro
 #if defined(USE_SPI) && (defined(USE_MAG_SPI_HMC5883) || defined(USE_MAG_SPI_AK8963))
-    compassConfig->mag_bustype = BUSTYPE_SPI;
+    compassConfig->mag_bustype = BUS_TYPE_SPI;
 #ifdef USE_MAG_SPI_HMC5883
     compassConfig->mag_spi_device = SPI_DEV_TO_CFG(spiDeviceByInstance(HMC5883_SPI_INSTANCE));
     compassConfig->mag_spi_csn = IO_TAG(HMC5883_CS_PIN);
@@ -87,20 +87,20 @@ void pgResetFn_compassConfig(compassConfig_t *compassConfig) {
     compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     compassConfig->mag_i2c_address = 0;
 #elif defined(USE_MAG_HMC5883) || defined(USE_MAG_QMC5883) || defined(USE_MAG_AK8975) || (defined(USE_MAG_AK8963) && !(defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250)))
-    compassConfig->mag_bustype = BUSTYPE_I2C;
+    compassConfig->mag_bustype = BUS_TYPE_I2C;
     compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(MAG_I2C_INSTANCE);
     compassConfig->mag_i2c_address = 0;
     compassConfig->mag_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
     compassConfig->mag_spi_csn = IO_TAG_NONE;
 #elif defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    compassConfig->mag_bustype = BUSTYPE_MPU_SLAVE;
+    compassConfig->mag_bustype = BUS_TYPE_MPU_SLAVE;
     compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     compassConfig->mag_i2c_address = 0;
     compassConfig->mag_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
     compassConfig->mag_spi_csn = IO_TAG_NONE;
 #else
     compassConfig->mag_hardware = MAG_NONE;
-    compassConfig->mag_bustype = BUSTYPE_NONE;
+    compassConfig->mag_bustype = BUS_TYPE_NONE;
     compassConfig->mag_i2c_device = I2C_DEV_TO_CFG(I2CINVALID);
     compassConfig->mag_i2c_address = 0;
     compassConfig->mag_spi_device = SPI_DEV_TO_CFG(SPIINVALID);
@@ -123,23 +123,23 @@ bool compassDetect(magDev_t *dev) {
 #endif
     switch (compassConfig()->mag_bustype) {
 #ifdef USE_I2C
-    case BUSTYPE_I2C:
-        busdev->bustype = BUSTYPE_I2C;
+    case BUS_TYPE_I2C:
+        busdev->bustype = BUS_TYPE_I2C;
         busdev->busdev_u.i2c.device = I2C_CFG_TO_DEV(compassConfig()->mag_i2c_device);
         busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
 #endif
         break;
 #ifdef USE_SPI
-    case BUSTYPE_SPI:
-        busdev->bustype = BUSTYPE_SPI;
+    case BUS_TYPE_SPI:
+        busdev->bustype = BUS_TYPE_SPI;
         spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(compassConfig()->mag_spi_device)));
         busdev->busdev_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
 #endif
         break;
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    case BUSTYPE_MPU_SLAVE: {
+    case BUS_TYPE_MPU_SLAVE: {
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            busdev->bustype = BUSTYPE_MPU_SLAVE;
+            busdev->bustype = BUS_TYPE_MPU_SLAVE;
             busdev->busdev_u.mpuSlave.master = gyroSensorBus();
             busdev->busdev_u.mpuSlave.address = compassConfig()->mag_i2c_address;
         } else {
@@ -157,7 +157,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_HMC5883:
 #if defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883)
-        if (busdev->bustype == BUSTYPE_I2C) {
+        if (busdev->bustype == BUS_TYPE_I2C) {
             busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (hmc5883lDetect(dev)) {
@@ -171,7 +171,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_QMC5883:
 #ifdef USE_MAG_QMC5883
-        if (busdev->bustype == BUSTYPE_I2C) {
+        if (busdev->bustype == BUS_TYPE_I2C) {
             busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (qmc5883lDetect(dev)) {
@@ -185,7 +185,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
-        if (busdev->bustype == BUSTYPE_I2C) {
+        if (busdev->bustype == BUS_TYPE_I2C) {
             busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (ak8975Detect(dev)) {
@@ -199,11 +199,11 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8963:
 #if defined(USE_MAG_AK8963) || defined(USE_MAG_SPI_AK8963)
-        if (busdev->bustype == BUSTYPE_I2C) {
+        if (busdev->bustype == BUS_TYPE_I2C) {
             busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            dev->busdev.bustype = BUSTYPE_MPU_SLAVE;
+            dev->busdev.bustype = BUS_TYPE_MPU_SLAVE;
             busdev->busdev_u.mpuSlave.address = compassConfig()->mag_i2c_address;
             dev->busdev.busdev_u.mpuSlave.master = gyroSensorBus();
         }

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -117,7 +117,7 @@ static uint8_t magInit = 0;
 #if !defined(SIMULATOR_BUILD)
 bool compassDetect(magDev_t *dev) {
     magSensor_e magHardware = MAG_NONE;
-    busDevice_t *busdev = &dev->busdev;
+    busDevice_t *busdev = &dev->dev;
 #ifdef USE_MAG_DATA_READY_SIGNAL
     dev->magIntExtiTag = compassConfig()->interruptTag;
 #endif
@@ -203,9 +203,9 @@ bool compassDetect(magDev_t *dev) {
             busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            dev->busdev.busType = BUS_TYPE_MPU_SLAVE;
+            dev->dev.busType = BUS_TYPE_MPU_SLAVE;
             busdev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
-            dev->busdev.busType_u.mpuSlave.master = gyroSensorBus();
+            dev->dev.busType_u.mpuSlave.master = gyroSensorBus();
         }
         if (ak8963Detect(dev)) {
 #ifdef MAG_AK8963_ALIGN

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -203,9 +203,9 @@ bool compassDetect(magDev_t *dev) {
             busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            dev->dev.busType = BUS_TYPE_MPU_SLAVE;
+            busdev->busType = BUS_TYPE_MPU_SLAVE;
             busdev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
-            dev->dev.busType_u.mpuSlave.master = gyroSensorBus();
+            busdev->busType_u.mpuSlave.master = gyroSensorBus();
         }
         if (ak8963Detect(dev)) {
 #ifdef MAG_AK8963_ALIGN

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -124,24 +124,24 @@ bool compassDetect(magDev_t *dev) {
     switch (compassConfig()->mag_bustype) {
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        busdev->bustype = BUS_TYPE_I2C;
-        busdev->busdev_u.i2c.device = I2C_CFG_TO_DEV(compassConfig()->mag_i2c_device);
-        busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+        busdev->busType = BUS_TYPE_I2C;
+        busdev->busType_u.i2c.device = I2C_CFG_TO_DEV(compassConfig()->mag_i2c_device);
+        busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
 #endif
         break;
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        busdev->bustype = BUS_TYPE_SPI;
+        busdev->busType = BUS_TYPE_SPI;
         spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(compassConfig()->mag_spi_device)));
-        busdev->busdev_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
+        busdev->busType_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
 #endif
         break;
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE: {
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            busdev->bustype = BUS_TYPE_MPU_SLAVE;
-            busdev->busdev_u.mpuSlave.master = gyroSensorBus();
-            busdev->busdev_u.mpuSlave.address = compassConfig()->mag_i2c_address;
+            busdev->busType = BUS_TYPE_MPU_SLAVE;
+            busdev->busType_u.mpuSlave.master = gyroSensorBus();
+            busdev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
         } else {
             return false;
         }
@@ -157,8 +157,8 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_HMC5883:
 #if defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883)
-        if (busdev->bustype == BUS_TYPE_I2C) {
-            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (busdev->busType == BUS_TYPE_I2C) {
+            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (hmc5883lDetect(dev)) {
 #ifdef MAG_HMC5883_ALIGN
@@ -171,8 +171,8 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_QMC5883:
 #ifdef USE_MAG_QMC5883
-        if (busdev->bustype == BUS_TYPE_I2C) {
-            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (busdev->busType == BUS_TYPE_I2C) {
+            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (qmc5883lDetect(dev)) {
 #ifdef MAG_QMC5883L_ALIGN
@@ -185,8 +185,8 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
-        if (busdev->bustype == BUS_TYPE_I2C) {
-            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (busdev->busType == BUS_TYPE_I2C) {
+            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (ak8975Detect(dev)) {
 #ifdef MAG_AK8975_ALIGN
@@ -199,13 +199,13 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8963:
 #if defined(USE_MAG_AK8963) || defined(USE_MAG_SPI_AK8963)
-        if (busdev->bustype == BUS_TYPE_I2C) {
-            busdev->busdev_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (busdev->busType == BUS_TYPE_I2C) {
+            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            dev->busdev.bustype = BUS_TYPE_MPU_SLAVE;
-            busdev->busdev_u.mpuSlave.address = compassConfig()->mag_i2c_address;
-            dev->busdev.busdev_u.mpuSlave.master = gyroSensorBus();
+            dev->busdev.busType = BUS_TYPE_MPU_SLAVE;
+            busdev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
+            dev->busdev.busType_u.mpuSlave.master = gyroSensorBus();
         }
         if (ak8963Detect(dev)) {
 #ifdef MAG_AK8963_ALIGN

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -328,12 +328,12 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
 const busDevice_t *gyroSensorBus(void) {
 #ifdef USE_DUAL_GYRO
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2) {
-        return &gyroSensor2.gyroDev.bus;
+        return &gyroSensor2.gyroDev.dev;
     } else {
-        return &gyroSensor1.gyroDev.bus;
+        return &gyroSensor1.gyroDev.dev;
     }
 #else
-    return &gyroSensor1.gyroDev.bus;
+    return &gyroSensor1.gyroDev.dev;
 #endif
 }
 
@@ -341,13 +341,13 @@ const busDevice_t *gyroSensorBus(void) {
 const busDevice_t *gyroSensorBusByDevice(uint8_t whichSensor) {
 #ifdef USE_DUAL_GYRO
     if (whichSensor == GYRO_CONFIG_USE_GYRO_2) {
-        return &gyroSensor2.gyroDev.bus;
+        return &gyroSensor2.gyroDev.dev;
     } else {
-        return &gyroSensor1.gyroDev.bus;
+        return &gyroSensor1.gyroDev.dev;
     }
 #else
     UNUSED(whichSensor);
-    return &gyroSensor1.gyroDev.bus;
+    return &gyroSensor1.gyroDev.dev;
 #endif
 }
 #endif // USE_GYRO_REGISTER_DUMP
@@ -672,18 +672,18 @@ bool gyroInit(void) {
     gyroToUse = gyroConfig()->gyro_to_use;
 #if defined(USE_DUAL_GYRO) && defined(GYRO_1_CS_PIN)
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
-        gyroSensor1.gyroDev.bus.busType_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_1_CS_PIN));
-        IOInit(gyroSensor1.gyroDev.bus.busType_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(0));
-        IOHi(gyroSensor1.gyroDev.bus.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
-        IOConfigGPIO(gyroSensor1.gyroDev.bus.busType_u.spi.csnPin, SPI_IO_CS_CFG);
+        gyroSensor1.gyroDev.dev.busType_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_1_CS_PIN));
+        IOInit(gyroSensor1.gyroDev.dev.busType_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(0));
+        IOHi(gyroSensor1.gyroDev.dev.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
+        IOConfigGPIO(gyroSensor1.gyroDev.dev.busType_u.spi.csnPin, SPI_IO_CS_CFG);
     }
 #endif
 #if defined(USE_DUAL_GYRO) && defined(GYRO_2_CS_PIN)
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
-        gyroSensor2.gyroDev.bus.busType_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_2_CS_PIN));
-        IOInit(gyroSensor2.gyroDev.bus.busType_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(1));
-        IOHi(gyroSensor2.gyroDev.bus.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
-        IOConfigGPIO(gyroSensor2.gyroDev.bus.busType_u.spi.csnPin, SPI_IO_CS_CFG);
+        gyroSensor2.gyroDev.dev.busType_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_2_CS_PIN));
+        IOInit(gyroSensor2.gyroDev.dev.busType_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(1));
+        IOHi(gyroSensor2.gyroDev.dev.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
+        IOConfigGPIO(gyroSensor2.gyroDev.dev.busType_u.spi.csnPin, SPI_IO_CS_CFG);
     }
 #endif
     gyroSensor1.gyroDev.gyroAlign = ALIGN_DEFAULT;
@@ -700,8 +700,8 @@ bool gyroInit(void) {
 #ifdef GYRO_1_ALIGN
     gyroSensor1.gyroDev.gyroAlign = GYRO_1_ALIGN;
 #endif
-    gyroSensor1.gyroDev.bus.busType = BUS_TYPE_SPI;
-    spiBusSetInstance(&gyroSensor1.gyroDev.bus, GYRO_1_SPI_INSTANCE);
+    gyroSensor1.gyroDev.dev.busType = BUS_TYPE_SPI;
+    spiBusSetInstance(&gyroSensor1.gyroDev.dev, GYRO_1_SPI_INSTANCE);
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor1);
         if (!ret) {
@@ -725,8 +725,8 @@ bool gyroInit(void) {
 #ifdef GYRO_2_ALIGN
     gyroSensor2.gyroDev.gyroAlign = GYRO_2_ALIGN;
 #endif
-    gyroSensor2.gyroDev.bus.busType = BUS_TYPE_SPI;
-    spiBusSetInstance(&gyroSensor2.gyroDev.bus, GYRO_2_SPI_INSTANCE);
+    gyroSensor2.gyroDev.dev.busType = BUS_TYPE_SPI;
+    spiBusSetInstance(&gyroSensor2.gyroDev.dev, GYRO_2_SPI_INSTANCE);
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor2);
         if (!ret) {

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -700,7 +700,7 @@ bool gyroInit(void) {
 #ifdef GYRO_1_ALIGN
     gyroSensor1.gyroDev.gyroAlign = GYRO_1_ALIGN;
 #endif
-    gyroSensor1.gyroDev.bus.bustype = BUSTYPE_SPI;
+    gyroSensor1.gyroDev.bus.bustype = BUS_TYPE_SPI;
     spiBusSetInstance(&gyroSensor1.gyroDev.bus, GYRO_1_SPI_INSTANCE);
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor1);
@@ -725,7 +725,7 @@ bool gyroInit(void) {
 #ifdef GYRO_2_ALIGN
     gyroSensor2.gyroDev.gyroAlign = GYRO_2_ALIGN;
 #endif
-    gyroSensor2.gyroDev.bus.bustype = BUSTYPE_SPI;
+    gyroSensor2.gyroDev.bus.bustype = BUS_TYPE_SPI;
     spiBusSetInstance(&gyroSensor2.gyroDev.bus, GYRO_2_SPI_INSTANCE);
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor2);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -672,18 +672,18 @@ bool gyroInit(void) {
     gyroToUse = gyroConfig()->gyro_to_use;
 #if defined(USE_DUAL_GYRO) && defined(GYRO_1_CS_PIN)
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
-        gyroSensor1.gyroDev.bus.busdev_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_1_CS_PIN));
-        IOInit(gyroSensor1.gyroDev.bus.busdev_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(0));
-        IOHi(gyroSensor1.gyroDev.bus.busdev_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
-        IOConfigGPIO(gyroSensor1.gyroDev.bus.busdev_u.spi.csnPin, SPI_IO_CS_CFG);
+        gyroSensor1.gyroDev.bus.busType_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_1_CS_PIN));
+        IOInit(gyroSensor1.gyroDev.bus.busType_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(0));
+        IOHi(gyroSensor1.gyroDev.bus.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
+        IOConfigGPIO(gyroSensor1.gyroDev.bus.busType_u.spi.csnPin, SPI_IO_CS_CFG);
     }
 #endif
 #if defined(USE_DUAL_GYRO) && defined(GYRO_2_CS_PIN)
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
-        gyroSensor2.gyroDev.bus.busdev_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_2_CS_PIN));
-        IOInit(gyroSensor2.gyroDev.bus.busdev_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(1));
-        IOHi(gyroSensor2.gyroDev.bus.busdev_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
-        IOConfigGPIO(gyroSensor2.gyroDev.bus.busdev_u.spi.csnPin, SPI_IO_CS_CFG);
+        gyroSensor2.gyroDev.bus.busType_u.spi.csnPin = IOGetByTag(IO_TAG(GYRO_2_CS_PIN));
+        IOInit(gyroSensor2.gyroDev.bus.busType_u.spi.csnPin, OWNER_MPU_CS, RESOURCE_INDEX(1));
+        IOHi(gyroSensor2.gyroDev.bus.busType_u.spi.csnPin); // Ensure device is disabled, important when two devices are on the same bus.
+        IOConfigGPIO(gyroSensor2.gyroDev.bus.busType_u.spi.csnPin, SPI_IO_CS_CFG);
     }
 #endif
     gyroSensor1.gyroDev.gyroAlign = ALIGN_DEFAULT;
@@ -700,7 +700,7 @@ bool gyroInit(void) {
 #ifdef GYRO_1_ALIGN
     gyroSensor1.gyroDev.gyroAlign = GYRO_1_ALIGN;
 #endif
-    gyroSensor1.gyroDev.bus.bustype = BUS_TYPE_SPI;
+    gyroSensor1.gyroDev.bus.busType = BUS_TYPE_SPI;
     spiBusSetInstance(&gyroSensor1.gyroDev.bus, GYRO_1_SPI_INSTANCE);
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor1);
@@ -725,7 +725,7 @@ bool gyroInit(void) {
 #ifdef GYRO_2_ALIGN
     gyroSensor2.gyroDev.gyroAlign = GYRO_2_ALIGN;
 #endif
-    gyroSensor2.gyroDev.bus.bustype = BUS_TYPE_SPI;
+    gyroSensor2.gyroDev.bus.busType = BUS_TYPE_SPI;
     spiBusSetInstance(&gyroSensor2.gyroDev.bus, GYRO_2_SPI_INSTANCE);
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor2);


### PR DESCRIPTION
AI Generated code from AI generated plan from AI analysis via human engineering :laughing: 

--

## Summary

Renames EmuFlight's SPI/I2C bus abstraction identifiers to match Betaflight `4.5-maintenance` so that future Betaflight sensor/IMU driver backports become paste-and-tweak instead of deep rewrites. **No runtime behaviour change — every diff is identifier replacement only.**

This is **phase 1 of a multi-phase alignment**. The structural changes (bus-resource split, DMA infrastructure, async API) are deferred to follow-up PRs so each can be bench-tested in isolation.

## What this PR does (4 commits, 44 files, 630 insertions / 623 deletions)

| Commit | Rename |
|---|---|
| `b0847d66` | `BUSTYPE_NONE/I2C/SPI/MPU_SLAVE` → `BUS_TYPE_NONE/I2C/SPI/MPU_SLAVE` (68 sites, 17 files) |
| `19dfc1b3` | `bustype`→`busType`, `busdev_u`→`busType_u`, `deviceSpi_s`/`deviceI2C_s`/`deviceMpuSlave_s` → `busSpi_s`/`busI2C_s`/`busMpuSlave_s` (333 sites, 34 files) |
| `7f7585ae` | Add `typedef busDevice_t extDevice_t;` alias, rename embedded members: `gyroDev_t.bus`/`accDev_t.bus` → `.dev`, `magDev_t.busdev` → `.dev`, `baroDev_t.busdev` → `.dev`, `flashDevice_t.busdev` → `.dev` (279 sites, 35 files) |
| `3e990f09` | Rename SPI transaction functions: `spiBusTransfer` → `spiReadWriteBuf`, `spiBusWriteRegister` → `spiWriteReg`, `spiBusReadRegisterBuffer` → `spiReadRegBuf`, `spiBusReadRegister` → `spiReadReg` (117 sites, 17 files) |

## Build verification

Each commit verified from a scratch build (`CCACHE_DISABLE=1` and `rm -rf obj/` between every target, so every translation unit recompiles fresh and any warning lands in the log). Cached builds are insufficient here because ccache suppresses gcc stderr on hits and would silently mask any regression.

| Build | Stage A baseline | After every commit in this PR |
|---|---|---|
| `make test` | rc=0, 0 compiler warnings | rc=0, 0 compiler warnings |
| `TARGET=HELIOSPRING` (STM32F7, IMUF9001) | rc=0, 0 compiler warnings | rc=0, 0 compiler warnings |
| `TARGET=FOXEERF405` (STM32F405) | rc=0, 0 compiler warnings | rc=0, 0 compiler warnings |
| `TARGET=FOXEERF722V4` (STM32F722) | rc=0, 0 compiler warnings | rc=0, 0 compiler warnings |
| `TARGET=HGLRCF411` (STM32F411) | rc=0, 0 compiler warnings | rc=0, 0 compiler warnings |
| `TARGET=NBDHMBF4PRO` (STM32F405, `nbd7456.c`) | rc=0, 0 compiler warnings | rc=0, 0 compiler warnings |

Warning gate: `grep 'warning:' log | grep -v '^make\[' | grep -v '^/usr/bin/ld:'` must be empty. Pre-existing non-compiler warnings (make's `-j0` jobserver notice; 24 linker `LOAD segment with RWX permissions` warnings in unit-test binaries) are unchanged across the whole PR.

CFLAGS relevant for warning coverage: `-pedantic -Wall -Wextra -Wdouble-promotion -Wduplicated-branches -Wduplicated-cond -Wformat-truncation -Wformat=2 -Wlogical-op -Wnull-dereference -Wrestrict -Wunknown-pragmas -Wunsafe-loop-optimizations`. No `-Werror`, no `-Wno-*` blanket disables added.

## Bench smoke-test

`TUNERCF405` (STM32F405, bench FC, props off): gyro traces swing proportionally on rotation about each axis and settle through zero when still; accelerometer reads ≈ 1 g on the vertical axis with correct signs on roll/pitch tilts. Sensor stack reads correctly post-refactor.

Additional on-bench testing on `HELIOSPRING` / `FOXEERF722V4` is planned before merge.

## What this PR does NOT do (deliberately deferred, follow-up PRs)

Full paste-and-tweak parity with Betaflight requires structural changes beyond naming. These each have their own risk profile and warrant independent bench testing — merging them in separate PRs keeps review surface manageable and regressions easy to bisect.

1. **Bus-resource split.** `busDevice_t` is still a combined bus-resource + per-device struct; `extDevice_t` is a typedef alias, not a separate type. BF driver code written as `dev->bus->busType_u.spi.instance` does not compile yet (you can currently write `dev->busType_u.spi.instance` instead, but that's an EmuFlight-ism). Splitting the shared bus out and giving `extDevice_t` a real `bus` back-pointer is the most architecturally meaningful follow-up.
2. **`spiSetBusInstance` signature.** BF's signature takes `uint32_t` device index; EmuFlight's takes `SPI_TypeDef *`. I intentionally left the EmuFlight name in place rather than rename-only; a rename with incompatible param types would be a worse trap for anyone pasting BF code than keeping the old name. The rename + signature change will land together in a later PR.
3. **Return-type alignment.** BF's `spiWriteReg` / `spiReadRegBuf` return `void`; EmuFlight's equivalents keep returning `bool`. Callers that check the return value keep working; BF code that ignores it also works. Aligning to `void` drops diagnostic info and deserves its own discussion.
4. **DMA segmentation.** `busSegment_t`, `busStatus_e`, per-device DMA buffers and init structs, `curSegment`/`initSegment` queueing.
5. **Async SPI API.** `spiSequence`, `spiWait`, `spiIsBusy`, `spiDmaEnable`.
6. **RB-suffix variants.** `spiReadRegBufRB`, `spiReadRegMskBufRB`, `spiWriteRegRB`.
7. **QSPI.** `BUS_TYPE_QSPI`, `quadSpiResource_t`, segment-width encoding. No current EmuFlight target uses QSPI, so this is lowest priority.
8. **`BUS_TYPE_GYRO_AUTO`.** BF-specific sentinel for acc/gyro auto-detection. Add if a later backport needs it.
9. **Cosmetic cleanup.** `busDevice_t` type references still appear widely — both names are valid via the typedef alias. A follow-up can sweep the remaining type-name references to `extDevice_t`. Likewise local-variable / parameter-body identifiers (`bus`, `busdev`) can be renamed to `dev` for consistency; functionally equivalent today.

## Test plan

- [x] `make test` passes from a clean `obj/` with `CCACHE_DISABLE=1`
- [x] All five MCU-diverse targets (HELIOSPRING / FOXEERF405 / FOXEERF722V4 / HGLRCF411 / NBDHMBF4PRO) build from scratch with zero new compiler warnings
- [x] Bench smoke-test on TUNERCF405 confirms accel + gyro read correctly
- [x] Bench smoke-test on HELIOSPRING (STM32F7 + IMUF9001) — ***success with caveat; lately i've noticed need to flash twice for good gyro/accel sensors reading in Configurator. Presuming with some certainty that such is unrelated to this branch.***
- [x] Bench smoke-test on FOXEERF722V4 — succeeded.
- [x] Hover-test smoke-test on FOXEERF722V4 — succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified device abstraction layer across sensor drivers (accelerometer, gyro, barometer, magnetometer, compass, flash) for improved code consistency and maintainability.
  * Reorganized internal bus device structures and renamed SPI helper functions to align with standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->