### PR TITLE
refactor(bus): naming cleanup phase 2 (type sweep + identifier consistency)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -196,8 +196,8 @@ void initImuf9001(void) {
     resetImuf9001();
 }
 
-FAST_CODE bool imufSendReceiveSpiBlocking(const extDevice_t *bus, uint8_t *dataTx, uint8_t *daRx, uint8_t length) {
-    spiReadWriteBuf(bus, dataTx, daRx, length);
+FAST_CODE bool imufSendReceiveSpiBlocking(const extDevice_t *dev, uint8_t *dataTx, uint8_t *daRx, uint8_t length) {
+    spiReadWriteBuf(dev, dataTx, daRx, length);
     return true;
 }
 

--- a/src/main/drivers/accgyro/accgyro_imuf9001.c
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.c
@@ -196,7 +196,7 @@ void initImuf9001(void) {
     resetImuf9001();
 }
 
-FAST_CODE bool imufSendReceiveSpiBlocking(const busDevice_t *bus, uint8_t *dataTx, uint8_t *daRx, uint8_t length) {
+FAST_CODE bool imufSendReceiveSpiBlocking(const extDevice_t *bus, uint8_t *dataTx, uint8_t *daRx, uint8_t length) {
     spiReadWriteBuf(bus, dataTx, daRx, length);
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_imuf9001.h
+++ b/src/main/drivers/accgyro/accgyro_imuf9001.h
@@ -19,7 +19,7 @@
 
 #include "drivers/bus.h"
 
-uint8_t imuf9001SpiDetect(const gyroDev_t *bus);
+uint8_t imuf9001SpiDetect(const gyroDev_t *dev);
 
 bool imufSpiAccDetect(accDev_t *acc);
 bool imufSpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -506,9 +506,9 @@ uint8_t mpuGyroFCHOICE(gyroDev_t *gyro) {
 }
 
 #ifdef USE_GYRO_REGISTER_DUMP
-uint8_t mpuGyroReadRegister(const extDevice_t *bus, uint8_t reg) {
+uint8_t mpuGyroReadRegister(const extDevice_t *dev, uint8_t reg) {
     uint8_t data;
-    const bool ack = busReadRegisterBuffer(bus, reg, &data, 1);
+    const bool ack = busReadRegisterBuffer(dev, reg, &data, 1);
     if (ack) {
         return data;
     } else {

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -506,7 +506,7 @@ uint8_t mpuGyroFCHOICE(gyroDev_t *gyro) {
 }
 
 #ifdef USE_GYRO_REGISTER_DUMP
-uint8_t mpuGyroReadRegister(const busDevice_t *bus, uint8_t reg) {
+uint8_t mpuGyroReadRegister(const extDevice_t *bus, uint8_t reg) {
     uint8_t data;
     const bool ack = busReadRegisterBuffer(bus, reg, &data, 1);
     if (ack) {

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -239,7 +239,7 @@ bool mpuGyroReadSPI(struct gyroDev_s *gyro);
 void mpuDetect(struct gyroDev_s *gyro);
 uint8_t mpuGyroDLPF(struct gyroDev_s *gyro);
 uint8_t mpuGyroFCHOICE(struct gyroDev_s *gyro);
-uint8_t mpuGyroReadRegister(const extDevice_t *bus, uint8_t reg);
+uint8_t mpuGyroReadRegister(const extDevice_t *dev, uint8_t reg);
 
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -239,7 +239,7 @@ bool mpuGyroReadSPI(struct gyroDev_s *gyro);
 void mpuDetect(struct gyroDev_s *gyro);
 uint8_t mpuGyroDLPF(struct gyroDev_s *gyro);
 uint8_t mpuGyroFCHOICE(struct gyroDev_s *gyro);
-uint8_t mpuGyroReadRegister(const busDevice_t *bus, uint8_t reg);
+uint8_t mpuGyroReadRegister(const extDevice_t *bus, uint8_t reg);
 
 struct accDev_s;
 bool mpuAccRead(struct accDev_s *acc);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -88,24 +88,24 @@ static volatile bool bmi160DataReady = false;
 static volatile bool bmi160ExtiInitDone = false;
 
 //! Private functions
-static int32_t BMI160_Config(const extDevice_t *bus);
-static int32_t BMI160_do_foc(const extDevice_t *bus);
+static int32_t BMI160_Config(const extDevice_t *dev);
+static int32_t BMI160_do_foc(const extDevice_t *dev);
 
-uint8_t bmi160Detect(const extDevice_t *bus) {
+uint8_t bmi160Detect(const extDevice_t *dev) {
     if (BMI160Detected) {
         return BMI_160_SPI;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busType_u.spi.instance, BMI160_SPI_DIVISOR);
+    spiSetDivisor(dev->busType_u.spi.instance, BMI160_SPI_DIVISOR);
     /* Read this address to activate SPI (see p. 84) */
-    spiReadReg(bus, 0x7F);
+    spiReadReg(dev, 0x7F);
     delay(100); // Give SPI some time to start up
     /* Check the chip ID */
-    if (spiReadReg(bus, BMI160_REG_CHIPID) != 0xd1) {
+    if (spiReadReg(dev, BMI160_REG_CHIPID) != 0xd1) {
         return MPU_NONE;
     }
     BMI160Detected = true;
@@ -117,18 +117,18 @@ uint8_t bmi160Detect(const extDevice_t *bus) {
  * @brief Initialize the BMI160 6-axis sensor.
  * @return 0 for success, -1 for failure to allocate, -10 for failure to get irq
  */
-static void BMI160_Init(const extDevice_t *bus) {
+static void BMI160_Init(const extDevice_t *dev) {
     if (BMI160InitDone || !BMI160Detected) {
         return;
     }
     /* Configure the BMI160 Sensor */
-    if (BMI160_Config(bus) != 0) {
+    if (BMI160_Config(dev) != 0) {
         return;
     }
     bool do_foc = false;
     /* Perform fast offset compensation if requested */
     if (do_foc) {
-        BMI160_do_foc(bus);
+        BMI160_do_foc(dev);
     }
     BMI160InitDone = true;
 }
@@ -137,52 +137,52 @@ static void BMI160_Init(const extDevice_t *bus) {
 /**
  * @brief Configure the sensor
  */
-static int32_t BMI160_Config(const extDevice_t *bus) {
+static int32_t BMI160_Config(const extDevice_t *dev) {
     // Set normal power mode for gyro and accelerometer
-    spiWriteReg(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_GYR_NORMAL);
+    spiWriteReg(dev, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_GYR_NORMAL);
     delay(100); // can take up to 80ms
-    spiWriteReg(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_ACC_NORMAL);
+    spiWriteReg(dev, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_ACC_NORMAL);
     delay(5); // can take up to 3.8ms
     // Verify that normal power mode was entered
-    uint8_t pmu_status = spiReadReg(bus, BMI160_REG_PMU_STAT);
+    uint8_t pmu_status = spiReadReg(dev, BMI160_REG_PMU_STAT);
     if ((pmu_status & 0x3C) != 0x14) {
         return -3;
     }
     // Set odr and ranges
     // Set acc_us = 0 acc_bwp = 0b010 so only the first filter stage is used
-    spiWriteReg(bus, BMI160_REG_ACC_CONF, 0x20 | BMI160_ODR_800_Hz);
+    spiWriteReg(dev, BMI160_REG_ACC_CONF, 0x20 | BMI160_ODR_800_Hz);
     delay(1);
     // Set gyr_bwp = 0b010 so only the first filter stage is used
-    spiWriteReg(bus, BMI160_REG_GYR_CONF, 0x20 | BMI160_ODR_3200_Hz);
+    spiWriteReg(dev, BMI160_REG_GYR_CONF, 0x20 | BMI160_ODR_3200_Hz);
     delay(1);
-    spiWriteReg(bus, BMI160_REG_ACC_RANGE, BMI160_RANGE_8G);
+    spiWriteReg(dev, BMI160_REG_ACC_RANGE, BMI160_RANGE_8G);
     delay(1);
-    spiWriteReg(bus, BMI160_REG_GYR_RANGE, BMI160_RANGE_2000DPS);
+    spiWriteReg(dev, BMI160_REG_GYR_RANGE, BMI160_RANGE_2000DPS);
     delay(1);
     // Enable offset compensation
-    uint8_t val = spiReadReg(bus, BMI160_REG_OFFSET_0);
-    spiWriteReg(bus, BMI160_REG_OFFSET_0, val | 0xC0);
+    uint8_t val = spiReadReg(dev, BMI160_REG_OFFSET_0);
+    spiWriteReg(dev, BMI160_REG_OFFSET_0, val | 0xC0);
     // Enable data ready interrupt
-    spiWriteReg(bus, BMI160_REG_INT_EN1, BMI160_INT_EN1_DRDY);
+    spiWriteReg(dev, BMI160_REG_INT_EN1, BMI160_INT_EN1_DRDY);
     delay(1);
     // Enable INT1 pin
-    spiWriteReg(bus, BMI160_REG_INT_OUT_CTRL, BMI160_INT_OUT_CTRL_INT1_CONFIG);
+    spiWriteReg(dev, BMI160_REG_INT_OUT_CTRL, BMI160_INT_OUT_CTRL_INT1_CONFIG);
     delay(1);
     // Map data ready interrupt to INT1 pin
-    spiWriteReg(bus, BMI160_REG_INT_MAP1, BMI160_REG_INT_MAP1_INT1_DRDY);
+    spiWriteReg(dev, BMI160_REG_INT_MAP1, BMI160_REG_INT_MAP1_INT1_DRDY);
     delay(1);
     return 0;
 }
 
-static int32_t BMI160_do_foc(const extDevice_t *bus) {
+static int32_t BMI160_do_foc(const extDevice_t *dev) {
     // assume sensor is mounted on top
     uint8_t val = 0x7D;;
-    spiWriteReg(bus, BMI160_REG_FOC_CONF, val);
+    spiWriteReg(dev, BMI160_REG_FOC_CONF, val);
     // Start FOC
-    spiWriteReg(bus, BMI160_REG_CMD, BMI160_CMD_START_FOC);
+    spiWriteReg(dev, BMI160_REG_CMD, BMI160_CMD_START_FOC);
     // Wait for FOC to complete
     for (int i = 0; i < 50; i++) {
-        val = spiReadReg(bus, BMI160_REG_STATUS);
+        val = spiReadReg(dev, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_FOC_RDY) {
             break;
         }
@@ -192,12 +192,12 @@ static int32_t BMI160_do_foc(const extDevice_t *bus) {
         return -3;
     }
     // Program NVM
-    val = spiReadReg(bus, BMI160_REG_CONF);
-    spiWriteReg(bus, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN);
-    spiWriteReg(bus, BMI160_REG_CMD, BMI160_CMD_PROG_NVM);
+    val = spiReadReg(dev, BMI160_REG_CONF);
+    spiWriteReg(dev, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN);
+    spiWriteReg(dev, BMI160_REG_CMD, BMI160_CMD_PROG_NVM);
     // Wait for NVM programming to complete
     for (int i = 0; i < 50; i++) {
-        val = spiReadReg(bus, BMI160_REG_STATUS);
+        val = spiReadReg(dev, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_NVM_RDY) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -88,10 +88,10 @@ static volatile bool bmi160DataReady = false;
 static volatile bool bmi160ExtiInitDone = false;
 
 //! Private functions
-static int32_t BMI160_Config(const busDevice_t *bus);
-static int32_t BMI160_do_foc(const busDevice_t *bus);
+static int32_t BMI160_Config(const extDevice_t *bus);
+static int32_t BMI160_do_foc(const extDevice_t *bus);
 
-uint8_t bmi160Detect(const busDevice_t *bus) {
+uint8_t bmi160Detect(const extDevice_t *bus) {
     if (BMI160Detected) {
         return BMI_160_SPI;
     }
@@ -117,7 +117,7 @@ uint8_t bmi160Detect(const busDevice_t *bus) {
  * @brief Initialize the BMI160 6-axis sensor.
  * @return 0 for success, -1 for failure to allocate, -10 for failure to get irq
  */
-static void BMI160_Init(const busDevice_t *bus) {
+static void BMI160_Init(const extDevice_t *bus) {
     if (BMI160InitDone || !BMI160Detected) {
         return;
     }
@@ -137,7 +137,7 @@ static void BMI160_Init(const busDevice_t *bus) {
 /**
  * @brief Configure the sensor
  */
-static int32_t BMI160_Config(const busDevice_t *bus) {
+static int32_t BMI160_Config(const extDevice_t *bus) {
     // Set normal power mode for gyro and accelerometer
     spiWriteReg(bus, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_GYR_NORMAL);
     delay(100); // can take up to 80ms
@@ -174,7 +174,7 @@ static int32_t BMI160_Config(const busDevice_t *bus) {
     return 0;
 }
 
-static int32_t BMI160_do_foc(const busDevice_t *bus) {
+static int32_t BMI160_do_foc(const extDevice_t *bus) {
     // assume sensor is mounted on top
     uint8_t val = 0x7D;;
     spiWriteReg(bus, BMI160_REG_FOC_CONF, val);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.h
@@ -68,6 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-uint8_t bmi160Detect(const busDevice_t *bus);
+uint8_t bmi160Detect(const extDevice_t *bus);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.h
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.h
@@ -68,6 +68,6 @@ enum bmi160_gyro_range {
     BMI160_RANGE_2000DPS = 0x00,
 };
 
-uint8_t bmi160Detect(const extDevice_t *bus);
+uint8_t bmi160Detect(const extDevice_t *dev);
 bool bmi160SpiAccDetect(accDev_t *acc);
 bool bmi160SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -146,20 +146,20 @@ typedef enum {
 
 // BMI270 register reads are 16bits with the first byte a "dummy" value 0
 // that must be ignored. The result is in the second byte.
-static uint8_t bmi270RegisterRead(const extDevice_t *bus, bmi270Register_e registerId)
+static uint8_t bmi270RegisterRead(const extDevice_t *dev, bmi270Register_e registerId)
 {
     uint8_t data[2] = { 0, 0 };
 
-    if (spiReadRegBuf(bus, registerId, data, 2)) {
+    if (spiReadRegBuf(dev, registerId, data, 2)) {
         return data[1];
     } else {
         return 0;
     }
 }
 
-static void bmi270RegisterWrite(const extDevice_t *bus, bmi270Register_e registerId, uint8_t value, unsigned delayMs)
+static void bmi270RegisterWrite(const extDevice_t *dev, bmi270Register_e registerId, uint8_t value, unsigned delayMs)
 {
-    spiWriteReg(bus, registerId, value);
+    spiWriteReg(dev, registerId, value);
     if (delayMs) {
         delay(delayMs);
     }
@@ -167,45 +167,45 @@ static void bmi270RegisterWrite(const extDevice_t *bus, bmi270Register_e registe
 
 // Toggle the CS to switch the device into SPI mode.
 // Device switches initializes as I2C and switches to SPI on a low to high CS transition
-static void bmi270EnableSPI(const extDevice_t *bus)
+static void bmi270EnableSPI(const extDevice_t *dev)
 {
-    IOLo(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
     delay(1);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOHi(dev->busType_u.spi.csnPin);
     delay(10);
 }
 
-uint8_t bmi270Detect(const extDevice_t *bus)
+uint8_t bmi270Detect(const extDevice_t *dev)
 {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
 
-    spiSetDivisor(bus->busType_u.spi.instance, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
-    bmi270EnableSPI(bus);
+    spiSetDivisor(dev->busType_u.spi.instance, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
+    bmi270EnableSPI(dev);
 
-    if (bmi270RegisterRead(bus, BMI270_REG_CHIP_ID) == BMI270_CHIP_ID) {
+    if (bmi270RegisterRead(dev, BMI270_REG_CHIP_ID) == BMI270_CHIP_ID) {
         return BMI_270_SPI;
     }
 
     return MPU_NONE;
 }
 
-static void bmi270UploadConfig(const extDevice_t *bus)
+static void bmi270UploadConfig(const extDevice_t *dev)
 {
-    bmi270RegisterWrite(bus, BMI270_REG_PWR_CONF, 0, 1);
-    bmi270RegisterWrite(bus, BMI270_REG_INIT_CTRL, 0, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_PWR_CONF, 0, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_INIT_CTRL, 0, 1);
 
     // Transfer the config file
-    IOLo(bus->busType_u.spi.csnPin);
-    spiTransferByte(bus->busType_u.spi.instance, BMI270_REG_INIT_DATA);
-    spiTransfer(bus->busType_u.spi.instance, bmi270_maximum_fifo_config_file, NULL, sizeof(bmi270_maximum_fifo_config_file));
-    IOHi(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
+    spiTransferByte(dev->busType_u.spi.instance, BMI270_REG_INIT_DATA);
+    spiTransfer(dev->busType_u.spi.instance, bmi270_maximum_fifo_config_file, NULL, sizeof(bmi270_maximum_fifo_config_file));
+    IOHi(dev->busType_u.spi.csnPin);
 
     delay(10);
-    bmi270RegisterWrite(bus, BMI270_REG_INIT_CTRL, 1, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_INIT_CTRL, 1, 1);
 }
 
 static uint8_t getBmiOsrMode()
@@ -221,7 +221,7 @@ static uint8_t getBmiOsrMode()
 
 static void bmi270Config(const gyroDev_t *gyro)
 {
-    const extDevice_t *bus = &gyro->dev;
+    const extDevice_t *dev = &gyro->dev;
 
     // If running in hardware_lpf experimental mode then switch to FIFO-based,
     // 6.4KHz sampling, unfiltered data vs. the default 3.2KHz with hardware filtering
@@ -233,55 +233,55 @@ static void bmi270Config(const gyroDev_t *gyro)
 
     // Perform a soft reset to set all configuration to default
     // Delay 100ms before continuing configuration
-    bmi270RegisterWrite(bus, BMI270_REG_CMD, BMI270_VAL_CMD_SOFTRESET, 100);
+    bmi270RegisterWrite(dev, BMI270_REG_CMD, BMI270_VAL_CMD_SOFTRESET, 100);
 
     // Toggle the chip into SPI mode
-    bmi270EnableSPI(bus);
+    bmi270EnableSPI(dev);
 
-    bmi270UploadConfig(bus);
+    bmi270UploadConfig(dev);
 
     // Configure the FIFO
     if (fifoMode) {
-        bmi270RegisterWrite(bus, BMI270_REG_FIFO_CONFIG_0, BMI270_VAL_FIFO_CONFIG_0, 1);
-        bmi270RegisterWrite(bus, BMI270_REG_FIFO_CONFIG_1, BMI270_VAL_FIFO_CONFIG_1, 1);
-        bmi270RegisterWrite(bus, BMI270_REG_FIFO_DOWNS, BMI270_VAL_FIFO_DOWNS, 1);
-        bmi270RegisterWrite(bus, BMI270_REG_FIFO_WTM_0, BMI270_VAL_FIFO_WTM_0, 1);
-        bmi270RegisterWrite(bus, BMI270_REG_FIFO_WTM_1, BMI270_VAL_FIFO_WTM_1, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_FIFO_CONFIG_0, BMI270_VAL_FIFO_CONFIG_0, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_FIFO_CONFIG_1, BMI270_VAL_FIFO_CONFIG_1, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_FIFO_DOWNS, BMI270_VAL_FIFO_DOWNS, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_FIFO_WTM_0, BMI270_VAL_FIFO_WTM_0, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_FIFO_WTM_1, BMI270_VAL_FIFO_WTM_1, 1);
     }
 
     // Configure the accelerometer
-    bmi270RegisterWrite(bus, BMI270_REG_ACC_CONF, (BMI270_VAL_ACC_CONF_HP << 7) | (BMI270_VAL_ACC_CONF_BWP << 4) | BMI270_VAL_ACC_CONF_ODR800, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_ACC_CONF, (BMI270_VAL_ACC_CONF_HP << 7) | (BMI270_VAL_ACC_CONF_BWP << 4) | BMI270_VAL_ACC_CONF_ODR800, 1);
 
     // Configure the accelerometer full-scale range
-    bmi270RegisterWrite(bus, BMI270_REG_ACC_RANGE, BMI270_VAL_ACC_RANGE_16G, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_ACC_RANGE, BMI270_VAL_ACC_RANGE_16G, 1);
 
     // Configure the gyro
-    bmi270RegisterWrite(bus, BMI270_REG_GYRO_CONF, (BMI270_VAL_GYRO_CONF_FILTER_PERF << 7) | (BMI270_VAL_GYRO_CONF_NOISE_PERF << 6) | (getBmiOsrMode() << 4) | BMI270_VAL_GYRO_CONF_ODR3200, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_GYRO_CONF, (BMI270_VAL_GYRO_CONF_FILTER_PERF << 7) | (BMI270_VAL_GYRO_CONF_NOISE_PERF << 6) | (getBmiOsrMode() << 4) | BMI270_VAL_GYRO_CONF_ODR3200, 1);
 
     // Configure the gyro full-range scale
-    bmi270RegisterWrite(bus, BMI270_REG_GYRO_RANGE, BMI270_VAL_GYRO_RANGE_2000DPS, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_GYRO_RANGE, BMI270_VAL_GYRO_RANGE_2000DPS, 1);
 
     // Configure the gyro data ready interrupt
     if (fifoMode) {
         // Interrupt driven by FIFO watermark level
-        bmi270RegisterWrite(bus, BMI270_REG_INT_MAP_DATA, BMI270_VAL_INT_MAP_FIFO_WM_INT1, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_INT_MAP_DATA, BMI270_VAL_INT_MAP_FIFO_WM_INT1, 1);
     } else {
         // Interrupt driven by data ready
-        bmi270RegisterWrite(bus, BMI270_REG_INT_MAP_DATA, BMI270_VAL_INT_MAP_DATA_DRDY_INT1, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_INT_MAP_DATA, BMI270_VAL_INT_MAP_DATA_DRDY_INT1, 1);
     }
 
     // Configure the behavior of the INT1 pin
-    bmi270RegisterWrite(bus, BMI270_REG_INT1_IO_CTRL, BMI270_VAL_INT1_IO_CTRL_PINMODE, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_INT1_IO_CTRL, BMI270_VAL_INT1_IO_CTRL_PINMODE, 1);
 
     // Configure the device for  performance mode
-    bmi270RegisterWrite(bus, BMI270_REG_PWR_CONF, BMI270_VAL_PWR_CONF, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_PWR_CONF, BMI270_VAL_PWR_CONF, 1);
 
     // Enable the gyro, accelerometer and temperature sensor - disable aux interface
-    bmi270RegisterWrite(bus, BMI270_REG_PWR_CTRL, BMI270_VAL_PWR_CTRL, 1);
+    bmi270RegisterWrite(dev, BMI270_REG_PWR_CTRL, BMI270_VAL_PWR_CTRL, 1);
 
     // Flush the FIFO
     if (fifoMode) {
-        bmi270RegisterWrite(bus, BMI270_REG_CMD, BMI270_VAL_CMD_FIFOFLUSH, 1);
+        bmi270RegisterWrite(dev, BMI270_REG_CMD, BMI270_VAL_CMD_FIFOFLUSH, 1);
     }
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -146,7 +146,7 @@ typedef enum {
 
 // BMI270 register reads are 16bits with the first byte a "dummy" value 0
 // that must be ignored. The result is in the second byte.
-static uint8_t bmi270RegisterRead(const busDevice_t *bus, bmi270Register_e registerId)
+static uint8_t bmi270RegisterRead(const extDevice_t *bus, bmi270Register_e registerId)
 {
     uint8_t data[2] = { 0, 0 };
 
@@ -157,7 +157,7 @@ static uint8_t bmi270RegisterRead(const busDevice_t *bus, bmi270Register_e regis
     }
 }
 
-static void bmi270RegisterWrite(const busDevice_t *bus, bmi270Register_e registerId, uint8_t value, unsigned delayMs)
+static void bmi270RegisterWrite(const extDevice_t *bus, bmi270Register_e registerId, uint8_t value, unsigned delayMs)
 {
     spiWriteReg(bus, registerId, value);
     if (delayMs) {
@@ -167,7 +167,7 @@ static void bmi270RegisterWrite(const busDevice_t *bus, bmi270Register_e registe
 
 // Toggle the CS to switch the device into SPI mode.
 // Device switches initializes as I2C and switches to SPI on a low to high CS transition
-static void bmi270EnableSPI(const busDevice_t *bus)
+static void bmi270EnableSPI(const extDevice_t *bus)
 {
     IOLo(bus->busType_u.spi.csnPin);
     delay(1);
@@ -175,7 +175,7 @@ static void bmi270EnableSPI(const busDevice_t *bus)
     delay(10);
 }
 
-uint8_t bmi270Detect(const busDevice_t *bus)
+uint8_t bmi270Detect(const extDevice_t *bus)
 {
 #ifndef USE_DUAL_GYRO
     IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
@@ -193,7 +193,7 @@ uint8_t bmi270Detect(const busDevice_t *bus)
     return MPU_NONE;
 }
 
-static void bmi270UploadConfig(const busDevice_t *bus)
+static void bmi270UploadConfig(const extDevice_t *bus)
 {
     bmi270RegisterWrite(bus, BMI270_REG_PWR_CONF, 0, 1);
     bmi270RegisterWrite(bus, BMI270_REG_INIT_CTRL, 0, 1);
@@ -221,7 +221,7 @@ static uint8_t getBmiOsrMode()
 
 static void bmi270Config(const gyroDev_t *gyro)
 {
-    const busDevice_t *bus = &gyro->dev;
+    const extDevice_t *bus = &gyro->dev;
 
     // If running in hardware_lpf experimental mode then switch to FIFO-based,
     // 6.4KHz sampling, unfiltered data vs. the default 3.2KHz with hardware filtering

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.h
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.h
@@ -22,7 +22,7 @@
 
 #include "drivers/bus.h"
 
-uint8_t bmi270Detect(const extDevice_t *bus);
+uint8_t bmi270Detect(const extDevice_t *dev);
 bool bmi270SpiAccDetect(accDev_t *acc);
 bool bmi270SpiGyroDetect(gyroDev_t *gyro);
 uint8_t bmi270InterruptStatus(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.h
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.h
@@ -22,7 +22,7 @@
 
 #include "drivers/bus.h"
 
-uint8_t bmi270Detect(const busDevice_t *bus);
+uint8_t bmi270Detect(const extDevice_t *bus);
 bool bmi270SpiAccDetect(accDev_t *acc);
 bool bmi270SpiGyroDetect(gyroDev_t *gyro);
 uint8_t bmi270InterruptStatus(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -37,33 +37,33 @@
 #include "drivers/time.h"
 
 
-static void icm20649SpiInit(const extDevice_t *bus) {
+static void icm20649SpiInit(const extDevice_t *dev) {
     static bool hardwareInitialised = false;
     if (hardwareInitialised) {
         return;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
     // all registers can be read/written at full speed (7MHz +-10%)
     // TODO verify that this works at 9MHz and 10MHz on non F7
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
-uint8_t icm20649SpiDetect(const extDevice_t *bus) {
-    icm20649SpiInit(bus);
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
-    spiWriteReg(bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
+uint8_t icm20649SpiDetect(const extDevice_t *dev) {
+    icm20649SpiInit(dev);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiWriteReg(dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
-    spiWriteReg(bus, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
+    spiWriteReg(dev, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(bus, ICM20649_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(dev, ICM20649_RA_WHO_AM_I);
         if (whoAmI == ICM20649_WHO_AM_I_CONST) {
             icmDetected = ICM_20649_SPI;
         } else {

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -37,7 +37,7 @@
 #include "drivers/time.h"
 
 
-static void icm20649SpiInit(const busDevice_t *bus) {
+static void icm20649SpiInit(const extDevice_t *bus) {
     static bool hardwareInitialised = false;
     if (hardwareInitialised) {
         return;
@@ -53,7 +53,7 @@ static void icm20649SpiInit(const busDevice_t *bus) {
     hardwareInitialised = true;
 }
 
-uint8_t icm20649SpiDetect(const busDevice_t *bus) {
+uint8_t icm20649SpiDetect(const extDevice_t *bus) {
     icm20649SpiInit(bus);
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     spiWriteReg(bus, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.h
@@ -59,7 +59,7 @@ enum icm20649_accel_fsr_e {
 void icm20649AccInit(accDev_t *acc);
 void icm20649GyroInit(gyroDev_t *gyro);
 
-uint8_t icm20649SpiDetect(const busDevice_t *bus);
+uint8_t icm20649SpiDetect(const extDevice_t *bus);
 
 bool icm20649SpiAccDetect(accDev_t *acc);
 bool icm20649SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.h
@@ -59,7 +59,7 @@ enum icm20649_accel_fsr_e {
 void icm20649AccInit(accDev_t *acc);
 void icm20649GyroInit(gyroDev_t *gyro);
 
-uint8_t icm20649SpiDetect(const extDevice_t *bus);
+uint8_t icm20649SpiDetect(const extDevice_t *dev);
 
 bool icm20649SpiAccDetect(accDev_t *acc);
 bool icm20649SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -37,7 +37,7 @@
 #include "drivers/time.h"
 
 
-static void icm20689SpiInit(const busDevice_t *bus) {
+static void icm20689SpiInit(const extDevice_t *bus) {
     static bool hardwareInitialised = false;
     if (hardwareInitialised) {
         return;
@@ -51,7 +51,7 @@ static void icm20689SpiInit(const busDevice_t *bus) {
     hardwareInitialised = true;
 }
 
-uint8_t icm20689SpiDetect(const busDevice_t *bus) {
+uint8_t icm20689SpiDetect(const extDevice_t *bus) {
     icm20689SpiInit(bus);
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -37,29 +37,29 @@
 #include "drivers/time.h"
 
 
-static void icm20689SpiInit(const extDevice_t *bus) {
+static void icm20689SpiInit(const extDevice_t *dev) {
     static bool hardwareInitialised = false;
     if (hardwareInitialised) {
         return;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
-uint8_t icm20689SpiDetect(const extDevice_t *bus) {
-    icm20689SpiInit(bus);
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
-    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+uint8_t icm20689SpiDetect(const extDevice_t *dev) {
+    icm20689SpiInit(dev);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiWriteReg(dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM20601_WHO_AM_I_CONST:
             icmDetected = ICM_20601_SPI;
@@ -84,7 +84,7 @@ uint8_t icm20689SpiDetect(const extDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.h
@@ -30,7 +30,7 @@ bool icm20689GyroDetect(gyroDev_t *gyro);
 void icm20689AccInit(accDev_t *acc);
 void icm20689GyroInit(gyroDev_t *gyro);
 
-uint8_t icm20689SpiDetect(const extDevice_t *bus);
+uint8_t icm20689SpiDetect(const extDevice_t *dev);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.h
@@ -30,7 +30,7 @@ bool icm20689GyroDetect(gyroDev_t *gyro);
 void icm20689AccInit(accDev_t *acc);
 void icm20689GyroInit(gyroDev_t *gyro);
 
-uint8_t icm20689SpiDetect(const busDevice_t *bus);
+uint8_t icm20689SpiDetect(const extDevice_t *bus);
 
 bool icm20689SpiAccDetect(accDev_t *acc);
 bool icm20689SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -153,7 +153,7 @@ static aafConfig_t aafLUT42605[AAF_CONFIG_COUNT] = {  // see table in section 5.
     [AAF_CONFIG_1962HZ] = { 63, 3968,  3 }, // 995 Hz is the max cutoff on the 42605
 };
 
-static void icm426xxSpiInit(const busDevice_t *bus) {
+static void icm426xxSpiInit(const extDevice_t *bus) {
     static bool hardwareInitialised = false;
     if (hardwareInitialised) {
         return;
@@ -167,7 +167,7 @@ static void icm426xxSpiInit(const busDevice_t *bus) {
     hardwareInitialised = true;
 }
 
-uint8_t icm426xxSpiDetect(const busDevice_t *bus) {
+uint8_t icm426xxSpiDetect(const extDevice_t *bus) {
     icm426xxSpiInit(bus);
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -153,29 +153,29 @@ static aafConfig_t aafLUT42605[AAF_CONFIG_COUNT] = {  // see table in section 5.
     [AAF_CONFIG_1962HZ] = { 63, 3968,  3 }, // 995 Hz is the max cutoff on the 42605
 };
 
-static void icm426xxSpiInit(const extDevice_t *bus) {
+static void icm426xxSpiInit(const extDevice_t *dev) {
     static bool hardwareInitialised = false;
     if (hardwareInitialised) {
         return;
     }
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
-uint8_t icm426xxSpiDetect(const extDevice_t *bus) {
-    icm426xxSpiInit(bus);
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
-    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);
+uint8_t icm426xxSpiDetect(const extDevice_t *dev) {
+    icm426xxSpiInit(dev);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiWriteReg(dev, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM42605_WHO_AM_I_CONST:
             icmDetected = ICM_42605_SPI;
@@ -194,7 +194,7 @@ uint8_t icm426xxSpiDetect(const extDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.h
@@ -30,7 +30,7 @@ bool icm426xxGyroDetect(gyroDev_t *gyro);
 void icm426xxAccInit(accDev_t *acc);
 void icm426xxGyroInit(gyroDev_t *gyro);
 
-uint8_t icm426xxSpiDetect(const busDevice_t *dev);
+uint8_t icm426xxSpiDetect(const extDevice_t *dev);
 
 bool icm426xxSpiAccDetect(accDev_t *acc);
 bool icm426xxSpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -117,7 +117,7 @@ void mpu6000SpiAccInit(accDev_t *acc) {
     acc->acc_1G = 512 * 4;
 }
 
-uint8_t mpu6000SpiDetect(const busDevice_t *bus) {
+uint8_t mpu6000SpiDetect(const extDevice_t *bus) {
 #ifndef USE_DUAL_GYRO
     IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
     IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -117,18 +117,18 @@ void mpu6000SpiAccInit(accDev_t *acc) {
     acc->acc_1G = 512 * 4;
 }
 
-uint8_t mpu6000SpiDetect(const extDevice_t *bus) {
+uint8_t mpu6000SpiDetect(const extDevice_t *dev) {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
-    spiWriteReg(bus, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiWriteReg(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     uint8_t attemptsRemaining = 5;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
         if (whoAmI == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -136,7 +136,7 @@ uint8_t mpu6000SpiDetect(const extDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    const uint8_t productID = spiReadReg(bus, MPU_RA_PRODUCT_ID);
+    const uint8_t productID = spiReadReg(dev, MPU_RA_PRODUCT_ID);
     /* look for a product ID we recognise */
     // verify product revision
     switch (productID) {

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.h
@@ -34,7 +34,7 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-uint8_t mpu6000SpiDetect(const extDevice_t *bus);
+uint8_t mpu6000SpiDetect(const extDevice_t *dev);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.h
@@ -34,7 +34,7 @@
 // RF = Register Flag
 #define MPU_RF_DATA_RDY_EN (1 << 0)
 
-uint8_t mpu6000SpiDetect(const busDevice_t *bus);
+uint8_t mpu6000SpiDetect(const extDevice_t *bus);
 
 bool mpu6000SpiAccDetect(accDev_t *acc);
 bool mpu6000SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -39,18 +39,18 @@
 
 #define BIT_SLEEP                   0x40
 
-static void mpu6500SpiInit(const extDevice_t *bus) {
+static void mpu6500SpiInit(const extDevice_t *dev) {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_FAST);
 }
 
-uint8_t mpu6500SpiDetect(const extDevice_t *bus) {
-    mpu6500SpiInit(bus);
-    const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
+uint8_t mpu6500SpiDetect(const extDevice_t *dev) {
+    mpu6500SpiInit(dev);
+    const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
     uint8_t mpuDetected = MPU_NONE;
     switch (whoAmI) {
     case MPU6500_WHO_AM_I_CONST:

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -39,7 +39,7 @@
 
 #define BIT_SLEEP                   0x40
 
-static void mpu6500SpiInit(const busDevice_t *bus) {
+static void mpu6500SpiInit(const extDevice_t *bus) {
 #ifndef USE_DUAL_GYRO
     IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
     IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
@@ -48,7 +48,7 @@ static void mpu6500SpiInit(const busDevice_t *bus) {
     spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_FAST);
 }
 
-uint8_t mpu6500SpiDetect(const busDevice_t *bus) {
+uint8_t mpu6500SpiDetect(const extDevice_t *bus) {
     mpu6500SpiInit(bus);
     const uint8_t whoAmI = spiReadReg(bus, MPU_RA_WHO_AM_I);
     uint8_t mpuDetected = MPU_NONE;

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.h
@@ -22,7 +22,7 @@
 
 #include "drivers/bus.h"
 
-uint8_t mpu6500SpiDetect(const extDevice_t *bus);
+uint8_t mpu6500SpiDetect(const extDevice_t *dev);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.h
@@ -22,7 +22,7 @@
 
 #include "drivers/bus.h"
 
-uint8_t mpu6500SpiDetect(const busDevice_t *bus);
+uint8_t mpu6500SpiDetect(const extDevice_t *bus);
 
 bool mpu6500SpiAccDetect(accDev_t *acc);
 bool mpu6500SpiGyroDetect(gyroDev_t *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -51,7 +51,7 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro);
 
 static bool mpuSpi9250InitDone = false;
 
-bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data) {
+bool mpu9250SpiWriteRegister(const extDevice_t *bus, uint8_t reg, uint8_t data) {
     IOLo(bus->busType_u.spi.csnPin);
     delayMicroseconds(1);
     spiTransferByte(bus->busType_u.spi.instance, reg);
@@ -61,7 +61,7 @@ bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data) 
     return true;
 }
 
-static bool mpu9250SpiSlowReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
+static bool mpu9250SpiSlowReadRegisterBuffer(const extDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
     IOLo(bus->busType_u.spi.csnPin);
     delayMicroseconds(1);
     spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
@@ -73,10 +73,10 @@ static bool mpu9250SpiSlowReadRegisterBuffer(const busDevice_t *bus, uint8_t reg
 
 void mpu9250SpiResetGyro(void) {
 #if 0
-// XXX This doesn't work. Need a proper busDevice_t.
+// XXX This doesn't work. Need a proper extDevice_t.
     // Device Reset
 #ifdef MPU9250_CS_PIN
-    busDevice_t bus = { .spi = { .csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) } };
+    extDevice_t bus = { .spi = { .csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) } };
     mpu9250SpiWriteRegister(&bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(150);
 #endif
@@ -99,7 +99,7 @@ void mpu9250SpiAccInit(accDev_t *acc) {
     acc->acc_1G = 512 * 4;
 }
 
-bool mpu9250SpiWriteRegisterVerify(const busDevice_t *bus, uint8_t reg, uint8_t data) {
+bool mpu9250SpiWriteRegisterVerify(const extDevice_t *bus, uint8_t reg, uint8_t data) {
     mpu9250SpiWriteRegister(bus, reg, data);
     delayMicroseconds(100);
     uint8_t attemptsRemaining = 20;
@@ -137,7 +137,7 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     mpuSpi9250InitDone = true; //init done
 }
 
-uint8_t mpu9250SpiDetect(const busDevice_t *bus) {
+uint8_t mpu9250SpiDetect(const extDevice_t *bus) {
 #ifndef USE_DUAL_GYRO
     IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
     IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -51,22 +51,22 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro);
 
 static bool mpuSpi9250InitDone = false;
 
-bool mpu9250SpiWriteRegister(const extDevice_t *bus, uint8_t reg, uint8_t data) {
-    IOLo(bus->busType_u.spi.csnPin);
+bool mpu9250SpiWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    IOLo(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
-    spiTransferByte(bus->busType_u.spi.instance, reg);
-    spiTransferByte(bus->busType_u.spi.instance, data);
-    IOHi(bus->busType_u.spi.csnPin);
+    spiTransferByte(dev->busType_u.spi.instance, reg);
+    spiTransferByte(dev->busType_u.spi.instance, data);
+    IOHi(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
     return true;
 }
 
-static bool mpu9250SpiSlowReadRegisterBuffer(const extDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
-    IOLo(bus->busType_u.spi.csnPin);
+static bool mpu9250SpiSlowReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+    IOLo(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
-    spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(bus->busType_u.spi.instance, NULL, data, length);
-    IOHi(bus->busType_u.spi.csnPin);
+    spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(dev->busType_u.spi.instance, NULL, data, length);
+    IOHi(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
     return true;
 }
@@ -76,8 +76,8 @@ void mpu9250SpiResetGyro(void) {
 // XXX This doesn't work. Need a proper extDevice_t.
     // Device Reset
 #ifdef MPU9250_CS_PIN
-    extDevice_t bus = { .spi = { .csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) } };
-    mpu9250SpiWriteRegister(&bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    extDevice_t dev = { .spi = { .csnPin = IOGetByTag(IO_TAG(MPU9250_CS_PIN)) } };
+    mpu9250SpiWriteRegister(&dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(150);
 #endif
 #endif
@@ -99,18 +99,18 @@ void mpu9250SpiAccInit(accDev_t *acc) {
     acc->acc_1G = 512 * 4;
 }
 
-bool mpu9250SpiWriteRegisterVerify(const extDevice_t *bus, uint8_t reg, uint8_t data) {
-    mpu9250SpiWriteRegister(bus, reg, data);
+bool mpu9250SpiWriteRegisterVerify(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    mpu9250SpiWriteRegister(dev, reg, data);
     delayMicroseconds(100);
     uint8_t attemptsRemaining = 20;
     do {
         uint8_t in;
-        mpu9250SpiSlowReadRegisterBuffer(bus, reg, &in, 1);
+        mpu9250SpiSlowReadRegisterBuffer(dev, reg, &in, 1);
         if (in == data) {
             return true;
         } else {
             debug[3]++;
-            mpu9250SpiWriteRegister(bus, reg, data);
+            mpu9250SpiWriteRegister(dev, reg, data);
             delayMicroseconds(100);
         }
     } while (attemptsRemaining--);
@@ -137,18 +137,18 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     mpuSpi9250InitDone = true; //init done
 }
 
-uint8_t mpu9250SpiDetect(const extDevice_t *bus) {
+uint8_t mpu9250SpiDetect(const extDevice_t *dev) {
 #ifndef USE_DUAL_GYRO
-    IOInit(bus->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
-    IOConfigGPIO(bus->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_MPU_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
-    mpu9250SpiWriteRegister(bus, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    mpu9250SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t in = spiReadReg(bus, MPU_RA_WHO_AM_I);
+        const uint8_t in = spiReadReg(dev, MPU_RA_WHO_AM_I);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }
@@ -156,7 +156,7 @@ uint8_t mpu9250SpiDetect(const extDevice_t *bus) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(bus->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_FAST);
     return MPU_9250_SPI;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
@@ -44,11 +44,11 @@
 
 void mpu9250SpiResetGyro(void);
 
-uint8_t mpu9250SpiDetect(const busDevice_t *bus);
+uint8_t mpu9250SpiDetect(const extDevice_t *bus);
 
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu9250SpiWriteRegisterVerify(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu9250SpiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteRegister(const extDevice_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiWriteRegisterVerify(const extDevice_t *bus, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegBuf(const extDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.h
@@ -44,11 +44,11 @@
 
 void mpu9250SpiResetGyro(void);
 
-uint8_t mpu9250SpiDetect(const extDevice_t *bus);
+uint8_t mpu9250SpiDetect(const extDevice_t *dev);
 
 bool mpu9250SpiAccDetect(accDev_t *acc);
 bool mpu9250SpiGyroDetect(gyroDev_t *gyro);
 
-bool mpu9250SpiWriteRegister(const extDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu9250SpiWriteRegisterVerify(const extDevice_t *bus, uint8_t reg, uint8_t data);
-bool mpu9250SpiReadRegBuf(const extDevice_t *bus, uint8_t reg, uint8_t length, uint8_t *data);
+bool mpu9250SpiWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool mpu9250SpiWriteRegisterVerify(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool mpu9250SpiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t length, uint8_t *data);

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -122,7 +122,7 @@ static bool bmp085InitDone = false;
 STATIC_UNIT_TESTED uint16_t bmp085_ut;  // static result of temperature measurement
 STATIC_UNIT_TESTED uint32_t bmp085_up;  // static result of pressure measurement
 
-static void bmp085_get_cal_param(busDevice_t *busdev);
+static void bmp085_get_cal_param(extDevice_t *busdev);
 static void bmp085_start_ut(baroDev_t *baro);
 static void bmp085_get_ut(baroDev_t *baro);
 static void bmp085_start_up(baroDev_t *baro);
@@ -180,7 +180,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
     UNUSED(config);
 #endif
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
-    busDevice_t *busdev = &baro->dev;
+    extDevice_t *busdev = &baro->dev;
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for BMP085
         busdev->busType_u.i2c.address = BMP085_I2C_ADDR;
@@ -316,7 +316,7 @@ STATIC_UNIT_TESTED void bmp085_calculate(int32_t *pressure, int32_t *temperature
         *temperature = temp;
 }
 
-static void bmp085_get_cal_param(busDevice_t *busdev) {
+static void bmp085_get_cal_param(extDevice_t *busdev) {
     uint8_t data[22];
     busReadRegisterBuffer(busdev, BMP085_PROM_START__ADDR, data, BMP085_PROM_DATA__LEN);
     /*parameters AC1-AC6*/

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -122,7 +122,7 @@ static bool bmp085InitDone = false;
 STATIC_UNIT_TESTED uint16_t bmp085_ut;  // static result of temperature measurement
 STATIC_UNIT_TESTED uint32_t bmp085_up;  // static result of pressure measurement
 
-static void bmp085_get_cal_param(extDevice_t *busdev);
+static void bmp085_get_cal_param(extDevice_t *dev);
 static void bmp085_start_ut(baroDev_t *baro);
 static void bmp085_get_ut(baroDev_t *baro);
 static void bmp085_start_up(baroDev_t *baro);
@@ -180,21 +180,21 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
     UNUSED(config);
 #endif
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
-    extDevice_t *busdev = &baro->dev;
-    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
+    extDevice_t *dev = &baro->dev;
+    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         // Default address for BMP085
-        busdev->busType_u.i2c.address = BMP085_I2C_ADDR;
+        dev->busType_u.i2c.address = BMP085_I2C_ADDR;
         defaultAddressApplied = true;
     }
-    ack = busReadRegisterBuffer(busdev, BMP085_CHIP_ID__REG, &data, 1); /* read Chip Id */
+    ack = busReadRegisterBuffer(dev, BMP085_CHIP_ID__REG, &data, 1); /* read Chip Id */
     if (ack) {
         bmp085.chip_id = BMP085_GET_BITSLICE(data, BMP085_CHIP_ID);
         bmp085.oversampling_setting = 3;
         if (bmp085.chip_id == BMP085_CHIP_ID) { /* get bitslice */
-            busReadRegisterBuffer(busdev, BMP085_VERSION_REG, &data, 1); /* read Version reg */
+            busReadRegisterBuffer(dev, BMP085_VERSION_REG, &data, 1); /* read Version reg */
             bmp085.ml_version = BMP085_GET_BITSLICE(data, BMP085_ML_VERSION); /* get ML Version */
             bmp085.al_version = BMP085_GET_BITSLICE(data, BMP085_AL_VERSION); /* get AL Version */
-            bmp085_get_cal_param(busdev); /* readout bmp085 calibparam structure */
+            bmp085_get_cal_param(dev); /* readout bmp085 calibparam structure */
             baro->ut_delay = UT_DELAY;
             baro->up_delay = UP_DELAY;
             baro->start_ut = bmp085_start_ut;
@@ -215,7 +215,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
 #endif
     BMP085_OFF;
     if (defaultAddressApplied) {
-        busdev->busType_u.i2c.address = 0;
+        dev->busType_u.i2c.address = 0;
     }
     return false;
 }
@@ -316,9 +316,9 @@ STATIC_UNIT_TESTED void bmp085_calculate(int32_t *pressure, int32_t *temperature
         *temperature = temp;
 }
 
-static void bmp085_get_cal_param(extDevice_t *busdev) {
+static void bmp085_get_cal_param(extDevice_t *dev) {
     uint8_t data[22];
-    busReadRegisterBuffer(busdev, BMP085_PROM_START__ADDR, data, BMP085_PROM_DATA__LEN);
+    busReadRegisterBuffer(dev, BMP085_PROM_START__ADDR, data, BMP085_PROM_DATA__LEN);
     /*parameters AC1-AC6*/
     bmp085.cal_param.ac1 = (data[0] << 8) | data[1];
     bmp085.cal_param.ac2 = (data[2] << 8) | data[3];

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -52,7 +52,7 @@ static void bmp280_get_up(baroDev_t *baro);
 
 STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature);
 
-void bmp280BusInit(busDevice_t *busdev) {
+void bmp280BusInit(extDevice_t *busdev) {
 #ifdef USE_BARO_SPI_BMP280
     if (busdev->busType == BUS_TYPE_SPI) {
         IOHi(busdev->busType_u.spi.csnPin); // Disable
@@ -65,7 +65,7 @@ void bmp280BusInit(busDevice_t *busdev) {
 #endif
 }
 
-void bmp280BusDeinit(busDevice_t *busdev) {
+void bmp280BusDeinit(extDevice_t *busdev) {
 #ifdef USE_BARO_SPI_BMP280
     if (busdev->busType == BUS_TYPE_SPI) {
         spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
@@ -77,7 +77,7 @@ void bmp280BusDeinit(busDevice_t *busdev) {
 
 bool bmp280Detect(baroDev_t *baro) {
     delay(20);
-    busDevice_t *busdev = &baro->dev;
+    extDevice_t *busdev = &baro->dev;
     bool defaultAddressApplied = false;
     bmp280BusInit(busdev);
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -52,51 +52,51 @@ static void bmp280_get_up(baroDev_t *baro);
 
 STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature);
 
-void bmp280BusInit(extDevice_t *busdev) {
+void bmp280BusInit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (busdev->busType == BUS_TYPE_SPI) {
-        IOHi(busdev->busType_u.spi.csnPin); // Disable
-        IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
-        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
+    if (dev->busType == BUS_TYPE_SPI) {
+        IOHi(dev->busType_u.spi.csnPin); // Disable
+        IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+        IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
-    UNUSED(busdev);
+    UNUSED(dev);
 #endif
 }
 
-void bmp280BusDeinit(extDevice_t *busdev) {
+void bmp280BusDeinit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (busdev->busType == BUS_TYPE_SPI) {
-        spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
+    if (dev->busType == BUS_TYPE_SPI) {
+        spiPreinitCsByIO(dev->busType_u.spi.csnPin);
     }
 #else
-    UNUSED(busdev);
+    UNUSED(dev);
 #endif
 }
 
 bool bmp280Detect(baroDev_t *baro) {
     delay(20);
-    extDevice_t *busdev = &baro->dev;
+    extDevice_t *dev = &baro->dev;
     bool defaultAddressApplied = false;
-    bmp280BusInit(busdev);
-    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
+    bmp280BusInit(dev);
+    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         // Default address for BMP280
-        busdev->busType_u.i2c.address = BMP280_I2C_ADDR;
+        dev->busType_u.i2c.address = BMP280_I2C_ADDR;
         defaultAddressApplied = true;
     }
-    busReadRegisterBuffer(busdev, BMP280_CHIP_ID_REG, &bmp280_chip_id, 1);  /* read Chip Id */
+    busReadRegisterBuffer(dev, BMP280_CHIP_ID_REG, &bmp280_chip_id, 1);  /* read Chip Id */
     if (bmp280_chip_id != BMP280_DEFAULT_CHIP_ID) {
-        bmp280BusDeinit(busdev);
+        bmp280BusDeinit(dev);
         if (defaultAddressApplied) {
-            busdev->busType_u.i2c.address = 0;
+            dev->busType_u.i2c.address = 0;
         }
         return false;
     }
     // read calibration
-    busReadRegisterBuffer(busdev, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, (uint8_t *)&bmp280_cal, 24);
+    busReadRegisterBuffer(dev, BMP280_TEMPERATURE_CALIB_DIG_T1_LSB_REG, (uint8_t *)&bmp280_cal, 24);
     // set oversampling + power mode (forced), and start sampling
-    busWriteRegister(busdev, BMP280_CTRL_MEAS_REG, BMP280_MODE);
+    busWriteRegister(dev, BMP280_CTRL_MEAS_REG, BMP280_MODE);
     // these are dummy as temperature is measured as part of pressure
     baro->ut_delay = 0;
     baro->get_ut = bmp280_get_ut;

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -189,29 +189,29 @@
 static uint32_t rawP = 0;
 static uint16_t rawT = 0;
 
-bool lpsWriteCommand(extDevice_t *busdev, uint8_t cmd, uint8_t byte) {
-    return spiWriteReg(busdev, cmd, byte);
+bool lpsWriteCommand(extDevice_t *dev, uint8_t cmd, uint8_t byte) {
+    return spiWriteReg(dev, cmd, byte);
 }
 
-bool lpsReadCommand(extDevice_t *busdev, uint8_t cmd, uint8_t *data, uint8_t len) {
-    return spiReadRegBuf(busdev, cmd | 0x80 | 0x40, data, len);
+bool lpsReadCommand(extDevice_t *dev, uint8_t cmd, uint8_t *data, uint8_t len) {
+    return spiReadRegBuf(dev, cmd | 0x80 | 0x40, data, len);
 }
 
-bool lpsWriteVerify(extDevice_t *busdev, uint8_t cmd, uint8_t byte) {
+bool lpsWriteVerify(extDevice_t *dev, uint8_t cmd, uint8_t byte) {
     uint8_t temp = 0xff;
-    spiWriteReg(busdev, cmd, byte);
-    spiReadRegBuf(busdev, cmd, &temp, 1);
+    spiWriteReg(dev, cmd, byte);
+    spiReadRegBuf(dev, cmd, &temp, 1);
     if (byte == temp) return true;
     return false;
 }
 
-static void lpsOn(extDevice_t *busdev, uint8_t CTRL1_val) {
-    lpsWriteCommand(busdev, LPS_CTRL1, CTRL1_val | 0x80);
+static void lpsOn(extDevice_t *dev, uint8_t CTRL1_val) {
+    lpsWriteCommand(dev, LPS_CTRL1, CTRL1_val | 0x80);
     //Instead of delay let's ready status reg
 }
 
-static void lpsOff(extDevice_t *busdev) {
-    lpsWriteCommand(busdev, LPS_CTRL1, 0x00 | (0x01 << 2));
+static void lpsOff(extDevice_t *dev) {
+    lpsWriteCommand(dev, LPS_CTRL1, 0x00 | (0x01 << 2));
 }
 
 static void lps_nothing(baroDev_t *baro) {
@@ -241,11 +241,11 @@ static void lps_calculate(int32_t *pressure, int32_t *temperature) {
 
 bool lpsDetect(baroDev_t *baro) {
     //Detect
-    extDevice_t *busdev = &baro->dev;
-    IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
-    IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-    IOHi(busdev->busType_u.spi.csnPin); // Disable
-    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
+    extDevice_t *dev = &baro->dev;
+    IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+    IOHi(dev->busType_u.spi.csnPin); // Disable
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
     uint8_t temp = 0x00;
     lpsReadCommand(&baro->dev, LPS_WHO_AM_I, &temp, 1);
     if (temp != LPS25_ID && temp != LPS22_ID && temp != LPS33_ID && temp != LPS35_ID) {
@@ -253,15 +253,15 @@ bool lpsDetect(baroDev_t *baro) {
     }
     //Init, if writeVerify is false fallback to false on detect
     bool ret = false;
-    lpsOff(busdev);
-    ret = lpsWriteVerify(busdev, LPS_CTRL2, (0x00 << 1));
+    lpsOff(dev);
+    ret = lpsWriteVerify(dev, LPS_CTRL2, (0x00 << 1));
     if (ret != true) return false;
-    ret = lpsWriteVerify(busdev, LPS_RES_CONF, (LPS_AVT_64 | LPS_AVP_512));
+    ret = lpsWriteVerify(dev, LPS_RES_CONF, (LPS_AVT_64 | LPS_AVP_512));
     if (ret != true) return false;
-    ret = lpsWriteVerify(busdev, LPS_CTRL4, 0x01);
+    ret = lpsWriteVerify(dev, LPS_CTRL4, 0x01);
     if (ret != true) return false;
-    lpsOn(busdev, (0x04 << 4) | (0x01 << 1) | (0x01 << 2) | (0x01 << 3));
-    lpsReadCommand(busdev, LPS_CTRL1, &temp, 1);
+    lpsOn(dev, (0x04 << 4) | (0x01 << 1) | (0x01 << 2) | (0x01 << 3));
+    lpsReadCommand(dev, LPS_CTRL1, &temp, 1);
     baro->ut_delay = 1;
     baro->up_delay = 1000000 / 24;
     baro->start_ut = lps_nothing;

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -189,15 +189,15 @@
 static uint32_t rawP = 0;
 static uint16_t rawT = 0;
 
-bool lpsWriteCommand(busDevice_t *busdev, uint8_t cmd, uint8_t byte) {
+bool lpsWriteCommand(extDevice_t *busdev, uint8_t cmd, uint8_t byte) {
     return spiWriteReg(busdev, cmd, byte);
 }
 
-bool lpsReadCommand(busDevice_t *busdev, uint8_t cmd, uint8_t *data, uint8_t len) {
+bool lpsReadCommand(extDevice_t *busdev, uint8_t cmd, uint8_t *data, uint8_t len) {
     return spiReadRegBuf(busdev, cmd | 0x80 | 0x40, data, len);
 }
 
-bool lpsWriteVerify(busDevice_t *busdev, uint8_t cmd, uint8_t byte) {
+bool lpsWriteVerify(extDevice_t *busdev, uint8_t cmd, uint8_t byte) {
     uint8_t temp = 0xff;
     spiWriteReg(busdev, cmd, byte);
     spiReadRegBuf(busdev, cmd, &temp, 1);
@@ -205,12 +205,12 @@ bool lpsWriteVerify(busDevice_t *busdev, uint8_t cmd, uint8_t byte) {
     return false;
 }
 
-static void lpsOn(busDevice_t *busdev, uint8_t CTRL1_val) {
+static void lpsOn(extDevice_t *busdev, uint8_t CTRL1_val) {
     lpsWriteCommand(busdev, LPS_CTRL1, CTRL1_val | 0x80);
     //Instead of delay let's ready status reg
 }
 
-static void lpsOff(busDevice_t *busdev) {
+static void lpsOff(extDevice_t *busdev) {
     lpsWriteCommand(busdev, LPS_CTRL1, 0x00 | (0x01 << 2));
 }
 
@@ -241,7 +241,7 @@ static void lps_calculate(int32_t *pressure, int32_t *temperature) {
 
 bool lpsDetect(baroDev_t *baro) {
     //Detect
-    busDevice_t *busdev = &baro->dev;
+    extDevice_t *busdev = &baro->dev;
     IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
     IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
     IOHi(busdev->busType_u.spi.csnPin); // Disable

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -49,10 +49,10 @@
 #define CMD_PROM_RD             0xA0 // Prom read command
 #define PROM_NB                 8
 
-static void ms5611_reset(busDevice_t *busdev);
-static uint16_t ms5611_prom(busDevice_t *busdev, int8_t coef_num);
+static void ms5611_reset(extDevice_t *busdev);
+static uint16_t ms5611_prom(extDevice_t *busdev, int8_t coef_num);
 STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom);
-static uint32_t ms5611_read_adc(busDevice_t *busdev);
+static uint32_t ms5611_read_adc(extDevice_t *busdev);
 static void ms5611_start_ut(baroDev_t *baro);
 static void ms5611_get_ut(baroDev_t *baro);
 static void ms5611_start_up(baroDev_t *baro);
@@ -64,7 +64,7 @@ STATIC_UNIT_TESTED uint32_t ms5611_up;  // static result of pressure measurement
 STATIC_UNIT_TESTED uint16_t ms5611_c[PROM_NB];  // on-chip ROM
 static uint8_t ms5611_osr = CMD_ADC_4096;
 
-void ms5611BusInit(busDevice_t *busdev) {
+void ms5611BusInit(extDevice_t *busdev) {
 #ifdef USE_BARO_SPI_MS5611
     if (busdev->busType == BUS_TYPE_SPI) {
         IOHi(busdev->busType_u.spi.csnPin); // Disable
@@ -77,7 +77,7 @@ void ms5611BusInit(busDevice_t *busdev) {
 #endif
 }
 
-void ms5611BusDeinit(busDevice_t *busdev) {
+void ms5611BusDeinit(extDevice_t *busdev) {
 #ifdef USE_BARO_SPI_MS5611
     if (busdev->busType == BUS_TYPE_SPI) {
         spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
@@ -92,7 +92,7 @@ bool ms5611Detect(baroDev_t *baro) {
     int i;
     bool defaultAddressApplied = false;
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
-    busDevice_t *busdev = &baro->dev;
+    extDevice_t *busdev = &baro->dev;
     ms5611BusInit(busdev);
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
         // Default address for MS5611
@@ -128,12 +128,12 @@ fail:
     return false;
 }
 
-static void ms5611_reset(busDevice_t *busdev) {
+static void ms5611_reset(extDevice_t *busdev) {
     busWriteRegister(busdev, CMD_RESET, 1);
     delayMicroseconds(2800);
 }
 
-static uint16_t ms5611_prom(busDevice_t *busdev, int8_t coef_num) {
+static uint16_t ms5611_prom(extDevice_t *busdev, int8_t coef_num) {
     uint8_t rxbuf[2] = { 0, 0 };
     busReadRegisterBuffer(busdev, CMD_PROM_RD + coef_num * 2, rxbuf, 2); // send PROM READ command
     return rxbuf[0] << 8 | rxbuf[1];
@@ -165,7 +165,7 @@ STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom) {
     return -1;
 }
 
-static uint32_t ms5611_read_adc(busDevice_t *busdev) {
+static uint32_t ms5611_read_adc(extDevice_t *busdev) {
     uint8_t rxbuf[3];
     busReadRegisterBuffer(busdev, CMD_ADC_READ, rxbuf, 3); // read ADC
     return (rxbuf[0] << 16) | (rxbuf[1] << 8) | rxbuf[2];

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -49,10 +49,10 @@
 #define CMD_PROM_RD             0xA0 // Prom read command
 #define PROM_NB                 8
 
-static void ms5611_reset(extDevice_t *busdev);
-static uint16_t ms5611_prom(extDevice_t *busdev, int8_t coef_num);
+static void ms5611_reset(extDevice_t *dev);
+static uint16_t ms5611_prom(extDevice_t *dev, int8_t coef_num);
 STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom);
-static uint32_t ms5611_read_adc(extDevice_t *busdev);
+static uint32_t ms5611_read_adc(extDevice_t *dev);
 static void ms5611_start_ut(baroDev_t *baro);
 static void ms5611_get_ut(baroDev_t *baro);
 static void ms5611_start_up(baroDev_t *baro);
@@ -64,26 +64,26 @@ STATIC_UNIT_TESTED uint32_t ms5611_up;  // static result of pressure measurement
 STATIC_UNIT_TESTED uint16_t ms5611_c[PROM_NB];  // on-chip ROM
 static uint8_t ms5611_osr = CMD_ADC_4096;
 
-void ms5611BusInit(extDevice_t *busdev) {
+void ms5611BusInit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (busdev->busType == BUS_TYPE_SPI) {
-        IOHi(busdev->busType_u.spi.csnPin); // Disable
-        IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
-        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
+    if (dev->busType == BUS_TYPE_SPI) {
+        IOHi(dev->busType_u.spi.csnPin); // Disable
+        IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+        IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
-    UNUSED(busdev);
+    UNUSED(dev);
 #endif
 }
 
-void ms5611BusDeinit(extDevice_t *busdev) {
+void ms5611BusDeinit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (busdev->busType == BUS_TYPE_SPI) {
-        spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
+    if (dev->busType == BUS_TYPE_SPI) {
+        spiPreinitCsByIO(dev->busType_u.spi.csnPin);
     }
 #else
-    UNUSED(busdev);
+    UNUSED(dev);
 #endif
 }
 
@@ -92,20 +92,20 @@ bool ms5611Detect(baroDev_t *baro) {
     int i;
     bool defaultAddressApplied = false;
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
-    extDevice_t *busdev = &baro->dev;
-    ms5611BusInit(busdev);
-    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
+    extDevice_t *dev = &baro->dev;
+    ms5611BusInit(dev);
+    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         // Default address for MS5611
-        busdev->busType_u.i2c.address = MS5611_I2C_ADDR;
+        dev->busType_u.i2c.address = MS5611_I2C_ADDR;
         defaultAddressApplied = true;
     }
-    if (!busReadRegisterBuffer(busdev, CMD_PROM_RD, &sig, 1) || sig == 0xFF) {
+    if (!busReadRegisterBuffer(dev, CMD_PROM_RD, &sig, 1) || sig == 0xFF) {
         goto fail;
     }
-    ms5611_reset(busdev);
+    ms5611_reset(dev);
     // read all coefficients
     for (i = 0; i < PROM_NB; i++)
-        ms5611_c[i] = ms5611_prom(busdev, i);
+        ms5611_c[i] = ms5611_prom(dev, i);
     // check crc, bail out if wrong - we are probably talking to BMP085 w/o XCLR line!
     if (ms5611_crc(ms5611_c) != 0) {
         goto fail;
@@ -121,21 +121,21 @@ bool ms5611Detect(baroDev_t *baro) {
     return true;
 fail:
     ;
-    ms5611BusDeinit(busdev);
+    ms5611BusDeinit(dev);
     if (defaultAddressApplied) {
-        busdev->busType_u.i2c.address = 0;
+        dev->busType_u.i2c.address = 0;
     }
     return false;
 }
 
-static void ms5611_reset(extDevice_t *busdev) {
-    busWriteRegister(busdev, CMD_RESET, 1);
+static void ms5611_reset(extDevice_t *dev) {
+    busWriteRegister(dev, CMD_RESET, 1);
     delayMicroseconds(2800);
 }
 
-static uint16_t ms5611_prom(extDevice_t *busdev, int8_t coef_num) {
+static uint16_t ms5611_prom(extDevice_t *dev, int8_t coef_num) {
     uint8_t rxbuf[2] = { 0, 0 };
-    busReadRegisterBuffer(busdev, CMD_PROM_RD + coef_num * 2, rxbuf, 2); // send PROM READ command
+    busReadRegisterBuffer(dev, CMD_PROM_RD + coef_num * 2, rxbuf, 2); // send PROM READ command
     return rxbuf[0] << 8 | rxbuf[1];
 }
 
@@ -165,9 +165,9 @@ STATIC_UNIT_TESTED int8_t ms5611_crc(uint16_t *prom) {
     return -1;
 }
 
-static uint32_t ms5611_read_adc(extDevice_t *busdev) {
+static uint32_t ms5611_read_adc(extDevice_t *dev) {
     uint8_t rxbuf[3];
-    busReadRegisterBuffer(busdev, CMD_ADC_READ, rxbuf, 3); // read ADC
+    busReadRegisterBuffer(dev, CMD_ADC_READ, rxbuf, 3); // read ADC
     return (rxbuf[0] << 16) | (rxbuf[1] << 8) | rxbuf[2];
 }
 

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -97,28 +97,28 @@ static void qmp6988_get_up(baroDev_t *baro);
 
 STATIC_UNIT_TESTED void qmp6988_calculate(int32_t *pressure, int32_t *temperature);
 
-void qmp6988BusInit(extDevice_t *busdev) {
+void qmp6988BusInit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (busdev->busType == BUS_TYPE_SPI) {
-        IOHi(busdev->busType_u.spi.csnPin);
-        IOInit(busdev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
-        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    if (dev->busType == BUS_TYPE_SPI) {
+        IOHi(dev->busType_u.spi.csnPin);
+        IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
+        IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     }
 #else
-    UNUSED(busdev);
+    UNUSED(dev);
 #endif
 }
 
-void qmp6988BusDeinit(extDevice_t *busdev) {
+void qmp6988BusDeinit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (busdev->busType == BUS_TYPE_SPI) {
-        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_IPU);
-        IORelease(busdev->busType_u.spi.csnPin);
-        IOInit(busdev->busType_u.spi.csnPin, OWNER_SPI_PREINIT, 0);
+    if (dev->busType == BUS_TYPE_SPI) {
+        IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_IPU);
+        IORelease(dev->busType_u.spi.csnPin);
+        IOInit(dev->busType_u.spi.csnPin, OWNER_SPI_PREINIT, 0);
     }
 #else
-    UNUSED(busdev);
+    UNUSED(dev);
 #endif
 }
 
@@ -139,25 +139,25 @@ bool qmp6988Detect(baroDev_t *baro) {
     uint16_t lb = 0, hb = 0;
     uint32_t lw = 0, hw = 0, temp1, temp2;
     delay(20);
-    extDevice_t *busdev = &baro->dev;
+    extDevice_t *dev = &baro->dev;
     bool defaultAddressApplied = false;
-    qmp6988BusInit(busdev);
-    if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {
-        busdev->busType_u.i2c.address = QMP6988_I2C_ADDR;
+    qmp6988BusInit(dev);
+    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
+        dev->busType_u.i2c.address = QMP6988_I2C_ADDR;
         defaultAddressApplied = true;
     }
-    busReadRegisterBuffer(busdev, QMP6988_CHIP_ID_REG, &qmp6988_chip_id, 1);  /* read Chip Id */
+    busReadRegisterBuffer(dev, QMP6988_CHIP_ID_REG, &qmp6988_chip_id, 1);  /* read Chip Id */
     if (qmp6988_chip_id != QMP6988_DEFAULT_CHIP_ID) {
-        qmp6988BusDeinit(busdev);
+        qmp6988BusDeinit(dev);
         if (defaultAddressApplied) {
-            busdev->busType_u.i2c.address = 0;
+            dev->busType_u.i2c.address = 0;
         }
         return false;
     }
     // SetIIR
-    busWriteRegister(busdev, QMP6988_SET_IIR_REG, 0x05);
+    busWriteRegister(dev, QMP6988_SET_IIR_REG, 0x05);
     //read OTP
-    busReadRegisterBuffer(busdev, QMP6988_COE_B00_1_REG, databuf, 25);
+    busReadRegisterBuffer(dev, QMP6988_COE_B00_1_REG, databuf, 25);
     //algo OTP
     hw = databuf[0];
     lw =  databuf[1];
@@ -221,7 +221,7 @@ bool qmp6988Detect(baroDev_t *baro) {
     qmp6988_cal.Coe_b21 = (2.10E-15) + (1.20E-14) * (float)Coe_b21_ / 32767.0;
     qmp6988_cal.Coe_bp3 = (1.30E-16) + (7.90E-17) * (float)Coe_bp3_ / 32767.0;
     // Set power mode and sample times
-    busWriteRegister(busdev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);
+    busWriteRegister(dev, QMP6988_CTRL_MEAS_REG, QMP6988_PWR_SAMPLE_MODE);
     // these are dummy as temperature is measured as part of pressure
     baro->ut_delay = 0;
     baro->get_ut = qmp6988_get_ut;

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -97,7 +97,7 @@ static void qmp6988_get_up(baroDev_t *baro);
 
 STATIC_UNIT_TESTED void qmp6988_calculate(int32_t *pressure, int32_t *temperature);
 
-void qmp6988BusInit(busDevice_t *busdev) {
+void qmp6988BusInit(extDevice_t *busdev) {
 #ifdef USE_BARO_SPI_QMP6988
     if (busdev->busType == BUS_TYPE_SPI) {
         IOHi(busdev->busType_u.spi.csnPin);
@@ -110,7 +110,7 @@ void qmp6988BusInit(busDevice_t *busdev) {
 #endif
 }
 
-void qmp6988BusDeinit(busDevice_t *busdev) {
+void qmp6988BusDeinit(extDevice_t *busdev) {
 #ifdef USE_BARO_SPI_QMP6988
     if (busdev->busType == BUS_TYPE_SPI) {
         IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_IPU);
@@ -139,7 +139,7 @@ bool qmp6988Detect(baroDev_t *baro) {
     uint16_t lb = 0, hb = 0;
     uint32_t lw = 0, hw = 0, temp1, temp2;
     delay(20);
-    busDevice_t *busdev = &baro->dev;
+    extDevice_t *busdev = &baro->dev;
     bool defaultAddressApplied = false;
     qmp6988BusInit(busdev);
     if ((busdev->busType == BUS_TYPE_I2C) && (busdev->busType_u.i2c.address == 0)) {

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -27,7 +27,7 @@
 #include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
 
-bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
+bool busWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
     return spiWriteReg(busdev, reg & 0x7f, data);
 #else
@@ -50,7 +50,7 @@ bool busWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
 #endif
 }
 
-bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
+bool busReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
     return spiReadRegBuf(busdev, reg | 0x80, data, length);
 #else
@@ -74,7 +74,7 @@ bool busReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data
 #endif
 }
 
-uint8_t busReadRegister(const busDevice_t *busdev, uint8_t reg) {
+uint8_t busReadRegister(const extDevice_t *busdev, uint8_t reg) {
 #ifdef USE_DMA_SPI_DEVICE
     uint8_t data;
     busReadRegisterBuffer(busdev, reg, &data, 1);

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -27,22 +27,22 @@
 #include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
 
-bool busWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
+bool busWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
-    return spiWriteReg(busdev, reg & 0x7f, data);
+    return spiWriteReg(dev, reg & 0x7f, data);
 #else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(reg);
     UNUSED(data);
 #endif
-    switch (busdev->busType) {
+    switch (dev->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        return spiWriteReg(busdev, reg & 0x7f, data);
+        return spiWriteReg(dev, reg & 0x7f, data);
 #endif
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        return i2cBusWriteRegister(busdev, reg, data);
+        return i2cBusWriteRegister(dev, reg, data);
 #endif
     default:
         return false;
@@ -50,23 +50,23 @@ bool busWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
 #endif
 }
 
-bool busReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
+bool busReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
-    return spiReadRegBuf(busdev, reg | 0x80, data, length);
+    return spiReadRegBuf(dev, reg | 0x80, data, length);
 #else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(reg);
     UNUSED(data);
     UNUSED(length);
 #endif
-    switch (busdev->busType) {
+    switch (dev->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        return spiReadRegBuf(busdev, reg | 0x80, data, length);
+        return spiReadRegBuf(dev, reg | 0x80, data, length);
 #endif
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        return i2cBusReadRegisterBuffer(busdev, reg, data, length);
+        return i2cBusReadRegisterBuffer(dev, reg, data, length);
 #endif
     default:
         return false;
@@ -74,19 +74,19 @@ bool busReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data
 #endif
 }
 
-uint8_t busReadRegister(const extDevice_t *busdev, uint8_t reg) {
+uint8_t busReadRegister(const extDevice_t *dev, uint8_t reg) {
 #ifdef USE_DMA_SPI_DEVICE
     uint8_t data;
-    busReadRegisterBuffer(busdev, reg, &data, 1);
+    busReadRegisterBuffer(dev, reg, &data, 1);
     return data;
 #else
 #if !defined(USE_SPI) && !defined(USE_I2C)
-    UNUSED(busdev);
+    UNUSED(dev);
     UNUSED(reg);
     return false;
 #else
     uint8_t data;
-    busReadRegisterBuffer(busdev, reg, &data, 1);
+    busReadRegisterBuffer(dev, reg, &data, 1);
     return data;
 #endif
 #endif

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -57,13 +57,6 @@ typedef struct extDevice_s {
     } busType_u;
 } extDevice_t;
 
-// Transitional alias. EmuFlight has not yet split the combined bus+device
-// struct into Betaflight's shared busDevice_s (per-peripheral resource) and
-// per-device extDevice_s. Until that split, both names resolve to the same
-// struct and code written against either name works. The alias can be
-// removed once all internal callers migrate off busDevice_t.
-typedef extDevice_t busDevice_t;
-
 #ifdef TARGET_BUS_INIT
 void targetBusInit(void);
 #endif

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -32,7 +32,7 @@ typedef enum {
     BUS_TYPE_MPU_SLAVE // Slave I2C on SPI master
 } busType_e;
 
-typedef struct busDevice_s {
+typedef struct extDevice_s {
     busType_e busType;
     union {
         struct busSpi_s {
@@ -51,23 +51,23 @@ typedef struct busDevice_s {
             uint8_t address;
         } i2c;
         struct busMpuSlave_s {
-            const struct busDevice_s *master;
+            const struct extDevice_s *master;
             uint8_t address;
         } mpuSlave;
     } busType_u;
-} busDevice_t;
+} extDevice_t;
+
+// Transitional alias. EmuFlight has not yet split the combined bus+device
+// struct into Betaflight's shared busDevice_s (per-peripheral resource) and
+// per-device extDevice_s. Until that split, both names resolve to the same
+// struct and code written against either name works. The alias can be
+// removed once all internal callers migrate off busDevice_t.
+typedef extDevice_t busDevice_t;
 
 #ifdef TARGET_BUS_INIT
 void targetBusInit(void);
 #endif
 
-bool busWriteRegister(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool busReadRegisterBuffer(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t busReadRegister(const busDevice_t *bus, uint8_t reg);
-
-// Betaflight paste-and-tweak alias. In BF master, extDevice_t is a separate
-// per-device struct pointing at a shared busDevice_s. EmuFlight has not yet
-// split the bus resource from the device; extDevice_t is a typedef so driver
-// code written against BF signatures compiles against our combined struct.
-// Splitting the shared-bus resource is a future refactor stage.
-typedef busDevice_t extDevice_t;
+bool busWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool busReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+uint8_t busReadRegister(const extDevice_t *dev, uint8_t reg);

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -29,17 +29,17 @@
 #include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 
-bool i2cBusWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
-    return i2cWrite(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, data);
+bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    return i2cWrite(dev->busType_u.i2c.device, dev->busType_u.i2c.address, reg, data);
 }
 
-bool i2cBusReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
-    return i2cRead(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, length, data);
+bool i2cBusReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+    return i2cRead(dev->busType_u.i2c.device, dev->busType_u.i2c.address, reg, length, data);
 }
 
-uint8_t i2cBusReadRegister(const extDevice_t *busdev, uint8_t reg) {
+uint8_t i2cBusReadRegister(const extDevice_t *dev, uint8_t reg) {
     uint8_t data;
-    i2cRead(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, 1, &data);
+    i2cRead(dev->busType_u.i2c.device, dev->busType_u.i2c.address, reg, 1, &data);
     return data;
 }
 #endif

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -29,15 +29,15 @@
 #include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
 
-bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
+bool i2cBusWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
     return i2cWrite(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, data);
 }
 
-bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
+bool i2cBusReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length) {
     return i2cRead(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, length, data);
 }
 
-uint8_t i2cBusReadRegister(const busDevice_t *busdev, uint8_t reg) {
+uint8_t i2cBusReadRegister(const extDevice_t *busdev, uint8_t reg) {
     uint8_t data;
     i2cRead(busdev->busType_u.i2c.device, busdev->busType_u.i2c.address, reg, 1, &data);
     return data;

--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -20,6 +20,6 @@
 
 #pragma once
 
-bool i2cBusWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data);
-bool i2cBusReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t i2cBusReadRegister(const extDevice_t *bus, uint8_t reg);
+bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool i2cBusReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+uint8_t i2cBusReadRegister(const extDevice_t *dev, uint8_t reg);

--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -20,6 +20,6 @@
 
 #pragma once
 
-bool i2cBusWriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data);
-bool i2cBusReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t i2cBusReadRegister(const busDevice_t *bus, uint8_t reg);
+bool i2cBusWriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data);
+bool i2cBusReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *data, uint8_t length);
+uint8_t i2cBusReadRegister(const extDevice_t *bus, uint8_t reg);

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -115,7 +115,7 @@ uint32_t spiTimeoutUserCallback(SPI_TypeDef *instance) {
 }
 
 
-FAST_CODE bool spiReadWriteBuf(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length) {
+FAST_CODE bool spiReadWriteBuf(const extDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -157,7 +157,7 @@ void spiResetErrorCounter(SPI_TypeDef *instance) {
     }
 }
 
-FAST_CODE bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data) {
+FAST_CODE bool spiWriteReg(const extDevice_t *bus, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -186,7 +186,7 @@ FAST_CODE bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data) {
     return true;
 }
 
-FAST_CODE bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
+FAST_CODE bool spiReadRegBuf(const extDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -215,7 +215,7 @@ FAST_CODE bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t *data,
     return true;
 }
 
-FAST_CODE uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg) {
+FAST_CODE uint8_t spiReadReg(const extDevice_t *bus, uint8_t reg) {
 #ifdef USE_DMA_SPI_DEVICE
     if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
@@ -247,7 +247,7 @@ FAST_CODE uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg) {
 #endif
 }
 
-void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance) {
+void spiBusSetInstance(extDevice_t *bus, SPI_TypeDef *instance) {
     bus->busType = BUS_TYPE_SPI;
     bus->busType_u.spi.instance = instance;
 }
@@ -275,7 +275,7 @@ uint16_t spiCalculateDivider(uint32_t freq)
 
 // Wait for bus to become free, then read a byte of data where the register is bitwise OR'ed with 0x80
 // EmuFlight codebase is old.  Bitwise or 0x80 is redundant here as spiReadReg already contains such.
-uint8_t spiReadRegMsk(const busDevice_t *bus, uint8_t reg)
+uint8_t spiReadRegMsk(const extDevice_t *bus, uint8_t reg)
 {
     return spiReadReg(bus, reg | 0x80);
 }

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -115,29 +115,29 @@ uint32_t spiTimeoutUserCallback(SPI_TypeDef *instance) {
 }
 
 
-FAST_CODE bool spiReadWriteBuf(const extDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length) {
+FAST_CODE bool spiReadWriteBuf(const extDevice_t *dev, const uint8_t *txData, uint8_t *rxData, int length) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         memcpy(dmaTxBuffer, (uint8_t *)txData, length);
         dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, length, 1);
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busType_u.spi.csnPin);
+                IOHi(dev->busType_u.spi.csnPin);
                 return false;
             }
         }
         memcpy((uint8_t *)rxData, dmaRxBuffer, length);
     } else {
-        IOLo(bus->busType_u.spi.csnPin);
-        spiTransfer(bus->busType_u.spi.instance, txData, rxData, length);
-        IOHi(bus->busType_u.spi.csnPin);
+        IOLo(dev->busType_u.spi.csnPin);
+        spiTransfer(dev->busType_u.spi.instance, txData, rxData, length);
+        IOHi(dev->busType_u.spi.csnPin);
     }
 #else
-    IOLo(bus->busType_u.spi.csnPin);
-    spiTransfer(bus->busType_u.spi.instance, txData, rxData, length);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
+    spiTransfer(dev->busType_u.spi.instance, txData, rxData, length);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
     return true;
 }
@@ -157,9 +157,9 @@ void spiResetErrorCounter(SPI_TypeDef *instance) {
     }
 }
 
-FAST_CODE bool spiWriteReg(const extDevice_t *bus, uint8_t reg, uint8_t data) {
+FAST_CODE bool spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         dmaTxBuffer[0] = reg;
         dmaTxBuffer[1] = data;
@@ -167,89 +167,89 @@ FAST_CODE bool spiWriteReg(const extDevice_t *bus, uint8_t reg, uint8_t data) {
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busType_u.spi.csnPin);
+                IOHi(dev->busType_u.spi.csnPin);
                 return false;
             }
         }
     } else {
-        IOLo(bus->busType_u.spi.csnPin);
-        spiTransferByte(bus->busType_u.spi.instance, reg);
-        spiTransferByte(bus->busType_u.spi.instance, data);
-        IOHi(bus->busType_u.spi.csnPin);
+        IOLo(dev->busType_u.spi.csnPin);
+        spiTransferByte(dev->busType_u.spi.instance, reg);
+        spiTransferByte(dev->busType_u.spi.instance, data);
+        IOHi(dev->busType_u.spi.csnPin);
     }
 #else
-    IOLo(bus->busType_u.spi.csnPin);
-    spiTransferByte(bus->busType_u.spi.instance, reg);
-    spiTransferByte(bus->busType_u.spi.instance, data);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
+    spiTransferByte(dev->busType_u.spi.instance, reg);
+    spiTransferByte(dev->busType_u.spi.instance, data);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
     return true;
 }
 
-FAST_CODE bool spiReadRegBuf(const extDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length) {
+FAST_CODE bool spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         dmaTxBuffer[0] = reg | 0x80;
         dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, length + 1, 1);
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busType_u.spi.csnPin);
+                IOHi(dev->busType_u.spi.csnPin);
                 return false;
             }
         }
         memcpy(data, dmaRxBuffer + 1, length);
     } else {
-        IOLo(bus->busType_u.spi.csnPin);
-        spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
-        spiTransfer(bus->busType_u.spi.instance, NULL, data, length);
-        IOHi(bus->busType_u.spi.csnPin);
+        IOLo(dev->busType_u.spi.csnPin);
+        spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
+        spiTransfer(dev->busType_u.spi.instance, NULL, data, length);
+        IOHi(dev->busType_u.spi.csnPin);
     }
 #else
-    IOLo(bus->busType_u.spi.csnPin);
-    spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(bus->busType_u.spi.instance, NULL, data, length);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
+    spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(dev->busType_u.spi.instance, NULL, data, length);
+    IOHi(dev->busType_u.spi.csnPin);
 #endif
     return true;
 }
 
-FAST_CODE uint8_t spiReadReg(const extDevice_t *bus, uint8_t reg) {
+FAST_CODE uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg) {
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == bus->busType_u.spi.instance) {
+    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
         uint32_t timeoutCheck = millis();
         dmaTxBuffer[0] = reg | 0x80;
         dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, 2, 1);
         while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
             if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
                 //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(bus->busType_u.spi.csnPin);
+                IOHi(dev->busType_u.spi.csnPin);
                 return 0;
             }
         }
         return dmaRxBuffer[1];
     } else {
         uint8_t data;
-        IOLo(bus->busType_u.spi.csnPin);
-        spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
-        spiTransfer(bus->busType_u.spi.instance, NULL, &data, 1);
-        IOHi(bus->busType_u.spi.csnPin);
+        IOLo(dev->busType_u.spi.csnPin);
+        spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
+        spiTransfer(dev->busType_u.spi.instance, NULL, &data, 1);
+        IOHi(dev->busType_u.spi.csnPin);
         return data;
     }
 #else
     uint8_t data;
-    IOLo(bus->busType_u.spi.csnPin);
-    spiTransferByte(bus->busType_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(bus->busType_u.spi.instance, NULL, &data, 1);
-    IOHi(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
+    spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(dev->busType_u.spi.instance, NULL, &data, 1);
+    IOHi(dev->busType_u.spi.csnPin);
     return data;
 #endif
 }
 
-void spiBusSetInstance(extDevice_t *bus, SPI_TypeDef *instance) {
-    bus->busType = BUS_TYPE_SPI;
-    bus->busType_u.spi.instance = instance;
+void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance) {
+    dev->busType = BUS_TYPE_SPI;
+    dev->busType_u.spi.instance = instance;
 }
 
 // icm42688p and bmi270 porting
@@ -275,9 +275,9 @@ uint16_t spiCalculateDivider(uint32_t freq)
 
 // Wait for bus to become free, then read a byte of data where the register is bitwise OR'ed with 0x80
 // EmuFlight codebase is old.  Bitwise or 0x80 is redundant here as spiReadReg already contains such.
-uint8_t spiReadRegMsk(const extDevice_t *bus, uint8_t reg)
+uint8_t spiReadRegMsk(const extDevice_t *dev, uint8_t reg)
 {
-    return spiReadReg(bus, reg | 0x80);
+    return spiReadReg(dev, reg | 0x80);
 }
 
 #endif

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -112,12 +112,12 @@ void spiResetErrorCounter(SPI_TypeDef *instance);
 SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
 SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
-bool spiReadWriteBuf(const busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length);
+bool spiReadWriteBuf(const extDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length);
 
-bool spiWriteReg(const busDevice_t *bus, uint8_t reg, uint8_t data);
-bool spiReadRegBuf(const busDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t spiReadReg(const busDevice_t *bus, uint8_t reg);
-void spiBusSetInstance(busDevice_t *bus, SPI_TypeDef *instance);
+bool spiWriteReg(const extDevice_t *bus, uint8_t reg, uint8_t data);
+bool spiReadRegBuf(const extDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
+uint8_t spiReadReg(const extDevice_t *bus, uint8_t reg);
+void spiBusSetInstance(extDevice_t *bus, SPI_TypeDef *instance);
 
 struct spiPinConfig_s;
 void spiPinConfigure(const struct spiPinConfig_s *pConfig);
@@ -125,4 +125,4 @@ void spiPinConfigure(const struct spiPinConfig_s *pConfig);
 // Determine the divisor to use for a given bus frequency
 uint16_t spiCalculateDivider(uint32_t freq);
 
-uint8_t spiReadRegMsk(const busDevice_t *bus, uint8_t reg);
+uint8_t spiReadRegMsk(const extDevice_t *bus, uint8_t reg);

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -112,12 +112,12 @@ void spiResetErrorCounter(SPI_TypeDef *instance);
 SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
 SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
-bool spiReadWriteBuf(const extDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int length);
+bool spiReadWriteBuf(const extDevice_t *dev, const uint8_t *txData, uint8_t *rxData, int length);
 
-bool spiWriteReg(const extDevice_t *bus, uint8_t reg, uint8_t data);
-bool spiReadRegBuf(const extDevice_t *bus, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t spiReadReg(const extDevice_t *bus, uint8_t reg);
-void spiBusSetInstance(extDevice_t *bus, SPI_TypeDef *instance);
+bool spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg);
+void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance);
 
 struct spiPinConfig_s;
 void spiPinConfigure(const struct spiPinConfig_s *pConfig);
@@ -125,4 +125,4 @@ void spiPinConfigure(const struct spiPinConfig_s *pConfig);
 // Determine the divisor to use for a given bus frequency
 uint16_t spiCalculateDivider(uint32_t freq);
 
-uint8_t spiReadRegMsk(const extDevice_t *bus, uint8_t reg);
+uint8_t spiReadRegMsk(const extDevice_t *dev, uint8_t reg);

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -100,30 +100,30 @@
 
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
 
-static bool ak8963SpiWriteRegisterDelay(const extDevice_t *bus, uint8_t reg, uint8_t data) {
-    spiWriteReg(bus, reg, data);
+static bool ak8963SpiWriteRegisterDelay(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    spiWriteReg(dev, reg, data);
     delayMicroseconds(10);
     return true;
 }
 
 static bool ak8963SlaveReadRegisterBuffer(const extDevice_t *slavedev, uint8_t reg, uint8_t *buf, uint8_t len) {
-    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG); // set I2C slave address for read
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);     // read number of bytes
+    const extDevice_t *dev = slavedev->busType_u.mpuSlave.master;
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG); // set I2C slave address for read
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);     // read number of bytes
     delay(4);
     __disable_irq();
-    bool ack = spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, buf, len);            // read I2C
+    bool ack = spiReadRegBuf(dev, MPU_RA_EXT_SENS_DATA_00, buf, len);            // read I2C
     __enable_irq();
     return ack;
 }
 
 static bool ak8963SlaveWriteRegister(const extDevice_t *slavedev, uint8_t reg, uint8_t data) {
-    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address); // set I2C slave address for write
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_DO, data);                             // set I2C sLave value
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (1 & 0x0F) | I2C_SLV0_EN);       // write 1 byte
+    const extDevice_t *dev = slavedev->busType_u.mpuSlave.master;
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address); // set I2C slave address for write
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_DO, data);                             // set I2C sLave value
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_CTRL, (1 & 0x0F) | I2C_SLV0_EN);       // write 1 byte
     return true;
 }
 
@@ -139,11 +139,11 @@ static bool ak8963SlaveStartRead(const extDevice_t *slavedev, uint8_t reg, uint8
     if (queuedRead.waiting) {
         return false;
     }
-    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+    const extDevice_t *dev = slavedev->busType_u.mpuSlave.master;
     queuedRead.len = len;
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG);  // set I2C slave address for read
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
-    ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);    // read number of bytes
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG);  // set I2C slave address for read
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
+    ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);    // read number of bytes
     queuedRead.readStartedAt = micros();
     queuedRead.waiting = true;
     return true;
@@ -163,16 +163,16 @@ static uint32_t ak8963SlaveQueuedReadTimeRemaining(void) {
 
 static bool ak8963SlaveCompleteRead(const extDevice_t *slavedev, uint8_t *buf) {
     uint32_t timeRemaining = ak8963SlaveQueuedReadTimeRemaining();
-    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+    const extDevice_t *dev = slavedev->busType_u.mpuSlave.master;
     if (timeRemaining > 0) {
         delayMicroseconds(timeRemaining);
     }
     queuedRead.waiting = false;
-    spiReadRegBuf(bus, MPU_RA_EXT_SENS_DATA_00, buf, queuedRead.len);            // read I2C buffer
+    spiReadRegBuf(dev, MPU_RA_EXT_SENS_DATA_00, buf, queuedRead.len);            // read I2C buffer
     return true;
 }
 
-static bool ak8963SlaveReadData(const extDevice_t *busdev, uint8_t *buf) {
+static bool ak8963SlaveReadData(const extDevice_t *dev, uint8_t *buf) {
     typedef enum {
         CHECK_STATUS = 0,
         WAITING_FOR_STATUS,
@@ -186,7 +186,7 @@ static bool ak8963SlaveReadData(const extDevice_t *busdev, uint8_t *buf) {
 restart:
     switch (state) {
     case CHECK_STATUS: {
-        ak8963SlaveStartRead(busdev, AK8963_MAG_REG_ST1, 1);
+        ak8963SlaveStartRead(dev, AK8963_MAG_REG_ST1, 1);
         state = WAITING_FOR_STATUS;
         return false;
     }
@@ -195,7 +195,7 @@ restart:
         if (timeRemaining) {
             return false;
         }
-        ack = ak8963SlaveCompleteRead(busdev, &buf[0]);
+        ack = ak8963SlaveCompleteRead(dev, &buf[0]);
         uint8_t status = buf[0];
         if (!ack || (status & ST1_DATA_READY) == 0) {
             // too early. queue the status read again
@@ -207,7 +207,7 @@ restart:
             return false;
         }
         // read the 6 bytes of data and the status2 register
-        ak8963SlaveStartRead(busdev, AK8963_MAG_REG_HXL, 7);
+        ak8963SlaveStartRead(dev, AK8963_MAG_REG_HXL, 7);
         state = WAITING_FOR_DATA;
         return false;
     }
@@ -216,7 +216,7 @@ restart:
         if (timeRemaining) {
             return false;
         }
-        ack = ak8963SlaveCompleteRead(busdev, &buf[0]);
+        ack = ak8963SlaveCompleteRead(dev, &buf[0]);
         state = CHECK_STATUS;
     }
     }
@@ -224,31 +224,31 @@ restart:
 }
 #endif
 
-static bool ak8963ReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *buf, uint8_t len) {
+static bool ak8963ReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *buf, uint8_t len) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (busdev->busType == BUS_TYPE_MPU_SLAVE) {
-        return ak8963SlaveReadRegisterBuffer(busdev, reg, buf, len);
+    if (dev->busType == BUS_TYPE_MPU_SLAVE) {
+        return ak8963SlaveReadRegisterBuffer(dev, reg, buf, len);
     }
 #endif
-    return busReadRegisterBuffer(busdev, reg, buf, len);
+    return busReadRegisterBuffer(dev, reg, buf, len);
 }
 
-static bool ak8963WriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
+static bool ak8963WriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (busdev->busType == BUS_TYPE_MPU_SLAVE) {
-        return ak8963SlaveWriteRegister(busdev, reg, data);
+    if (dev->busType == BUS_TYPE_MPU_SLAVE) {
+        return ak8963SlaveWriteRegister(dev, reg, data);
     }
 #endif
-    return busWriteRegister(busdev, reg, data);
+    return busWriteRegister(dev, reg, data);
 }
 
-static bool ak8963DirectReadData(const extDevice_t *busdev, uint8_t *buf) {
+static bool ak8963DirectReadData(const extDevice_t *dev, uint8_t *buf) {
     uint8_t status;
-    bool ack = ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ST1, &status, 1);
+    bool ack = ak8963ReadRegisterBuffer(dev, AK8963_MAG_REG_ST1, &status, 1);
     if (!ack || (status & ST1_DATA_READY) == 0) {
         return false;
     }
-    return ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_HXL, buf, 7);
+    return ak8963ReadRegisterBuffer(dev, AK8963_MAG_REG_HXL, buf, 7);
 }
 
 static int16_t parseMag(uint8_t *raw, int16_t gain) {
@@ -259,17 +259,17 @@ static int16_t parseMag(uint8_t *raw, int16_t gain) {
 static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     bool ack = false;
     uint8_t buf[7];
-    const extDevice_t *busdev = &mag->dev;
-    switch (busdev->busType) {
+    const extDevice_t *dev = &mag->dev;
+    switch (dev->busType) {
 #if defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_AK8963)
     case BUS_TYPE_I2C:
     case BUS_TYPE_SPI:
-        ack = ak8963DirectReadData(busdev, buf);
+        ack = ak8963DirectReadData(dev, buf);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
-        ack = ak8963SlaveReadData(busdev, buf);
+        ack = ak8963SlaveReadData(dev, buf);
         break;
 #endif
     default:
@@ -279,7 +279,7 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     if (!ack) {
         return false;
     }
-    ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_BIT_16_BIT | CNTL1_MODE_ONCE); // start reading again    uint8_t status2 = buf[6];
+    ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL1, CNTL1_BIT_16_BIT | CNTL1_MODE_ONCE); // start reading again    uint8_t status2 = buf[6];
     if (status2 & ST2_MAG_SENSOR_OVERFLOW) {
         return false;
     }
@@ -292,44 +292,44 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
 static bool ak8963Init(magDev_t *mag) {
     uint8_t asa[3];
     uint8_t status;
-    const extDevice_t *busdev = &mag->dev;
-    ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down before entering fuse mode
-    ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_FUSE_ROM);                 // Enter Fuse ROM access mode
-    ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ASAX, asa, sizeof(asa));                // Read the x-, y-, and z-axis calibration values
+    const extDevice_t *dev = &mag->dev;
+    ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down before entering fuse mode
+    ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_FUSE_ROM);                 // Enter Fuse ROM access mode
+    ak8963ReadRegisterBuffer(dev, AK8963_MAG_REG_ASAX, asa, sizeof(asa));                // Read the x-, y-, and z-axis calibration values
     mag->magGain[X] = asa[X] + 128;
     mag->magGain[Y] = asa[Y] + 128;
     mag->magGain[Z] = asa[Z] + 128;
-    ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down after reading.
+    ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down after reading.
     // Clear status registers
-    ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ST1, &status, 1);
-    ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ST2, &status, 1);
+    ak8963ReadRegisterBuffer(dev, AK8963_MAG_REG_ST1, &status, 1);
+    ak8963ReadRegisterBuffer(dev, AK8963_MAG_REG_ST2, &status, 1);
     // Trigger first measurement
-    ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_BIT_16_BIT | CNTL1_MODE_ONCE);
+    ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL1, CNTL1_BIT_16_BIT | CNTL1_MODE_ONCE);
     return true;
 }
 
-void ak8963BusInit(const extDevice_t *busdev) {
-    switch (busdev->busType) {
+void ak8963BusInit(const extDevice_t *dev) {
+    switch (dev->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
-        UNUSED(busdev);
+        UNUSED(dev);
         break;
 #endif
 #ifdef USE_MAG_SPI_AK8963
     case BUS_TYPE_SPI:
-        IOHi(busdev->busType_u.spi.csnPin);                                                  // Disable
-        IOInit(busdev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
-        IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+        IOHi(dev->busType_u.spi.csnPin);                                                  // Disable
+        IOInit(dev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
+        IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
         rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
         // initialze I2C master via SPI bus
-        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
-        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz
-        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_USER_CTRL, 0x30);   // I2C master mode, SPI mode only
+        ak8963SpiWriteRegisterDelay(dev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
+        ak8963SpiWriteRegisterDelay(dev->busType_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz
+        ak8963SpiWriteRegisterDelay(dev->busType_u.mpuSlave.master, MPU_RA_USER_CTRL, 0x30);   // I2C master mode, SPI mode only
         break;
 #endif
     default:
@@ -337,21 +337,21 @@ void ak8963BusInit(const extDevice_t *busdev) {
     }
 }
 
-void ak8963BusDeInit(const extDevice_t *busdev) {
-    switch (busdev->busType) {
+void ak8963BusDeInit(const extDevice_t *dev) {
+    switch (dev->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
-        UNUSED(busdev);
+        UNUSED(dev);
         break;
 #endif
 #ifdef USE_MAG_SPI_AK8963
     case BUS_TYPE_SPI:
-        spiPreinitCsByIO(busdev->busType_u.spi.csnPin);
+        spiPreinitCsByIO(dev->busType_u.spi.csnPin);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
-        ak8963SpiWriteRegisterDelay(busdev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);
+        ak8963SpiWriteRegisterDelay(dev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR);
         break;
 #endif
     default:
@@ -361,20 +361,20 @@ void ak8963BusDeInit(const extDevice_t *busdev) {
 
 bool ak8963Detect(magDev_t *mag) {
     uint8_t sig = 0;
-    extDevice_t *busdev = &mag->dev;
-    if ((busdev->busType == BUS_TYPE_I2C || busdev->busType == BUS_TYPE_MPU_SLAVE) && busdev->busType_u.mpuSlave.address == 0) {
-        busdev->busType_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
+    extDevice_t *dev = &mag->dev;
+    if ((dev->busType == BUS_TYPE_I2C || dev->busType == BUS_TYPE_MPU_SLAVE) && dev->busType_u.mpuSlave.address == 0) {
+        dev->busType_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
     }
-    ak8963BusInit(busdev);
-    ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL2, CNTL2_SOFT_RESET);                    // reset MAG
+    ak8963BusInit(dev);
+    ak8963WriteRegister(dev, AK8963_MAG_REG_CNTL2, CNTL2_SOFT_RESET);                    // reset MAG
     delay(4);
-    bool ack = ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_WIA, &sig, 1);               // check for AK8963
+    bool ack = ak8963ReadRegisterBuffer(dev, AK8963_MAG_REG_WIA, &sig, 1);               // check for AK8963
     if (ack && sig == AK8963_DEVICE_ID) { // 0x48 / 01001000 / 'H'
         mag->init = ak8963Init;
         mag->read = ak8963Read;
         return true;
     }
-    ak8963BusDeInit(busdev);
+    ak8963BusDeInit(dev);
     return false;
 }
 #endif

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -100,14 +100,14 @@
 
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
 
-static bool ak8963SpiWriteRegisterDelay(const busDevice_t *bus, uint8_t reg, uint8_t data) {
+static bool ak8963SpiWriteRegisterDelay(const extDevice_t *bus, uint8_t reg, uint8_t data) {
     spiWriteReg(bus, reg, data);
     delayMicroseconds(10);
     return true;
 }
 
-static bool ak8963SlaveReadRegisterBuffer(const busDevice_t *slavedev, uint8_t reg, uint8_t *buf, uint8_t len) {
-    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+static bool ak8963SlaveReadRegisterBuffer(const extDevice_t *slavedev, uint8_t reg, uint8_t *buf, uint8_t len) {
+    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG); // set I2C slave address for read
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);     // read number of bytes
@@ -118,8 +118,8 @@ static bool ak8963SlaveReadRegisterBuffer(const busDevice_t *slavedev, uint8_t r
     return ack;
 }
 
-static bool ak8963SlaveWriteRegister(const busDevice_t *slavedev, uint8_t reg, uint8_t data) {
-    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+static bool ak8963SlaveWriteRegister(const extDevice_t *slavedev, uint8_t reg, uint8_t data) {
+    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address); // set I2C slave address for write
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_DO, data);                             // set I2C sLave value
@@ -135,11 +135,11 @@ typedef struct queuedReadState_s {
 
 static queuedReadState_t queuedRead = { false, 0, 0};
 
-static bool ak8963SlaveStartRead(const busDevice_t *slavedev, uint8_t reg, uint8_t len) {
+static bool ak8963SlaveStartRead(const extDevice_t *slavedev, uint8_t reg, uint8_t len) {
     if (queuedRead.waiting) {
         return false;
     }
-    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
     queuedRead.len = len;
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_ADDR, slavedev->busType_u.mpuSlave.address | READ_FLAG);  // set I2C slave address for read
     ak8963SpiWriteRegisterDelay(bus, MPU_RA_I2C_SLV0_REG, reg);                             // set I2C slave register
@@ -161,9 +161,9 @@ static uint32_t ak8963SlaveQueuedReadTimeRemaining(void) {
     return timeRemaining;
 }
 
-static bool ak8963SlaveCompleteRead(const busDevice_t *slavedev, uint8_t *buf) {
+static bool ak8963SlaveCompleteRead(const extDevice_t *slavedev, uint8_t *buf) {
     uint32_t timeRemaining = ak8963SlaveQueuedReadTimeRemaining();
-    const busDevice_t *bus = slavedev->busType_u.mpuSlave.master;
+    const extDevice_t *bus = slavedev->busType_u.mpuSlave.master;
     if (timeRemaining > 0) {
         delayMicroseconds(timeRemaining);
     }
@@ -172,7 +172,7 @@ static bool ak8963SlaveCompleteRead(const busDevice_t *slavedev, uint8_t *buf) {
     return true;
 }
 
-static bool ak8963SlaveReadData(const busDevice_t *busdev, uint8_t *buf) {
+static bool ak8963SlaveReadData(const extDevice_t *busdev, uint8_t *buf) {
     typedef enum {
         CHECK_STATUS = 0,
         WAITING_FOR_STATUS,
@@ -224,7 +224,7 @@ restart:
 }
 #endif
 
-static bool ak8963ReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uint8_t *buf, uint8_t len) {
+static bool ak8963ReadRegisterBuffer(const extDevice_t *busdev, uint8_t reg, uint8_t *buf, uint8_t len) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     if (busdev->busType == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveReadRegisterBuffer(busdev, reg, buf, len);
@@ -233,7 +233,7 @@ static bool ak8963ReadRegisterBuffer(const busDevice_t *busdev, uint8_t reg, uin
     return busReadRegisterBuffer(busdev, reg, buf, len);
 }
 
-static bool ak8963WriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t data) {
+static bool ak8963WriteRegister(const extDevice_t *busdev, uint8_t reg, uint8_t data) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     if (busdev->busType == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveWriteRegister(busdev, reg, data);
@@ -242,7 +242,7 @@ static bool ak8963WriteRegister(const busDevice_t *busdev, uint8_t reg, uint8_t 
     return busWriteRegister(busdev, reg, data);
 }
 
-static bool ak8963DirectReadData(const busDevice_t *busdev, uint8_t *buf) {
+static bool ak8963DirectReadData(const extDevice_t *busdev, uint8_t *buf) {
     uint8_t status;
     bool ack = ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ST1, &status, 1);
     if (!ack || (status & ST1_DATA_READY) == 0) {
@@ -259,7 +259,7 @@ static int16_t parseMag(uint8_t *raw, int16_t gain) {
 static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     bool ack = false;
     uint8_t buf[7];
-    const busDevice_t *busdev = &mag->dev;
+    const extDevice_t *busdev = &mag->dev;
     switch (busdev->busType) {
 #if defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_AK8963)
     case BUS_TYPE_I2C:
@@ -292,7 +292,7 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
 static bool ak8963Init(magDev_t *mag) {
     uint8_t asa[3];
     uint8_t status;
-    const busDevice_t *busdev = &mag->dev;
+    const extDevice_t *busdev = &mag->dev;
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_POWER_DOWN);               // power down before entering fuse mode
     ak8963WriteRegister(busdev, AK8963_MAG_REG_CNTL1, CNTL1_MODE_FUSE_ROM);                 // Enter Fuse ROM access mode
     ak8963ReadRegisterBuffer(busdev, AK8963_MAG_REG_ASAX, asa, sizeof(asa));                // Read the x-, y-, and z-axis calibration values
@@ -308,7 +308,7 @@ static bool ak8963Init(magDev_t *mag) {
     return true;
 }
 
-void ak8963BusInit(const busDevice_t *busdev) {
+void ak8963BusInit(const extDevice_t *busdev) {
     switch (busdev->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
@@ -337,7 +337,7 @@ void ak8963BusInit(const busDevice_t *busdev) {
     }
 }
 
-void ak8963BusDeInit(const busDevice_t *busdev) {
+void ak8963BusDeInit(const extDevice_t *busdev) {
     switch (busdev->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
@@ -361,7 +361,7 @@ void ak8963BusDeInit(const busDevice_t *busdev) {
 
 bool ak8963Detect(magDev_t *mag) {
     uint8_t sig = 0;
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     if ((busdev->busType == BUS_TYPE_I2C || busdev->busType == BUS_TYPE_MPU_SLAVE) && busdev->busType_u.mpuSlave.address == 0) {
         busdev->busType_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
     }

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -80,7 +80,7 @@
 static bool ak8975Init(magDev_t *mag) {
     uint8_t asa[3];
     uint8_t status;
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down before entering fuse mode
     delay(20);
     busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_FUSE_ROM); // Enter Fuse ROM access mode
@@ -109,7 +109,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
     bool ack;
     uint8_t status;
     uint8_t buf[6];
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST1, &status, 1);
     if (!ack || (status & ST1_REG_DATA_READY) == 0) {
         return false;
@@ -134,7 +134,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
 
 bool ak8975Detect(magDev_t *mag) {
     uint8_t sig = 0;
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
         busdev->busType_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
     }

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -80,23 +80,23 @@
 static bool ak8975Init(magDev_t *mag) {
     uint8_t asa[3];
     uint8_t status;
-    extDevice_t *busdev = &mag->dev;
-    busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down before entering fuse mode
+    extDevice_t *dev = &mag->dev;
+    busWriteRegister(dev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down before entering fuse mode
     delay(20);
-    busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_FUSE_ROM); // Enter Fuse ROM access mode
+    busWriteRegister(dev, AK8975_MAG_REG_CNTL, CNTL_MODE_FUSE_ROM); // Enter Fuse ROM access mode
     delay(10);
-    busReadRegisterBuffer(busdev, AK8975_MAG_REG_ASAX, asa, sizeof(asa)); // Read the x-, y-, and z-axis asa values
+    busReadRegisterBuffer(dev, AK8975_MAG_REG_ASAX, asa, sizeof(asa)); // Read the x-, y-, and z-axis asa values
     delay(10);
     mag->magGain[X] = asa[X] + 128;
     mag->magGain[Y] = asa[Y] + 128;
     mag->magGain[Z] = asa[Z] + 128;
-    busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down after reading.
+    busWriteRegister(dev, AK8975_MAG_REG_CNTL, CNTL_MODE_POWER_DOWN); // power down after reading.
     delay(10);
     // Clear status registers
-    busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST1, &status, 1);
-    busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST2, &status, 1);
+    busReadRegisterBuffer(dev, AK8975_MAG_REG_ST1, &status, 1);
+    busReadRegisterBuffer(dev, AK8975_MAG_REG_ST2, &status, 1);
     // Trigger first measurement
-    busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_BIT_16_BIT | CNTL_MODE_ONCE);
+    busWriteRegister(dev, AK8975_MAG_REG_CNTL, CNTL_BIT_16_BIT | CNTL_MODE_ONCE);
     return true;
 }
 
@@ -109,17 +109,17 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
     bool ack;
     uint8_t status;
     uint8_t buf[6];
-    extDevice_t *busdev = &mag->dev;
-    ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST1, &status, 1);
+    extDevice_t *dev = &mag->dev;
+    ack = busReadRegisterBuffer(dev, AK8975_MAG_REG_ST1, &status, 1);
     if (!ack || (status & ST1_REG_DATA_READY) == 0) {
         return false;
     }
-    busReadRegisterBuffer(busdev, AK8975_MAG_REG_HXL, buf, 6); // read from AK8975_MAG_REG_HXL to AK8975_MAG_REG_HZH
-    ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_ST2, &status, 1);
+    busReadRegisterBuffer(dev, AK8975_MAG_REG_HXL, buf, 6); // read from AK8975_MAG_REG_HXL to AK8975_MAG_REG_HZH
+    ack = busReadRegisterBuffer(dev, AK8975_MAG_REG_ST2, &status, 1);
     if (!ack) {
         return false;
     }
-    busWriteRegister(busdev, AK8975_MAG_REG_CNTL, CNTL_BIT_16_BIT | CNTL_MODE_ONCE); // start reading again    uint8_t status2 = buf[6];
+    busWriteRegister(dev, AK8975_MAG_REG_CNTL, CNTL_BIT_16_BIT | CNTL_MODE_ONCE); // start reading again    uint8_t status2 = buf[6];
     if (status & ST2_REG_DATA_ERROR) {
         return false;
     }
@@ -134,11 +134,11 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
 
 bool ak8975Detect(magDev_t *mag) {
     uint8_t sig = 0;
-    extDevice_t *busdev = &mag->dev;
-    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
-        busdev->busType_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
+    extDevice_t *dev = &mag->dev;
+    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+        dev->busType_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
     }
-    bool ack = busReadRegisterBuffer(busdev, AK8975_MAG_REG_WIA, &sig, 1);
+    bool ack = busReadRegisterBuffer(dev, AK8975_MAG_REG_WIA, &sig, 1);
     if (!ack || sig != AK8975_DEVICE_ID) // 0x48 / 01001000 / 'H'
         return false;
     mag->init = ak8975Init;

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -182,7 +182,7 @@ static void hmc5883lConfigureDataReadyInterruptHandling(magDev_t* mag) {
 }
 
 #ifdef USE_MAG_SPI_HMC5883
-static void hmc5883SpiInit(busDevice_t *busdev) {
+static void hmc5883SpiInit(extDevice_t *busdev) {
     IOHi(busdev->busType_u.spi.csnPin); // Disable
     IOInit(busdev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
     IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
@@ -192,7 +192,7 @@ static void hmc5883SpiInit(busDevice_t *busdev) {
 
 static bool hmc5883lRead(magDev_t *mag, int16_t *magData) {
     uint8_t buf[6];
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     bool ack = busReadRegisterBuffer(busdev, HMC58X3_REG_DATA, buf, 6);
     if (!ack) {
         return false;
@@ -204,7 +204,7 @@ static bool hmc5883lRead(magDev_t *mag, int16_t *magData) {
 }
 
 static bool hmc5883lInit(magDev_t *mag) {
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     // leave test mode
     busWriteRegister(busdev, HMC58X3_REG_CONFA, HMC_CONFA_8_SAMLES | HMC_CONFA_DOR_15HZ | HMC_CONFA_NORMAL);    // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode
     busWriteRegister(busdev, HMC58X3_REG_CONFB, HMC_CONFB_GAIN_1_3GA);                                          // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
@@ -215,7 +215,7 @@ static bool hmc5883lInit(magDev_t *mag) {
 }
 
 bool hmc5883lDetect(magDev_t* mag) {
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     uint8_t sig = 0;
 #ifdef USE_MAG_SPI_HMC5883
     if (busdev->busType == BUS_TYPE_SPI) {

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -182,18 +182,18 @@ static void hmc5883lConfigureDataReadyInterruptHandling(magDev_t* mag) {
 }
 
 #ifdef USE_MAG_SPI_HMC5883
-static void hmc5883SpiInit(extDevice_t *busdev) {
-    IOHi(busdev->busType_u.spi.csnPin); // Disable
-    IOInit(busdev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
-    IOConfigGPIO(busdev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+static void hmc5883SpiInit(extDevice_t *dev) {
+    IOHi(dev->busType_u.spi.csnPin); // Disable
+    IOInit(dev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 #endif
 
 static bool hmc5883lRead(magDev_t *mag, int16_t *magData) {
     uint8_t buf[6];
-    extDevice_t *busdev = &mag->dev;
-    bool ack = busReadRegisterBuffer(busdev, HMC58X3_REG_DATA, buf, 6);
+    extDevice_t *dev = &mag->dev;
+    bool ack = busReadRegisterBuffer(dev, HMC58X3_REG_DATA, buf, 6);
     if (!ack) {
         return false;
     }
@@ -204,27 +204,27 @@ static bool hmc5883lRead(magDev_t *mag, int16_t *magData) {
 }
 
 static bool hmc5883lInit(magDev_t *mag) {
-    extDevice_t *busdev = &mag->dev;
+    extDevice_t *dev = &mag->dev;
     // leave test mode
-    busWriteRegister(busdev, HMC58X3_REG_CONFA, HMC_CONFA_8_SAMLES | HMC_CONFA_DOR_15HZ | HMC_CONFA_NORMAL);    // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode
-    busWriteRegister(busdev, HMC58X3_REG_CONFB, HMC_CONFB_GAIN_1_3GA);                                          // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
-    busWriteRegister(busdev, HMC58X3_REG_MODE, HMC_MODE_CONTINOUS);                                             // Mode register             -- 000000 00    continuous Conversion Mode
+    busWriteRegister(dev, HMC58X3_REG_CONFA, HMC_CONFA_8_SAMLES | HMC_CONFA_DOR_15HZ | HMC_CONFA_NORMAL);    // Configuration Register A  -- 0 11 100 00  num samples: 8 ; output rate: 15Hz ; normal measurement mode
+    busWriteRegister(dev, HMC58X3_REG_CONFB, HMC_CONFB_GAIN_1_3GA);                                          // Configuration Register B  -- 001 00000    configuration gain 1.3Ga
+    busWriteRegister(dev, HMC58X3_REG_MODE, HMC_MODE_CONTINOUS);                                             // Mode register             -- 000000 00    continuous Conversion Mode
     delay(100);
     hmc5883lConfigureDataReadyInterruptHandling(mag);
     return true;
 }
 
 bool hmc5883lDetect(magDev_t* mag) {
-    extDevice_t *busdev = &mag->dev;
+    extDevice_t *dev = &mag->dev;
     uint8_t sig = 0;
 #ifdef USE_MAG_SPI_HMC5883
-    if (busdev->busType == BUS_TYPE_SPI) {
+    if (dev->busType == BUS_TYPE_SPI) {
         hmc5883SpiInit(&mag->dev);
     }
 #endif
 #ifdef USE_MAG_HMC5883
-    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
-        busdev->busType_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
+    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+        dev->busType_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
     }
 #endif
     bool ack = busReadRegisterBuffer(&mag->dev, HMC58X3_REG_IDA, &sig, 1);

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -103,7 +103,7 @@
 
 static bool lis3mdlRead(magDev_t * mag, int16_t *magData) {
     uint8_t buf[6];
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     bool ack = busReadRegisterBuffer(busdev, LIS3MDL_REG_OUT_X_L, buf, 6);
     if (!ack) {
         return false;
@@ -115,7 +115,7 @@ static bool lis3mdlRead(magDev_t * mag, int16_t *magData) {
 }
 
 static bool lis3mdlInit(magDev_t *mag) {
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG2, LIS3MDL_FS_4GAUSS);
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG1, LIS3MDL_TEMP_EN | LIS3MDL_OM_ULTRA_HI_PROF | LIS3MDL_DO_80);
     busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG5, LIS3MDL_BDU);
@@ -126,7 +126,7 @@ static bool lis3mdlInit(magDev_t *mag) {
 }
 
 bool lis3mdlDetect(magDev_t * mag) {
-    busDevice_t *busdev = &mag->dev;
+    extDevice_t *busdev = &mag->dev;
     uint8_t sig = 0;
     if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
         busdev->busType_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -103,8 +103,8 @@
 
 static bool lis3mdlRead(magDev_t * mag, int16_t *magData) {
     uint8_t buf[6];
-    extDevice_t *busdev = &mag->dev;
-    bool ack = busReadRegisterBuffer(busdev, LIS3MDL_REG_OUT_X_L, buf, 6);
+    extDevice_t *dev = &mag->dev;
+    bool ack = busReadRegisterBuffer(dev, LIS3MDL_REG_OUT_X_L, buf, 6);
     if (!ack) {
         return false;
     }
@@ -115,21 +115,21 @@ static bool lis3mdlRead(magDev_t * mag, int16_t *magData) {
 }
 
 static bool lis3mdlInit(magDev_t *mag) {
-    extDevice_t *busdev = &mag->dev;
-    busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG2, LIS3MDL_FS_4GAUSS);
-    busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG1, LIS3MDL_TEMP_EN | LIS3MDL_OM_ULTRA_HI_PROF | LIS3MDL_DO_80);
-    busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG5, LIS3MDL_BDU);
-    busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG4, LIS3MDL_ZOM_UHP);
-    busWriteRegister(busdev, LIS3MDL_REG_CTRL_REG3, 0x00);
+    extDevice_t *dev = &mag->dev;
+    busWriteRegister(dev, LIS3MDL_REG_CTRL_REG2, LIS3MDL_FS_4GAUSS);
+    busWriteRegister(dev, LIS3MDL_REG_CTRL_REG1, LIS3MDL_TEMP_EN | LIS3MDL_OM_ULTRA_HI_PROF | LIS3MDL_DO_80);
+    busWriteRegister(dev, LIS3MDL_REG_CTRL_REG5, LIS3MDL_BDU);
+    busWriteRegister(dev, LIS3MDL_REG_CTRL_REG4, LIS3MDL_ZOM_UHP);
+    busWriteRegister(dev, LIS3MDL_REG_CTRL_REG3, 0x00);
     delay(100);
     return true;
 }
 
 bool lis3mdlDetect(magDev_t * mag) {
-    extDevice_t *busdev = &mag->dev;
+    extDevice_t *dev = &mag->dev;
     uint8_t sig = 0;
-    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
-        busdev->busType_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
+    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+        dev->busType_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(&mag->dev, LIS3MDL_REG_WHO_AM_I, &sig, 1);
     if (!ack || sig != LIS3MDL_DEVICE_ID) {

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -75,7 +75,7 @@
 static bool qmc5883lInit(magDev_t *magDev) {
     UNUSED(magDev);
     bool ack = true;
-    busDevice_t *busdev = &magDev->dev;
+    extDevice_t *busdev = &magDev->dev;
     ack = ack && busWriteRegister(busdev, 0x0B, 0x01);
     ack = ack && busWriteRegister(busdev, QMC5883L_REG_CONF1, QMC5883L_MODE_CONTINUOUS | QMC5883L_ODR_200HZ | QMC5883L_OSR_512 | QMC5883L_RNG_8G);
     if (!ack) {
@@ -91,7 +91,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
     magData[X] = 0;
     magData[Y] = 0;
     magData[Z] = 0;
-    busDevice_t *busdev = &magDev->dev;
+    extDevice_t *busdev = &magDev->dev;
     bool ack = busReadRegisterBuffer(busdev, QMC5883L_REG_STATUS, &status, 1);
     if (!ack || (status & 0x04) == 0) {
         return false;
@@ -107,7 +107,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
 }
 
 bool qmc5883lDetect(magDev_t *magDev) {
-    busDevice_t *busdev = &magDev->dev;
+    extDevice_t *busdev = &magDev->dev;
     if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
         busdev->busType_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
     }

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -75,9 +75,9 @@
 static bool qmc5883lInit(magDev_t *magDev) {
     UNUSED(magDev);
     bool ack = true;
-    extDevice_t *busdev = &magDev->dev;
-    ack = ack && busWriteRegister(busdev, 0x0B, 0x01);
-    ack = ack && busWriteRegister(busdev, QMC5883L_REG_CONF1, QMC5883L_MODE_CONTINUOUS | QMC5883L_ODR_200HZ | QMC5883L_OSR_512 | QMC5883L_RNG_8G);
+    extDevice_t *dev = &magDev->dev;
+    ack = ack && busWriteRegister(dev, 0x0B, 0x01);
+    ack = ack && busWriteRegister(dev, QMC5883L_REG_CONF1, QMC5883L_MODE_CONTINUOUS | QMC5883L_ODR_200HZ | QMC5883L_OSR_512 | QMC5883L_RNG_8G);
     if (!ack) {
         return false;
     }
@@ -91,12 +91,12 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
     magData[X] = 0;
     magData[Y] = 0;
     magData[Z] = 0;
-    extDevice_t *busdev = &magDev->dev;
-    bool ack = busReadRegisterBuffer(busdev, QMC5883L_REG_STATUS, &status, 1);
+    extDevice_t *dev = &magDev->dev;
+    bool ack = busReadRegisterBuffer(dev, QMC5883L_REG_STATUS, &status, 1);
     if (!ack || (status & 0x04) == 0) {
         return false;
     }
-    ack = busReadRegisterBuffer(busdev, QMC5883L_REG_DATA_OUTPUT_X, buf, 6);
+    ack = busReadRegisterBuffer(dev, QMC5883L_REG_DATA_OUTPUT_X, buf, 6);
     if (!ack) {
         return false;
     }
@@ -107,19 +107,19 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
 }
 
 bool qmc5883lDetect(magDev_t *magDev) {
-    extDevice_t *busdev = &magDev->dev;
-    if (busdev->busType == BUS_TYPE_I2C && busdev->busType_u.i2c.address == 0) {
-        busdev->busType_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
+    extDevice_t *dev = &magDev->dev;
+    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+        dev->busType_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
     }
     // Must write reset first  - don't care about the result
-    busWriteRegister(busdev, QMC5883L_REG_CONF2, QMC5883L_RST);
+    busWriteRegister(dev, QMC5883L_REG_CONF2, QMC5883L_RST);
     delay(20);
     uint8_t sig = 0;
-    bool ack = busReadRegisterBuffer(busdev, QMC5883L_REG_ID, &sig, 1);
+    bool ack = busReadRegisterBuffer(dev, QMC5883L_REG_ID, &sig, 1);
     if (ack && sig == QMC5883_ID_VAL) {
         // Should be in standby mode after soft reset and sensor is really present
         // Reading ChipID of 0xFF alone is not sufficient to be sure the QMC is present
-        ack = busReadRegisterBuffer(busdev, QMC5883L_REG_CONF1, &sig, 1);
+        ack = busReadRegisterBuffer(dev, QMC5883L_REG_CONF1, &sig, 1);
         if (ack && sig != QMC5883L_MODE_STANDBY) {
             return false;
         }

--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -173,81 +173,81 @@ static const uint8_t multiWiiFont[][5] = { // Refer to "Times New Roman" Font Da
     { 0x7A, 0x7E, 0x7E, 0x7E, 0x7A }, //   (131)    - 0x00C8 Vertical Bargraph - 6 (full)
 };
 
-static bool i2c_OLED_send_cmd(extDevice_t *bus, uint8_t command) {
-    return i2cWrite(bus->busType_u.i2c.device, bus->busType_u.i2c.address, 0x80, command);
+static bool i2c_OLED_send_cmd(extDevice_t *dev, uint8_t command) {
+    return i2cWrite(dev->busType_u.i2c.device, dev->busType_u.i2c.address, 0x80, command);
 }
 
-static bool i2c_OLED_send_cmdarray(extDevice_t *bus, const uint8_t *commands, size_t len) {
+static bool i2c_OLED_send_cmdarray(extDevice_t *dev, const uint8_t *commands, size_t len) {
     for (size_t i = 0 ; i < len ; i++) {
-        if (!i2c_OLED_send_cmd(bus, commands[i])) {
+        if (!i2c_OLED_send_cmd(dev, commands[i])) {
             return false;
         }
     }
     return true;
 }
 
-static bool i2c_OLED_send_byte(extDevice_t *bus, uint8_t val) {
-    return i2cWrite(bus->busType_u.i2c.device, bus->busType_u.i2c.address, 0x40, val);
+static bool i2c_OLED_send_byte(extDevice_t *dev, uint8_t val) {
+    return i2cWrite(dev->busType_u.i2c.device, dev->busType_u.i2c.address, 0x40, val);
 }
 
-void i2c_OLED_clear_display_quick(extDevice_t *bus) {
+void i2c_OLED_clear_display_quick(extDevice_t *dev) {
     static const uint8_t i2c_OLED_cmd_clear_display_quick[] = {
         0xb0, // set page address to 0
         0x40, // Display start line register to 0
         0,    // Set low col address to 0
         0x10, // Set high col address to 0
     };
-    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_quick, ARRAYLEN(i2c_OLED_cmd_clear_display_quick));
+    i2c_OLED_send_cmdarray(dev, i2c_OLED_cmd_clear_display_quick, ARRAYLEN(i2c_OLED_cmd_clear_display_quick));
     for (uint16_t i = 0; i < 1024; i++) {      // fill the display's RAM with graphic... 128*64 pixel picture
-        i2c_OLED_send_byte(bus, 0x00);  // clear
+        i2c_OLED_send_byte(dev, 0x00);  // clear
     }
 }
 
-void i2c_OLED_clear_display(extDevice_t *bus) {
+void i2c_OLED_clear_display(extDevice_t *dev) {
     static const uint8_t i2c_OLED_cmd_clear_display_pre[] = {
         0xa6, // Set Normal Display
         0xae, // Display OFF
         0x20, // Set Memory Addressing Mode
         0x00, // Set Memory Addressing Mode to Horizontal addressing mode
     };
-    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_pre, ARRAYLEN(i2c_OLED_cmd_clear_display_pre));
-    i2c_OLED_clear_display_quick(bus);
+    i2c_OLED_send_cmdarray(dev, i2c_OLED_cmd_clear_display_pre, ARRAYLEN(i2c_OLED_cmd_clear_display_pre));
+    i2c_OLED_clear_display_quick(dev);
     static const uint8_t i2c_OLED_cmd_clear_display_post[] = {
         0x81, // Setup CONTRAST CONTROL, following byte is the contrast Value... always a 2 byte instruction
         200,  // Here you can set the brightness 1 = dull, 255 is very bright
         0xaf, // display on
     };
-    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_post, ARRAYLEN(i2c_OLED_cmd_clear_display_post));
+    i2c_OLED_send_cmdarray(dev, i2c_OLED_cmd_clear_display_post, ARRAYLEN(i2c_OLED_cmd_clear_display_post));
 }
 
-void i2c_OLED_set_xy(extDevice_t *bus, uint8_t col, uint8_t row) {
+void i2c_OLED_set_xy(extDevice_t *dev, uint8_t col, uint8_t row) {
     uint8_t i2c_OLED_cmd_set_xy[] = {
         0xb0 + row,                                            //set page address
         0x00 + ((CHARACTER_WIDTH_TOTAL * col) & 0x0f),         //set low col address
         0x10 + (((CHARACTER_WIDTH_TOTAL * col) >> 4) & 0x0f)   //set high col address
     };
-    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_set_xy, ARRAYLEN(i2c_OLED_cmd_set_xy));
+    i2c_OLED_send_cmdarray(dev, i2c_OLED_cmd_set_xy, ARRAYLEN(i2c_OLED_cmd_set_xy));
 }
 
-void i2c_OLED_set_line(extDevice_t *bus, uint8_t row) {
-    i2c_OLED_set_xy(bus, 0, row);
+void i2c_OLED_set_line(extDevice_t *dev, uint8_t row) {
+    i2c_OLED_set_xy(dev, 0, row);
 }
 
-void i2c_OLED_send_char(extDevice_t *bus, unsigned char ascii) {
+void i2c_OLED_send_char(extDevice_t *dev, unsigned char ascii) {
     unsigned char i;
     uint8_t buffer;
     for (i = 0; i < 5; i++) {
         buffer = multiWiiFont[ascii - 32][i];
         buffer ^= CHAR_FORMAT;  // apply
-        i2c_OLED_send_byte(bus, buffer);
+        i2c_OLED_send_byte(dev, buffer);
     }
-    i2c_OLED_send_byte(bus, CHAR_FORMAT);    // the gap
+    i2c_OLED_send_byte(dev, CHAR_FORMAT);    // the gap
 }
 
-void i2c_OLED_send_string(extDevice_t *bus, const char *string) {
+void i2c_OLED_send_string(extDevice_t *dev, const char *string) {
     // Sends a string of chars until null terminator
     while (*string) {
-        i2c_OLED_send_char(bus, *string);
+        i2c_OLED_send_char(dev, *string);
         string++;
     }
 }
@@ -256,9 +256,9 @@ void i2c_OLED_send_string(extDevice_t *bus, const char *string) {
 * according to http://www.adafruit.com/datasheets/UG-2864HSWEG01.pdf Chapter 4.4 Page 15
 */
 
-bool ug2864hsweg01InitI2C(extDevice_t *bus) {
+bool ug2864hsweg01InitI2C(extDevice_t *dev) {
     // Set display OFF
-    if (!i2c_OLED_send_cmd(bus, 0xAE)) {
+    if (!i2c_OLED_send_cmd(dev, 0xAE)) {
         return false;
     }
     static const uint8_t i2c_OLED_cmd_init[] = {
@@ -285,8 +285,8 @@ bool ug2864hsweg01InitI2C(extDevice_t *bus) {
         0xA6, // Set display not inverted
         0xAF, // Set display On
     };
-    i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_init, ARRAYLEN(i2c_OLED_cmd_init));
-    i2c_OLED_clear_display(bus);
+    i2c_OLED_send_cmdarray(dev, i2c_OLED_cmd_init, ARRAYLEN(i2c_OLED_cmd_init));
+    i2c_OLED_clear_display(dev);
     return true;
 }
 #endif // USE_I2C_OLED_DISPLAY

--- a/src/main/drivers/display_ug2864hsweg01.c
+++ b/src/main/drivers/display_ug2864hsweg01.c
@@ -173,11 +173,11 @@ static const uint8_t multiWiiFont[][5] = { // Refer to "Times New Roman" Font Da
     { 0x7A, 0x7E, 0x7E, 0x7E, 0x7A }, //   (131)    - 0x00C8 Vertical Bargraph - 6 (full)
 };
 
-static bool i2c_OLED_send_cmd(busDevice_t *bus, uint8_t command) {
+static bool i2c_OLED_send_cmd(extDevice_t *bus, uint8_t command) {
     return i2cWrite(bus->busType_u.i2c.device, bus->busType_u.i2c.address, 0x80, command);
 }
 
-static bool i2c_OLED_send_cmdarray(busDevice_t *bus, const uint8_t *commands, size_t len) {
+static bool i2c_OLED_send_cmdarray(extDevice_t *bus, const uint8_t *commands, size_t len) {
     for (size_t i = 0 ; i < len ; i++) {
         if (!i2c_OLED_send_cmd(bus, commands[i])) {
             return false;
@@ -186,11 +186,11 @@ static bool i2c_OLED_send_cmdarray(busDevice_t *bus, const uint8_t *commands, si
     return true;
 }
 
-static bool i2c_OLED_send_byte(busDevice_t *bus, uint8_t val) {
+static bool i2c_OLED_send_byte(extDevice_t *bus, uint8_t val) {
     return i2cWrite(bus->busType_u.i2c.device, bus->busType_u.i2c.address, 0x40, val);
 }
 
-void i2c_OLED_clear_display_quick(busDevice_t *bus) {
+void i2c_OLED_clear_display_quick(extDevice_t *bus) {
     static const uint8_t i2c_OLED_cmd_clear_display_quick[] = {
         0xb0, // set page address to 0
         0x40, // Display start line register to 0
@@ -203,7 +203,7 @@ void i2c_OLED_clear_display_quick(busDevice_t *bus) {
     }
 }
 
-void i2c_OLED_clear_display(busDevice_t *bus) {
+void i2c_OLED_clear_display(extDevice_t *bus) {
     static const uint8_t i2c_OLED_cmd_clear_display_pre[] = {
         0xa6, // Set Normal Display
         0xae, // Display OFF
@@ -220,7 +220,7 @@ void i2c_OLED_clear_display(busDevice_t *bus) {
     i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_clear_display_post, ARRAYLEN(i2c_OLED_cmd_clear_display_post));
 }
 
-void i2c_OLED_set_xy(busDevice_t *bus, uint8_t col, uint8_t row) {
+void i2c_OLED_set_xy(extDevice_t *bus, uint8_t col, uint8_t row) {
     uint8_t i2c_OLED_cmd_set_xy[] = {
         0xb0 + row,                                            //set page address
         0x00 + ((CHARACTER_WIDTH_TOTAL * col) & 0x0f),         //set low col address
@@ -229,11 +229,11 @@ void i2c_OLED_set_xy(busDevice_t *bus, uint8_t col, uint8_t row) {
     i2c_OLED_send_cmdarray(bus, i2c_OLED_cmd_set_xy, ARRAYLEN(i2c_OLED_cmd_set_xy));
 }
 
-void i2c_OLED_set_line(busDevice_t *bus, uint8_t row) {
+void i2c_OLED_set_line(extDevice_t *bus, uint8_t row) {
     i2c_OLED_set_xy(bus, 0, row);
 }
 
-void i2c_OLED_send_char(busDevice_t *bus, unsigned char ascii) {
+void i2c_OLED_send_char(extDevice_t *bus, unsigned char ascii) {
     unsigned char i;
     uint8_t buffer;
     for (i = 0; i < 5; i++) {
@@ -244,7 +244,7 @@ void i2c_OLED_send_char(busDevice_t *bus, unsigned char ascii) {
     i2c_OLED_send_byte(bus, CHAR_FORMAT);    // the gap
 }
 
-void i2c_OLED_send_string(busDevice_t *bus, const char *string) {
+void i2c_OLED_send_string(extDevice_t *bus, const char *string) {
     // Sends a string of chars until null terminator
     while (*string) {
         i2c_OLED_send_char(bus, *string);
@@ -256,7 +256,7 @@ void i2c_OLED_send_string(busDevice_t *bus, const char *string) {
 * according to http://www.adafruit.com/datasheets/UG-2864HSWEG01.pdf Chapter 4.4 Page 15
 */
 
-bool ug2864hsweg01InitI2C(busDevice_t *bus) {
+bool ug2864hsweg01InitI2C(extDevice_t *bus) {
     // Set display OFF
     if (!i2c_OLED_send_cmd(bus, 0xAE)) {
         return false;

--- a/src/main/drivers/display_ug2864hsweg01.h
+++ b/src/main/drivers/display_ug2864hsweg01.h
@@ -39,11 +39,11 @@
 #define VERTICAL_BARGRAPH_ZERO_CHARACTER (128 + 32)
 #define VERTICAL_BARGRAPH_CHARACTER_COUNT 7
 
-bool ug2864hsweg01InitI2C(extDevice_t *bus);
+bool ug2864hsweg01InitI2C(extDevice_t *dev);
 
-void i2c_OLED_set_xy(extDevice_t *bus, uint8_t col, uint8_t row);
-void i2c_OLED_set_line(extDevice_t *bus, uint8_t row);
-void i2c_OLED_send_char(extDevice_t *bus, unsigned char ascii);
-void i2c_OLED_send_string(extDevice_t *bus, const char *string);
-void i2c_OLED_clear_display(extDevice_t *bus);
-void i2c_OLED_clear_display_quick(extDevice_t *bus);
+void i2c_OLED_set_xy(extDevice_t *dev, uint8_t col, uint8_t row);
+void i2c_OLED_set_line(extDevice_t *dev, uint8_t row);
+void i2c_OLED_send_char(extDevice_t *dev, unsigned char ascii);
+void i2c_OLED_send_string(extDevice_t *dev, const char *string);
+void i2c_OLED_clear_display(extDevice_t *dev);
+void i2c_OLED_clear_display_quick(extDevice_t *dev);

--- a/src/main/drivers/display_ug2864hsweg01.h
+++ b/src/main/drivers/display_ug2864hsweg01.h
@@ -39,11 +39,11 @@
 #define VERTICAL_BARGRAPH_ZERO_CHARACTER (128 + 32)
 #define VERTICAL_BARGRAPH_CHARACTER_COUNT 7
 
-bool ug2864hsweg01InitI2C(busDevice_t *bus);
+bool ug2864hsweg01InitI2C(extDevice_t *bus);
 
-void i2c_OLED_set_xy(busDevice_t *bus, uint8_t col, uint8_t row);
-void i2c_OLED_set_line(busDevice_t *bus, uint8_t row);
-void i2c_OLED_send_char(busDevice_t *bus, unsigned char ascii);
-void i2c_OLED_send_string(busDevice_t *bus, const char *string);
-void i2c_OLED_clear_display(busDevice_t *bus);
-void i2c_OLED_clear_display_quick(busDevice_t *bus);
+void i2c_OLED_set_xy(extDevice_t *bus, uint8_t col, uint8_t row);
+void i2c_OLED_set_line(extDevice_t *bus, uint8_t row);
+void i2c_OLED_send_char(extDevice_t *bus, unsigned char ascii);
+void i2c_OLED_send_string(extDevice_t *bus, const char *string);
+void i2c_OLED_clear_display(extDevice_t *bus);
+void i2c_OLED_clear_display_quick(extDevice_t *bus);

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -35,8 +35,8 @@
 #include "drivers/io.h"
 #include "drivers/time.h"
 
-static busDevice_t busInstance;
-static busDevice_t *busdev;
+static extDevice_t busInstance;
+static extDevice_t *busdev;
 
 static flashDevice_t flashDevice;
 

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -36,37 +36,37 @@
 #include "drivers/time.h"
 
 static extDevice_t busInstance;
-static extDevice_t *busdev;
+static extDevice_t *dev;
 
 static flashDevice_t flashDevice;
 
 // Read chip identification and send it to device detect
 
 bool flashInit(const flashConfig_t *flashConfig) {
-    busdev = &busInstance;
+    dev = &busInstance;
     if (flashConfig->csTag) {
-        busdev->busType_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
+        dev->busType_u.spi.csnPin = IOGetByTag(flashConfig->csTag);
     } else {
         return false;
     }
-    if (!IOIsFreeOrPreinit(busdev->busType_u.spi.csnPin)) {
+    if (!IOIsFreeOrPreinit(dev->busType_u.spi.csnPin)) {
         return false;
     }
-    busdev->busType = BUS_TYPE_SPI;
+    dev->busType = BUS_TYPE_SPI;
     SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(flashConfig->spiDevice));
     if (!instance) {
         return false;
     }
-    spiBusSetInstance(busdev, instance);
-    IOInit(busdev->busType_u.spi.csnPin, OWNER_FLASH_CS, 0);
-    IOConfigGPIO(busdev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(busdev->busType_u.spi.csnPin);
+    spiBusSetInstance(dev, instance);
+    IOInit(dev->busType_u.spi.csnPin, OWNER_FLASH_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
 #ifndef FLASH_SPI_SHARED
     //Maximum speed for standard READ command is 20mHz, other commands tolerate 25mHz
-    //spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_FAST);
-    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD * 2);
+    //spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD * 2);
 #endif
-    flashDevice.dev = busdev;
+    flashDevice.dev = dev;
     const uint8_t out[] = { SPIFLASH_INSTRUCTION_RDID, 0, 0, 0 };
     delay(50); // short delay required after initialisation of SPI device instance.
     /* Just in case transfer fails and writes nothing, so we don't try to verify the ID against random garbage
@@ -74,7 +74,7 @@ bool flashInit(const flashConfig_t *flashConfig) {
      */
     uint8_t in[4] = { 0 };
     // Clearing the CS bit terminates the command early so we don't have to read the chip UID:
-    spiReadWriteBuf(busdev, out, in, sizeof(out));
+    spiReadWriteBuf(dev, out, in, sizeof(out));
     // Manufacturer, memory type, and capacity
     uint32_t chipID = (in[1] << 16) | (in[2] << 8) | (in[3]);
 #ifdef USE_FLASH_M25P16

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -79,29 +79,29 @@ STATIC_ASSERT(M25P16_PAGESIZE < FLASH_MAX_PAGE_SIZE, M25P16_PAGESIZE_too_small);
 
 const flashVTable_t m25p16_vTable;
 
-static void m25p16_disable(extDevice_t *bus) {
-    IOHi(bus->busType_u.spi.csnPin);
+static void m25p16_disable(extDevice_t *dev) {
+    IOHi(dev->busType_u.spi.csnPin);
     __NOP();
 }
 
-static void m25p16_enable(extDevice_t *bus) {
+static void m25p16_enable(extDevice_t *dev) {
     __NOP();
-    IOLo(bus->busType_u.spi.csnPin);
+    IOLo(dev->busType_u.spi.csnPin);
 }
 
-static void m25p16_transfer(extDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int len) {
-    m25p16_enable(bus);
-    spiTransfer(bus->busType_u.spi.instance, txData, rxData, len);
-    m25p16_disable(bus);
+static void m25p16_transfer(extDevice_t *dev, const uint8_t *txData, uint8_t *rxData, int len) {
+    m25p16_enable(dev);
+    spiTransfer(dev->busType_u.spi.instance, txData, rxData, len);
+    m25p16_disable(dev);
 }
 
 /**
  * Send the given command byte to the device.
  */
-static void m25p16_performOneByteCommand(extDevice_t *bus, uint8_t command) {
-    m25p16_enable(bus);
-    spiTransferByte(bus->busType_u.spi.instance, command);
-    m25p16_disable(bus);
+static void m25p16_performOneByteCommand(extDevice_t *dev, uint8_t command) {
+    m25p16_enable(dev);
+    spiTransferByte(dev->busType_u.spi.instance, command);
+    m25p16_disable(dev);
 }
 
 /**
@@ -114,10 +114,10 @@ static void m25p16_writeEnable(flashDevice_t *fdevice) {
     fdevice->couldBeBusy = true;
 }
 
-static uint8_t m25p16_readStatus(extDevice_t *bus) {
+static uint8_t m25p16_readStatus(extDevice_t *dev) {
     const uint8_t command[2] = { M25P16_INSTRUCTION_READ_STATUS_REG, 0 };
     uint8_t in[2];
-    m25p16_transfer(bus, command, in, sizeof(command));
+    m25p16_transfer(dev, command, in, sizeof(command));
     return in[1];
 }
 

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -79,17 +79,17 @@ STATIC_ASSERT(M25P16_PAGESIZE < FLASH_MAX_PAGE_SIZE, M25P16_PAGESIZE_too_small);
 
 const flashVTable_t m25p16_vTable;
 
-static void m25p16_disable(busDevice_t *bus) {
+static void m25p16_disable(extDevice_t *bus) {
     IOHi(bus->busType_u.spi.csnPin);
     __NOP();
 }
 
-static void m25p16_enable(busDevice_t *bus) {
+static void m25p16_enable(extDevice_t *bus) {
     __NOP();
     IOLo(bus->busType_u.spi.csnPin);
 }
 
-static void m25p16_transfer(busDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int len) {
+static void m25p16_transfer(extDevice_t *bus, const uint8_t *txData, uint8_t *rxData, int len) {
     m25p16_enable(bus);
     spiTransfer(bus->busType_u.spi.instance, txData, rxData, len);
     m25p16_disable(bus);
@@ -98,7 +98,7 @@ static void m25p16_transfer(busDevice_t *bus, const uint8_t *txData, uint8_t *rx
 /**
  * Send the given command byte to the device.
  */
-static void m25p16_performOneByteCommand(busDevice_t *bus, uint8_t command) {
+static void m25p16_performOneByteCommand(extDevice_t *bus, uint8_t command) {
     m25p16_enable(bus);
     spiTransferByte(bus->busType_u.spi.instance, command);
     m25p16_disable(bus);
@@ -114,7 +114,7 @@ static void m25p16_writeEnable(flashDevice_t *fdevice) {
     fdevice->couldBeBusy = true;
 }
 
-static uint8_t m25p16_readStatus(busDevice_t *bus) {
+static uint8_t m25p16_readStatus(extDevice_t *bus) {
     const uint8_t command[2] = { M25P16_INSTRUCTION_READ_STATUS_REG, 0 };
     uint8_t in[2];
     m25p16_transfer(bus, command, in, sizeof(command));

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -59,13 +59,13 @@ static flashDevice_t dieDevice[MAX_DIE_COUNT];
 static int dieCount;
 static uint32_t dieSize;
 
-static void w25m_dieSelect(extDevice_t *busdev, int die) {
+static void w25m_dieSelect(extDevice_t *dev, int die) {
     static int activeDie = -1;
     if (activeDie == die) {
         return;
     }
     uint8_t command[2] = { W25M_INSTRUCTION_SOFTWARE_DIE_SELECT, die };
-    spiReadWriteBuf(busdev, command, NULL, 2);
+    spiReadWriteBuf(dev, command, NULL, 2);
     activeDie = die;
 }
 

--- a/src/main/drivers/flash_w25m.c
+++ b/src/main/drivers/flash_w25m.c
@@ -59,7 +59,7 @@ static flashDevice_t dieDevice[MAX_DIE_COUNT];
 static int dieCount;
 static uint32_t dieSize;
 
-static void w25m_dieSelect(busDevice_t *busdev, int die) {
+static void w25m_dieSelect(extDevice_t *busdev, int die) {
     static int activeDie = -1;
     if (activeDie == die) {
         return;

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -190,8 +190,8 @@
 #define MAX7456_SPI_CLK           (SPI_CLOCK_STANDARD)
 #endif
 
-busDevice_t max7456BusDevice;
-busDevice_t *busdev = &max7456BusDevice;
+extDevice_t max7456BusDevice;
+extDevice_t *busdev = &max7456BusDevice;
 
 static uint16_t max7456SpiClock = MAX7456_SPI_CLK;
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -175,15 +175,15 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-#define __spiBusTransactionBegin(busdev)        {spiSetDivisor((busdev)->busType_u.spi.instance, max7456SpiClock);IOLo((busdev)->busType_u.spi.csnPin);}
+#define __spiBusTransactionBegin(dev)        {spiSetDivisor((dev)->busType_u.spi.instance, max7456SpiClock);IOLo((dev)->busType_u.spi.csnPin);}
 #else
-#define __spiBusTransactionBegin(busdev)        IOLo((busdev)->busType_u.spi.csnPin)
+#define __spiBusTransactionBegin(dev)        IOLo((dev)->busType_u.spi.csnPin)
 #endif
 
 #ifdef MAX7456_RESTORE_CLK
-#define __spiBusTransactionEnd(busdev)       {IOHi((busdev)->busType_u.spi.csnPin);spiSetDivisor((busdev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
+#define __spiBusTransactionEnd(dev)       {IOHi((dev)->busType_u.spi.csnPin);spiSetDivisor((dev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
 #else
-#define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busType_u.spi.csnPin)
+#define __spiBusTransactionEnd(dev)       IOHi((dev)->busType_u.spi.csnPin)
 #endif
 
 #ifndef MAX7456_SPI_CLK
@@ -191,7 +191,7 @@
 #endif
 
 extDevice_t max7456BusDevice;
-extDevice_t *busdev = &max7456BusDevice;
+extDevice_t *dev = &max7456BusDevice;
 
 static uint16_t max7456SpiClock = MAX7456_SPI_CLK;
 
@@ -228,11 +228,11 @@ static uint8_t max7456DeviceType;
 static void max7456DrawScreenSlow(void);
 
 static uint8_t max7456Send(uint8_t add, uint8_t data) {
-    spiTransferByte(busdev->busType_u.spi.instance, add);
+    spiTransferByte(dev->busType_u.spi.instance, add);
 #ifdef USE_NBD7456
     delayMicroseconds(10);
 #endif
-    return spiTransferByte(busdev->busType_u.spi.instance, data);
+    return spiTransferByte(dev->busType_u.spi.instance, data);
 }
 
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -250,7 +250,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
 #endif
     // Common to both channels
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(busdev->busType_u.spi.instance->DR));
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(dev->busType_u.spi.instance->DR));
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
@@ -287,9 +287,9 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
     DMA_ITConfig(MAX7456_DMA_CHANNEL_TX, DMA_IT_TC, ENABLE);
 #endif
     // Enable SPI TX/RX request
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     dmaTransactionInProgress = true;
-    SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
+    SPI_I2S_DMACmd(dev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                    SPI_I2S_DMAReq_Rx |
 #endif
@@ -302,21 +302,21 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         DMA_Cmd(MAX7456_DMA_CHANNEL_RX, DISABLE);
 #endif
         // Make sure SPI DMA transfer is complete
-        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
-        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
+        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
+        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
-        while (SPI_I2S_GetFlagStatus(busdev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            busdev->busType_u.spi.instance->DR;
+        while (SPI_I2S_GetFlagStatus(dev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
+            dev->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-        SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
+        SPI_I2S_DMACmd(dev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                        SPI_I2S_DMAReq_Rx |
 #endif
                        SPI_I2S_DMAReq_Tx, DISABLE);
-        __spiBusTransactionEnd(busdev);
+        __spiBusTransactionEnd(dev);
         dmaTransactionInProgress = false;
     }
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_HTIF)) {
@@ -336,7 +336,7 @@ uint8_t max7456GetRowsCount(void) {
 void max7456ReInit(void) {
     uint8_t srdata = 0;
     static bool firstInit = true;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     switch (videoSignalCfg) {
     case VIDEO_SYSTEM_PAL:
         videoSignalReg = VIDEO_MODE_PAL | OSD_ENABLE;
@@ -364,13 +364,13 @@ void max7456ReInit(void) {
     // Set all rows to same charactor black/white level
     max7456Brightness(0, 2);
     // Re-enable MAX7456 (last function call disables it)
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     // Make sure the Max7456 is enabled
     max7456Send(MAX7456ADD_VM0, videoSignalReg);
     max7456Send(MAX7456ADD_HOS, hosRegValue);
     max7456Send(MAX7456ADD_VOS, vosRegValue);
     max7456Send(MAX7456ADD_DMM, displayMemoryModeReg | CLEAR_DISPLAY);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     // Clear shadow to force redraw all screen in non-dma mode.
     memset(shadowBuffer, 0, maxScreenSize);
     if (firstInit) {
@@ -388,17 +388,17 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     if (!max7456Config->csTag) {
         return false;
     }
-    busdev->busType_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
-    if (!IOIsFreeOrPreinit(busdev->busType_u.spi.csnPin)) {
+    dev->busType_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
+    if (!IOIsFreeOrPreinit(dev->busType_u.spi.csnPin)) {
         return false;
     }
-    IOInit(busdev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
-    IOConfigGPIO(busdev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(busdev->busType_u.spi.csnPin);
-    spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
+    IOInit(dev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
+    spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
-    spiSetDivisor(busdev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
+    spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
     max7456Send(MAX7456ADD_CMAL, (1 << 6)); // CA[8] bit
     if (max7456Send(MAX7456ADD_CMAL | MAX7456ADD_READ, 0xff) & (1 << 6)) {
         max7456DeviceType = MAX7456_DEVICE_TYPE_AT;
@@ -425,11 +425,11 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
 #endif
-    spiSetDivisor(busdev->busType_u.spi.instance, max7456SpiClock);
+    spiSetDivisor(dev->busType_u.spi.instance, max7456SpiClock);
     // force soft reset on Max7456
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     max7456Send(MAX7456ADD_VM0, MAX7456_RESET);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     // Setup values to write to registers
     videoSignalCfg = pVcdProfile->video_system;
     hosRegValue = 32 - pVcdProfile->h_offset;
@@ -450,9 +450,9 @@ void max7456Invert(bool invert) {
     } else {
         displayMemoryModeReg &= ~INVERT_PIXEL_COLOR;
     }
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     max7456Send(MAX7456ADD_DMM, displayMemoryModeReg);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
 }
 
 /**
@@ -463,11 +463,11 @@ void max7456Invert(bool invert) {
  */
 void max7456Brightness(uint8_t black, uint8_t white) {
     const uint8_t reg = (black << 2) | (3 - white);
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     for (int i = MAX7456ADD_RB0; i <= MAX7456ADD_RB15; i++) {
         max7456Send(i, reg);
     }
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
 }
 
 //just fill with spaces with some tricks
@@ -512,18 +512,18 @@ void max7456ReInitIfRequired(void) {
     static uint32_t lastSigCheckMs = 0;
     static uint32_t videoDetectTimeMs = 0;
     static uint16_t reInitCount = 0;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     const uint8_t stallCheck = max7456Send(MAX7456ADD_VM0 | MAX7456ADD_READ, 0x00);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     const timeMs_t nowMs = millis();
     if (stallCheck != videoSignalReg) {
         max7456ReInit();
     } else if ((videoSignalCfg == VIDEO_SYSTEM_AUTO)
                && ((nowMs - lastSigCheckMs) > MAX7456_SIGNAL_CHECK_INTERVAL_MS)) {
         // Adjust output format based on the current input format.
-        __spiBusTransactionBegin(busdev);
+        __spiBusTransactionBegin(dev);
         const uint8_t videoSense = max7456Send(MAX7456ADD_STAT, 0x00);
-        __spiBusTransactionEnd(busdev);
+        __spiBusTransactionEnd(dev);
         DEBUG_SET(DEBUG_MAX7456_SIGNAL, DEBUG_MAX7456_SIGNAL_MODEREG, videoSignalReg & VIDEO_MODE_MASK);
         DEBUG_SET(DEBUG_MAX7456_SIGNAL, DEBUG_MAX7456_SIGNAL_SENSE, videoSense & 0x7);
         DEBUG_SET(DEBUG_MAX7456_SIGNAL, DEBUG_MAX7456_SIGNAL_ROWS, max7456GetRowsCount());
@@ -576,16 +576,16 @@ void max7456DrawScreen(void) {
 #ifdef MAX7456_DMA_CHANNEL_TX
             max7456SendDma(spiBuff, NULL, buff_len);
 #else
-            __spiBusTransactionBegin(busdev);
+            __spiBusTransactionBegin(dev);
 #ifdef USE_NBD7456
             for(int k = 0; k < buff_len; k++) {
                 delayMicroseconds(5);
-                spiTransferByte(busdev->busType_u.spi.instance, spiBuff[k]);
+                spiTransferByte(dev->busType_u.spi.instance, spiBuff[k]);
             }
 #else // USE_NBD7456
-            spiTransfer(busdev->busType_u.spi.instance, spiBuff, NULL, buff_len);
+            spiTransfer(dev->busType_u.spi.instance, spiBuff, NULL, buff_len);
 #endif
-            __spiBusTransactionEnd(busdev);
+            __spiBusTransactionEnd(dev);
 #endif // MAX7456_DMA_CHANNEL_TX
         }
         max7456Lock = false;
@@ -594,7 +594,7 @@ void max7456DrawScreen(void) {
 
 static void max7456DrawScreenSlow(void) {
     bool escapeCharFound = false;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     // Enable auto-increment mode and update every character in the screenBuffer.
     // The "escape" character 0xFF must be skipped as it causes the MAX7456 to exit auto-increment mode.
     max7456Send(MAX7456ADD_DMAH, 0);
@@ -622,7 +622,7 @@ static void max7456DrawScreenSlow(void) {
             }
         }
     }
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
 }
 
 
@@ -645,7 +645,7 @@ void max7456WriteNvm(uint8_t char_address, const uint8_t *font_data) {
 #endif
     while (max7456Lock);
     max7456Lock = true;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     // disable display
     fontIsLoading = true;
     max7456Send(MAX7456ADD_VM0, 0);
@@ -667,7 +667,7 @@ void max7456WriteNvm(uint8_t char_address, const uint8_t *font_data) {
         delay(10);
 #endif
     }
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     max7456Lock = false;
 }
 

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -190,8 +190,8 @@
 #define MAX7456_SPI_CLK           (SPI_CLOCK_STANDARD)
 #endif
 
-busDevice_t max7456BusDevice;
-busDevice_t *busdev = &max7456BusDevice;
+extDevice_t max7456BusDevice;
+extDevice_t *busdev = &max7456BusDevice;
 
 static uint16_t max7456SpiClock = MAX7456_SPI_CLK;
 

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -175,15 +175,15 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-#define __spiBusTransactionBegin(busdev)        {spiSetDivisor((busdev)->busType_u.spi.instance, max7456SpiClock);IOLo((busdev)->busType_u.spi.csnPin);}
+#define __spiBusTransactionBegin(dev)        {spiSetDivisor((dev)->busType_u.spi.instance, max7456SpiClock);IOLo((dev)->busType_u.spi.csnPin);}
 #else
-#define __spiBusTransactionBegin(busdev)        IOLo((busdev)->busType_u.spi.csnPin)
+#define __spiBusTransactionBegin(dev)        IOLo((dev)->busType_u.spi.csnPin)
 #endif
 
 #ifdef MAX7456_RESTORE_CLK
-#define __spiBusTransactionEnd(busdev)       {IOHi((busdev)->busType_u.spi.csnPin);spiSetDivisor((busdev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
+#define __spiBusTransactionEnd(dev)       {IOHi((dev)->busType_u.spi.csnPin);spiSetDivisor((dev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
 #else
-#define __spiBusTransactionEnd(busdev)       IOHi((busdev)->busType_u.spi.csnPin)
+#define __spiBusTransactionEnd(dev)       IOHi((dev)->busType_u.spi.csnPin)
 #endif
 
 #ifndef MAX7456_SPI_CLK
@@ -191,7 +191,7 @@
 #endif
 
 extDevice_t max7456BusDevice;
-extDevice_t *busdev = &max7456BusDevice;
+extDevice_t *dev = &max7456BusDevice;
 
 static uint16_t max7456SpiClock = MAX7456_SPI_CLK;
 
@@ -228,9 +228,9 @@ static uint8_t max7456DeviceType;
 static void max7456DrawScreenSlow(void);
 
 static uint8_t max7456Send(uint8_t add, uint8_t data) {
-    spiTransferByte(busdev->busType_u.spi.instance, add);
+    spiTransferByte(dev->busType_u.spi.instance, add);
     delayMicroseconds(10);
-    return spiTransferByte(busdev->busType_u.spi.instance, data);
+    return spiTransferByte(dev->busType_u.spi.instance, data);
 }
 
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -248,7 +248,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
 #endif
     // Common to both channels
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(busdev->busType_u.spi.instance->DR));
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(dev->busType_u.spi.instance->DR));
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
@@ -285,9 +285,9 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
     DMA_ITConfig(MAX7456_DMA_CHANNEL_TX, DMA_IT_TC, ENABLE);
 #endif
     // Enable SPI TX/RX request
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     dmaTransactionInProgress = true;
-    SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
+    SPI_I2S_DMACmd(dev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                    SPI_I2S_DMAReq_Rx |
 #endif
@@ -300,21 +300,21 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         DMA_Cmd(MAX7456_DMA_CHANNEL_RX, DISABLE);
 #endif
         // Make sure SPI DMA transfer is complete
-        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
-        while (SPI_I2S_GetFlagStatus (busdev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
+        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
+        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
-        while (SPI_I2S_GetFlagStatus(busdev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            busdev->busType_u.spi.instance->DR;
+        while (SPI_I2S_GetFlagStatus(dev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
+            dev->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-        SPI_I2S_DMACmd(busdev->busType_u.spi.instance,
+        SPI_I2S_DMACmd(dev->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                        SPI_I2S_DMAReq_Rx |
 #endif
                        SPI_I2S_DMAReq_Tx, DISABLE);
-        __spiBusTransactionEnd(busdev);
+        __spiBusTransactionEnd(dev);
         dmaTransactionInProgress = false;
     }
     if (DMA_GET_FLAG_STATUS(descriptor, DMA_IT_HTIF)) {
@@ -334,7 +334,7 @@ uint8_t max7456GetRowsCount(void) {
 void max7456ReInit(void) {
     uint8_t srdata = 0;
     static bool firstInit = true;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     switch (videoSignalCfg) {
     case VIDEO_SYSTEM_PAL:
         videoSignalReg = VIDEO_MODE_PAL | OSD_ENABLE;
@@ -362,13 +362,13 @@ void max7456ReInit(void) {
     // Set all rows to same charactor black/white level
     max7456Brightness(0, 2);
     // Re-enable MAX7456 (last function call disables it)
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     // Make sure the Max7456 is enabled
     max7456Send(MAX7456ADD_VM0, videoSignalReg);
     max7456Send(MAX7456ADD_HOS, hosRegValue);
     max7456Send(MAX7456ADD_VOS, vosRegValue);
     max7456Send(MAX7456ADD_DMM, displayMemoryModeReg | CLEAR_DISPLAY);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     // Clear shadow to force redraw all screen in non-dma mode.
     memset(shadowBuffer, 0, maxScreenSize);
     if (firstInit) {
@@ -386,17 +386,17 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     if (!max7456Config->csTag) {
         return false;
     }
-    busdev->busType_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
-    if (!IOIsFreeOrPreinit(busdev->busType_u.spi.csnPin)) {
+    dev->busType_u.spi.csnPin = IOGetByTag(max7456Config->csTag);
+    if (!IOIsFreeOrPreinit(dev->busType_u.spi.csnPin)) {
         return false;
     }
-    IOInit(busdev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
-    IOConfigGPIO(busdev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
-    IOHi(busdev->busType_u.spi.csnPin);
-    spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
+    IOInit(dev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
+    IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
+    IOHi(dev->busType_u.spi.csnPin);
+    spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
-    spiSetDivisor(busdev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
+    spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
     max7456Send(MAX7456ADD_CMAL, (1 << 6)); // CA[8] bit
     if (max7456Send(MAX7456ADD_CMAL | MAX7456ADD_READ, 0xff) & (1 << 6)) {
         max7456DeviceType = MAX7456_DEVICE_TYPE_AT;
@@ -423,11 +423,11 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
 #endif
-    spiSetDivisor(busdev->busType_u.spi.instance, max7456SpiClock);
+    spiSetDivisor(dev->busType_u.spi.instance, max7456SpiClock);
     // force soft reset on Max7456
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     max7456Send(MAX7456ADD_VM0, MAX7456_RESET);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     // Setup values to write to registers
     videoSignalCfg = pVcdProfile->video_system;
     hosRegValue = 32 - pVcdProfile->h_offset;
@@ -448,9 +448,9 @@ void max7456Invert(bool invert) {
     } else {
         displayMemoryModeReg &= ~INVERT_PIXEL_COLOR;
     }
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     max7456Send(MAX7456ADD_DMM, displayMemoryModeReg);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
 }
 
 /**
@@ -461,11 +461,11 @@ void max7456Invert(bool invert) {
  */
 void max7456Brightness(uint8_t black, uint8_t white) {
     const uint8_t reg = (black << 2) | (3 - white);
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     for (int i = MAX7456ADD_RB0; i <= MAX7456ADD_RB15; i++) {
         max7456Send(i, reg);
     }
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
 }
 
 //just fill with spaces with some tricks
@@ -510,18 +510,18 @@ void max7456ReInitIfRequired(void) {
     static uint32_t lastSigCheckMs = 0;
     static uint32_t videoDetectTimeMs = 0;
     static uint16_t reInitCount = 0;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     const uint8_t stallCheck = max7456Send(MAX7456ADD_VM0 | MAX7456ADD_READ, 0x00);
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     const timeMs_t nowMs = millis();
     if (stallCheck != videoSignalReg) {
         max7456ReInit();
     } else if ((videoSignalCfg == VIDEO_SYSTEM_AUTO)
                && ((nowMs - lastSigCheckMs) > MAX7456_SIGNAL_CHECK_INTERVAL_MS)) {
         // Adjust output format based on the current input format.
-        __spiBusTransactionBegin(busdev);
+        __spiBusTransactionBegin(dev);
         const uint8_t videoSense = max7456Send(MAX7456ADD_STAT, 0x00);
-        __spiBusTransactionEnd(busdev);
+        __spiBusTransactionEnd(dev);
         DEBUG_SET(DEBUG_MAX7456_SIGNAL, DEBUG_MAX7456_SIGNAL_MODEREG, videoSignalReg & VIDEO_MODE_MASK);
         DEBUG_SET(DEBUG_MAX7456_SIGNAL, DEBUG_MAX7456_SIGNAL_SENSE, videoSense & 0x7);
         DEBUG_SET(DEBUG_MAX7456_SIGNAL, DEBUG_MAX7456_SIGNAL_ROWS, max7456GetRowsCount());
@@ -572,15 +572,15 @@ void max7456DrawScreen(void) {
 #ifdef MAX7456_DMA_CHANNEL_TX
             max7456SendDma(spiBuff, NULL, buff_len);
 #else
-            // __spiBusTransactionBegin(busdev);
-            // spiTransfer(busdev->busType_u.spi.instance, spiBuff, NULL, buff_len);
-            // __spiBusTransactionEnd(busdev);
-            __spiBusTransactionBegin(busdev);
+            // __spiBusTransactionBegin(dev);
+            // spiTransfer(dev->busType_u.spi.instance, spiBuff, NULL, buff_len);
+            // __spiBusTransactionEnd(dev);
+            __spiBusTransactionBegin(dev);
             for(int k = 0; k < buff_len; k++) {
                 delayMicroseconds(5);
-                spiTransferByte(busdev->busType_u.spi.instance, spiBuff[k]);
+                spiTransferByte(dev->busType_u.spi.instance, spiBuff[k]);
             }
-            __spiBusTransactionEnd(busdev);
+            __spiBusTransactionEnd(dev);
 #endif // MAX7456_DMA_CHANNEL_TX
         }
         max7456Lock = false;
@@ -589,7 +589,7 @@ void max7456DrawScreen(void) {
 
 static void max7456DrawScreenSlow(void) {
     bool escapeCharFound = false;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     // Enable auto-increment mode and update every character in the screenBuffer.
     // The "escape" character 0xFF must be skipped as it causes the MAX7456 to exit auto-increment mode.
     max7456Send(MAX7456ADD_DMAH, 0);
@@ -617,7 +617,7 @@ static void max7456DrawScreenSlow(void) {
             }
         }
     }
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
 }
 
 
@@ -640,7 +640,7 @@ void max7456WriteNvm(uint8_t char_address, const uint8_t *font_data) {
 #endif
     while (max7456Lock);
     max7456Lock = true;
-    __spiBusTransactionBegin(busdev);
+    __spiBusTransactionBegin(dev);
     // disable display
     fontIsLoading = true;
     max7456Send(MAX7456ADD_VM0, 0);
@@ -660,7 +660,7 @@ void max7456WriteNvm(uint8_t char_address, const uint8_t *font_data) {
     while ((max7456Send(MAX7456ADD_STAT, 0x00) & STAT_NVR_BUSY) != 0x00) {
         delay(10);
     }
-    __spiBusTransactionEnd(busdev);
+    __spiBusTransactionEnd(dev);
     max7456Lock = false;
 }
 

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -41,8 +41,8 @@
 
 #include "rx_spi.h"
 
-static busDevice_t rxSpiDevice;
-static busDevice_t *busdev = &rxSpiDevice;
+static extDevice_t rxSpiDevice;
+static extDevice_t *busdev = &rxSpiDevice;
 
 #define DISABLE_RX()    {IOHi(busdev->busType_u.spi.csnPin);}
 #define ENABLE_RX()     {IOLo(busdev->busType_u.spi.csnPin);}

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -42,27 +42,27 @@
 #include "rx_spi.h"
 
 static extDevice_t rxSpiDevice;
-static extDevice_t *busdev = &rxSpiDevice;
+static extDevice_t *dev = &rxSpiDevice;
 
-#define DISABLE_RX()    {IOHi(busdev->busType_u.spi.csnPin);}
-#define ENABLE_RX()     {IOLo(busdev->busType_u.spi.csnPin);}
+#define DISABLE_RX()    {IOHi(dev->busType_u.spi.csnPin);}
+#define ENABLE_RX()     {IOLo(dev->busType_u.spi.csnPin);}
 
 bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig) {
     if (!rxSpiConfig->spibus) {
         return false;
     }
-    spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(rxSpiConfig->spibus)));
+    spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(rxSpiConfig->spibus)));
     const IO_t rxCsPin = IOGetByTag(rxSpiConfig->csnTag);
     IOInit(rxCsPin, OWNER_RX_SPI_CS, 0);
     IOConfigGPIO(rxCsPin, SPI_IO_CS_CFG);
-    busdev->busType_u.spi.csnPin = rxCsPin;
+    dev->busType_u.spi.csnPin = rxCsPin;
     DISABLE_RX();
-    spiSetDivisor(busdev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return true;
 }
 
 uint8_t rxSpiTransferByte(uint8_t data) {
-    return spiTransferByte(busdev->busType_u.spi.instance, data);
+    return spiTransferByte(dev->busType_u.spi.instance, data);
 }
 
 uint8_t rxSpiWriteByte(uint8_t data) {

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -80,7 +80,7 @@
 #define DISPLAY_UPDATE_FREQUENCY (MICROSECONDS_IN_A_SECOND / 5)
 #define PAGE_CYCLE_FREQUENCY (MICROSECONDS_IN_A_SECOND * 5)
 
-static extDevice_t *bus;
+static extDevice_t *dev;
 
 static uint32_t nextDisplayUpdateAt = 0;
 static bool dashboardPresent = false;
@@ -126,11 +126,11 @@ typedef struct pageState_s {
 static pageState_t pageState;
 
 static void resetDisplay(void) {
-    dashboardPresent = ug2864hsweg01InitI2C(bus);
+    dashboardPresent = ug2864hsweg01InitI2C(dev);
 }
 
 void LCDprint(uint8_t i) {
-    i2c_OLED_send_char(bus, i);
+    i2c_OLED_send_char(dev, i);
 }
 
 static void padLineBuffer(void) {
@@ -170,8 +170,8 @@ static void drawHorizonalPercentageBar(uint8_t width, uint8_t percent) {
 static void fillScreenWithCharacters(void) {
     for (uint8_t row = 0; row < SCREEN_CHARACTER_ROW_COUNT; row++) {
         for (uint8_t column = 0; column < SCREEN_CHARACTER_COLUMN_COUNT; column++) {
-            i2c_OLED_set_xy(bus, column, row);
-            i2c_OLED_send_char(bus, 'A' + column);
+            i2c_OLED_set_xy(dev, column, row);
+            i2c_OLED_send_char(dev, 'A' + column);
         }
     }
 }
@@ -180,14 +180,14 @@ static void fillScreenWithCharacters(void) {
 
 static void updateTicker(void) {
     static uint8_t tickerIndex = 0;
-    i2c_OLED_set_xy(bus, SCREEN_CHARACTER_COLUMN_COUNT - 1, 0);
-    i2c_OLED_send_char(bus, tickerCharacters[tickerIndex]);
+    i2c_OLED_set_xy(dev, SCREEN_CHARACTER_COLUMN_COUNT - 1, 0);
+    i2c_OLED_send_char(dev, tickerCharacters[tickerIndex]);
     tickerIndex++;
     tickerIndex = tickerIndex % TICKER_CHARACTER_COUNT;
 }
 
 static void updateRxStatus(void) {
-    i2c_OLED_set_xy(bus, SCREEN_CHARACTER_COLUMN_COUNT - 2, 0);
+    i2c_OLED_set_xy(dev, SCREEN_CHARACTER_COLUMN_COUNT - 2, 0);
     char rxStatus = '!';
     if (rxIsReceivingSignal()) {
         rxStatus = 'r';
@@ -195,7 +195,7 @@ static void updateRxStatus(void) {
     if (rxAreFlightChannelsValid()) {
         rxStatus = 'R';
     }
-    i2c_OLED_send_char(bus, rxStatus);
+    i2c_OLED_send_char(dev, rxStatus);
 }
 
 static void updateFailsafeStatus(void) {
@@ -223,17 +223,17 @@ static void updateFailsafeStatus(void) {
         failsafeIndicator = 'G';
         break;
     }
-    i2c_OLED_set_xy(bus, SCREEN_CHARACTER_COLUMN_COUNT - 3, 0);
-    i2c_OLED_send_char(bus, failsafeIndicator);
+    i2c_OLED_set_xy(dev, SCREEN_CHARACTER_COLUMN_COUNT - 3, 0);
+    i2c_OLED_send_char(dev, failsafeIndicator);
 }
 
 static void showTitle(void) {
-    i2c_OLED_set_line(bus, 0);
-    i2c_OLED_send_string(bus, pageState.page->title);
+    i2c_OLED_set_line(dev, 0);
+    i2c_OLED_send_string(dev, pageState.page->title);
 }
 
 static void handlePageChange(void) {
-    i2c_OLED_clear_display_quick(bus);
+    i2c_OLED_clear_display_quick(dev);
     showTitle();
 }
 
@@ -246,7 +246,7 @@ static void drawRxChannel(uint8_t channelIndex, uint8_t width) {
 #define RX_CHANNELS_PER_PAGE_COUNT 14
 static void showRxPage(void) {
     for (int channelIndex = 0; channelIndex < rxRuntimeConfig.channelCount && channelIndex < RX_CHANNELS_PER_PAGE_COUNT; channelIndex += 2) {
-        i2c_OLED_set_line(bus, (channelIndex / 2) + PAGE_TITLE_LINE_COUNT);
+        i2c_OLED_set_line(dev, (channelIndex / 2) + PAGE_TITLE_LINE_COUNT);
         drawRxChannel(channelIndex, HALF_SCREEN_CHARACTER_COLUMN_COUNT);
         if (channelIndex >= rxRuntimeConfig.channelCount) {
             continue;
@@ -261,10 +261,10 @@ static void showRxPage(void) {
 static void showWelcomePage(void) {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
     tfp_sprintf(lineBuffer, "v%s (%s)", FC_VERSION_STRING, shortGitRevision);
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, targetName);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, targetName);
 }
 
 static void showArmedPage(void) {
@@ -273,8 +273,8 @@ static void showArmedPage(void) {
 static void showProfilePage(void) {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
     tfp_sprintf(lineBuffer, "Profile: %d", getCurrentPidProfileIndex());
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     static const char* const axisTitles[3] = {"ROL", "PIT", "YAW"};
     const pidProfile_t *pidProfile = currentPidProfile;
     for (int axis = 0; axis < 3; ++axis) {
@@ -285,8 +285,8 @@ static void showProfilePage(void) {
                     pidProfile->pid[axis].D
                    );
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex++);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex++);
+        i2c_OLED_send_string(dev, lineBuffer);
     }
 }
 
@@ -294,37 +294,37 @@ static void showRateProfilePage(void) {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
     const uint8_t currentRateProfileIndex = getCurrentControlRateProfileIndex();
     tfp_sprintf(lineBuffer, "Rate profile: %d", currentRateProfileIndex);
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     const controlRateConfig_t *controlRateConfig = controlRateProfiles(currentRateProfileIndex);
     tfp_sprintf(lineBuffer, "         R   P   Y");
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "RcRate %3d %3d %3d",
                 controlRateConfig->rcRates[FD_ROLL],
                 controlRateConfig->rcRates[FD_PITCH],
                 controlRateConfig->rcRates[FD_YAW]
                );
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "Super  %3d %3d %3d",
                 controlRateConfig->rates[FD_ROLL],
                 controlRateConfig->rates[FD_PITCH],
                 controlRateConfig->rates[FD_YAW]
                );
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "Expo   %3d %3d %3d",
                 controlRateConfig->rcExpo[FD_ROLL],
                 controlRateConfig->rcExpo[FD_PITCH],
                 controlRateConfig->rcExpo[FD_YAW]
                );
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
 }
 
 #define SATELLITE_COUNT (sizeof(GPS_svinfo_cno) / sizeof(GPS_svinfo_cno[0]))
@@ -344,52 +344,52 @@ static void showGpsPage(void) {
         gpsTicker++;
         gpsTicker = gpsTicker % TICKER_CHARACTER_COUNT;
     }
-    i2c_OLED_set_xy(bus, 0, rowIndex);
-    i2c_OLED_send_char(bus, tickerCharacters[gpsTicker]);
-    i2c_OLED_set_xy(bus, MAX(0, (uint8_t)SATELLITE_GRAPH_LEFT_OFFSET), rowIndex++);
+    i2c_OLED_set_xy(dev, 0, rowIndex);
+    i2c_OLED_send_char(dev, tickerCharacters[gpsTicker]);
+    i2c_OLED_set_xy(dev, MAX(0, (uint8_t)SATELLITE_GRAPH_LEFT_OFFSET), rowIndex++);
     uint32_t index;
     for (index = 0; index < SATELLITE_COUNT && index < SCREEN_CHARACTER_COLUMN_COUNT; index++) {
         uint8_t bargraphOffset = ((uint16_t) GPS_svinfo_cno[index] * VERTICAL_BARGRAPH_CHARACTER_COUNT) / (GPS_DBHZ_MAX - 1);
         bargraphOffset = MIN(bargraphOffset, VERTICAL_BARGRAPH_CHARACTER_COUNT - 1);
-        i2c_OLED_send_char(bus, VERTICAL_BARGRAPH_ZERO_CHARACTER + bargraphOffset);
+        i2c_OLED_send_char(dev, VERTICAL_BARGRAPH_ZERO_CHARACTER + bargraphOffset);
     }
     char fixChar = STATE(GPS_FIX) ? 'Y' : 'N';
     tfp_sprintf(lineBuffer, "Sats: %d Fix: %c", gpsSol.numSat, fixChar);
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "La/Lo: %d/%d", gpsSol.llh.lat / GPS_DEGREES_DIVIDER, gpsSol.llh.lon / GPS_DEGREES_DIVIDER);
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "Spd: %d", gpsSol.groundSpeed);
     padHalfLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "GC: %d", gpsSol.groundCourse);
     padHalfLineBuffer();
-    i2c_OLED_set_xy(bus, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_xy(dev, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "RX: %d", GPS_packetCount);
     padHalfLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "ERRs: %d", gpsData.errors, gpsData.timeouts);
     padHalfLineBuffer();
-    i2c_OLED_set_xy(bus, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_xy(dev, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "Dt: %d", gpsData.lastMessage - gpsData.lastLastMessage);
     padHalfLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex);
+    i2c_OLED_send_string(dev, lineBuffer);
     tfp_sprintf(lineBuffer, "TOs: %d", gpsData.timeouts);
     padHalfLineBuffer();
-    i2c_OLED_set_xy(bus, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_xy(dev, HALF_SCREEN_CHARACTER_COLUMN_COUNT, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     strncpy(lineBuffer, gpsPacketLog, GPS_PACKET_LOG_ENTRY_COUNT);
     padHalfLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
 }
 #endif
 
@@ -398,10 +398,10 @@ static void showBatteryPage(void) {
     if (batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE) {
         tfp_sprintf(lineBuffer, "Volts: %d.%1d Cells: %d", getBatteryVoltage() / 10, getBatteryVoltage() % 10, getBatteryCellCount());
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex++);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex++);
+        i2c_OLED_send_string(dev, lineBuffer);
         uint8_t batteryPercentage = calculateBatteryPercentageRemaining();
-        i2c_OLED_set_line(bus, rowIndex++);
+        i2c_OLED_set_line(dev, rowIndex++);
         drawHorizonalPercentageBar(SCREEN_CHARACTER_COLUMN_COUNT, batteryPercentage);
     }
     if (batteryConfig()->currentMeterSource != CURRENT_METER_NONE) {
@@ -410,10 +410,10 @@ static void showBatteryPage(void) {
         // Amp: DDD.D mAh: DDDDD
         tfp_sprintf(lineBuffer, "Amp: %d.%d mAh: %d", amperage / 100, (amperage % 100) / 10, getMAhDrawn());
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex++);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex++);
+        i2c_OLED_send_string(dev, lineBuffer);
         uint8_t capacityPercentage = calculateBatteryPercentageRemaining();
-        i2c_OLED_set_line(bus, rowIndex++);
+        i2c_OLED_set_line(dev, rowIndex++);
         drawHorizonalPercentageBar(SCREEN_CHARACTER_COLUMN_COUNT, capacityPercentage);
     }
 }
@@ -421,32 +421,32 @@ static void showBatteryPage(void) {
 static void showSensorsPage(void) {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
     static const char *format = "%s %5d %5d %5d";
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, "        X     Y     Z");
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, "        X     Y     Z");
     if (sensors(SENSOR_ACC)) {
         tfp_sprintf(lineBuffer, format, "ACC", lrintf(acc.accADC[X]), lrintf(acc.accADC[Y]), lrintf(acc.accADC[Z]));
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex++);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex++);
+        i2c_OLED_send_string(dev, lineBuffer);
     }
     if (sensors(SENSOR_GYRO)) {
         tfp_sprintf(lineBuffer, format, "GYR", lrintf(gyro.gyroADCf[X]), lrintf(gyro.gyroADCf[Y]), lrintf(gyro.gyroADCf[Z]));
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex++);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex++);
+        i2c_OLED_send_string(dev, lineBuffer);
     }
 #ifdef USE_MAG
     if (sensors(SENSOR_MAG)) {
         tfp_sprintf(lineBuffer, format, "MAG", lrintf(mag.magADC[X]), lrintf(mag.magADC[Y]), lrintf(mag.magADC[Z]));
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex++);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex++);
+        i2c_OLED_send_string(dev, lineBuffer);
     }
 #endif
     tfp_sprintf(lineBuffer, format, "I&H", attitude.values.roll, attitude.values.pitch, DECIDEGREES_TO_DEGREES(attitude.values.yaw));
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     /*
     uint8_t length;
 
@@ -458,8 +458,8 @@ static void showSensorsPage(void) {
     }
     ftoa(EstG.A[Y], lineBuffer + length);
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
 
     ftoa(EstG.A[Z], lineBuffer);
     length = strlen(lineBuffer);
@@ -469,8 +469,8 @@ static void showSensorsPage(void) {
     }
     ftoa(smallAngle, lineBuffer + length);
     padLineBuffer();
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, lineBuffer);
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, lineBuffer);
     */
 }
 
@@ -478,8 +478,8 @@ static void showSensorsPage(void) {
 static void showTasksPage(void) {
     uint8_t rowIndex = PAGE_TITLE_LINE_COUNT;
     static const char *format = "%2d%6d%5d%4d%4d";
-    i2c_OLED_set_line(bus, rowIndex++);
-    i2c_OLED_send_string(bus, "Task max  avg mx% av%");
+    i2c_OLED_set_line(dev, rowIndex++);
+    i2c_OLED_send_string(dev, "Task max  avg mx% av%");
     cfTaskInfo_t taskInfo;
     for (cfTaskId_e taskId = 0; taskId < TASK_COUNT; ++taskId) {
         getTaskInfo(taskId, &taskInfo);
@@ -489,8 +489,8 @@ static void showTasksPage(void) {
             const int averageLoad = (taskInfo.averageExecutionTime * taskFrequency + 5000) / 10000;
             tfp_sprintf(lineBuffer, format, taskId, taskInfo.maxExecutionTime, taskInfo.averageExecutionTime, maxLoad, averageLoad);
             padLineBuffer();
-            i2c_OLED_set_line(bus, rowIndex++);
-            i2c_OLED_send_string(bus, lineBuffer);
+            i2c_OLED_set_line(dev, rowIndex++);
+            i2c_OLED_send_string(dev, lineBuffer);
             if (rowIndex > SCREEN_CHARACTER_ROW_COUNT) {
                 break;
             }
@@ -505,8 +505,8 @@ static void showDebugPage(void) {
     for (int rowIndex = 0; rowIndex < 4; rowIndex++) {
         tfp_sprintf(lineBuffer, "%d = %5d", rowIndex, debug[rowIndex]);
         padLineBuffer();
-        i2c_OLED_set_line(bus, rowIndex + PAGE_TITLE_LINE_COUNT);
-        i2c_OLED_send_string(bus, lineBuffer);
+        i2c_OLED_set_line(dev, rowIndex + PAGE_TITLE_LINE_COUNT);
+        i2c_OLED_send_string(dev, lineBuffer);
     }
 }
 #endif
@@ -603,11 +603,11 @@ void dashboardInit(void) {
     static extDevice_t dashBoardBus;
     dashBoardBus.busType_u.i2c.device = I2C_CFG_TO_DEV(dashboardConfig()->device);
     dashBoardBus.busType_u.i2c.address = dashboardConfig()->address;
-    bus = &dashBoardBus;
+    dev = &dashBoardBus;
     delay(200);
     resetDisplay();
     delay(200);
-    displayPort = displayPortOledInit(bus);
+    displayPort = displayPortOledInit(dev);
 #if defined(USE_CMS)
     if (dashboardPresent) {
         cmsDisplayPortRegister(displayPort);

--- a/src/main/io/dashboard.c
+++ b/src/main/io/dashboard.c
@@ -80,7 +80,7 @@
 #define DISPLAY_UPDATE_FREQUENCY (MICROSECONDS_IN_A_SECOND / 5)
 #define PAGE_CYCLE_FREQUENCY (MICROSECONDS_IN_A_SECOND * 5)
 
-static busDevice_t *bus;
+static extDevice_t *bus;
 
 static uint32_t nextDisplayUpdateAt = 0;
 static bool dashboardPresent = false;
@@ -600,7 +600,7 @@ void dashboardUpdate(timeUs_t currentTimeUs) {
 }
 
 void dashboardInit(void) {
-    static busDevice_t dashBoardBus;
+    static extDevice_t dashBoardBus;
     dashBoardBus.busType_u.i2c.device = I2C_CFG_TO_DEV(dashboardConfig()->device);
     dashBoardBus.busType_u.i2c.address = dashboardConfig()->address;
     bus = &dashBoardBus;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -117,31 +117,31 @@ static uint8_t magInit = 0;
 #if !defined(SIMULATOR_BUILD)
 bool compassDetect(magDev_t *dev) {
     magSensor_e magHardware = MAG_NONE;
-    extDevice_t *busdev = &dev->dev;
+    extDevice_t *extDev = &dev->dev;
 #ifdef USE_MAG_DATA_READY_SIGNAL
     dev->magIntExtiTag = compassConfig()->interruptTag;
 #endif
     switch (compassConfig()->mag_bustype) {
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        busdev->busType = BUS_TYPE_I2C;
-        busdev->busType_u.i2c.device = I2C_CFG_TO_DEV(compassConfig()->mag_i2c_device);
-        busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
+        extDev->busType = BUS_TYPE_I2C;
+        extDev->busType_u.i2c.device = I2C_CFG_TO_DEV(compassConfig()->mag_i2c_device);
+        extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
 #endif
         break;
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        busdev->busType = BUS_TYPE_SPI;
-        spiBusSetInstance(busdev, spiInstanceByDevice(SPI_CFG_TO_DEV(compassConfig()->mag_spi_device)));
-        busdev->busType_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
+        extDev->busType = BUS_TYPE_SPI;
+        spiBusSetInstance(extDev, spiInstanceByDevice(SPI_CFG_TO_DEV(compassConfig()->mag_spi_device)));
+        extDev->busType_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
 #endif
         break;
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE: {
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            busdev->busType = BUS_TYPE_MPU_SLAVE;
-            busdev->busType_u.mpuSlave.master = gyroSensorBus();
-            busdev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
+            extDev->busType = BUS_TYPE_MPU_SLAVE;
+            extDev->busType_u.mpuSlave.master = gyroSensorBus();
+            extDev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
         } else {
             return false;
         }
@@ -157,8 +157,8 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_HMC5883:
 #if defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883)
-        if (busdev->busType == BUS_TYPE_I2C) {
-            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (extDev->busType == BUS_TYPE_I2C) {
+            extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (hmc5883lDetect(dev)) {
 #ifdef MAG_HMC5883_ALIGN
@@ -171,8 +171,8 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_QMC5883:
 #ifdef USE_MAG_QMC5883
-        if (busdev->busType == BUS_TYPE_I2C) {
-            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (extDev->busType == BUS_TYPE_I2C) {
+            extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (qmc5883lDetect(dev)) {
 #ifdef MAG_QMC5883L_ALIGN
@@ -185,8 +185,8 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
-        if (busdev->busType == BUS_TYPE_I2C) {
-            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (extDev->busType == BUS_TYPE_I2C) {
+            extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (ak8975Detect(dev)) {
 #ifdef MAG_AK8975_ALIGN
@@ -199,13 +199,13 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8963:
 #if defined(USE_MAG_AK8963) || defined(USE_MAG_SPI_AK8963)
-        if (busdev->busType == BUS_TYPE_I2C) {
-            busdev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
+        if (extDev->busType == BUS_TYPE_I2C) {
+            extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            busdev->busType = BUS_TYPE_MPU_SLAVE;
-            busdev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
-            busdev->busType_u.mpuSlave.master = gyroSensorBus();
+            extDev->busType = BUS_TYPE_MPU_SLAVE;
+            extDev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
+            extDev->busType_u.mpuSlave.master = gyroSensorBus();
         }
         if (ak8963Detect(dev)) {
 #ifdef MAG_AK8963_ALIGN

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -117,7 +117,7 @@ static uint8_t magInit = 0;
 #if !defined(SIMULATOR_BUILD)
 bool compassDetect(magDev_t *dev) {
     magSensor_e magHardware = MAG_NONE;
-    busDevice_t *busdev = &dev->dev;
+    extDevice_t *busdev = &dev->dev;
 #ifdef USE_MAG_DATA_READY_SIGNAL
     dev->magIntExtiTag = compassConfig()->interruptTag;
 #endif

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -325,7 +325,7 @@ PG_RESET_TEMPLATE(gyroConfig_t, gyroConfig,
 #endif //USE_GYRO_IMUF9001
 
 
-const busDevice_t *gyroSensorBus(void) {
+const extDevice_t *gyroSensorBus(void) {
 #ifdef USE_DUAL_GYRO
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2) {
         return &gyroSensor2.gyroDev.dev;
@@ -338,7 +338,7 @@ const busDevice_t *gyroSensorBus(void) {
 }
 
 #ifdef USE_GYRO_REGISTER_DUMP
-const busDevice_t *gyroSensorBusByDevice(uint8_t whichSensor) {
+const extDevice_t *gyroSensorBusByDevice(uint8_t whichSensor) {
 #ifdef USE_DUAL_GYRO
     if (whichSensor == GYRO_CONFIG_USE_GYRO_2) {
         return &gyroSensor2.gyroDev.dev;

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -192,7 +192,7 @@ void gyroDmaSpiStartRead(void);
 #endif
 void gyroUpdate(timeUs_t currentTimeUs);
 bool gyroGetAverage(quaternion *vAverage);
-const busDevice_t *gyroSensorBus(void);
+const extDevice_t *gyroSensorBus(void);
 struct mpuConfiguration_s;
 const struct mpuConfiguration_s *gyroMpuConfiguration(void);
 struct mpuDetectionResult_s;

--- a/src/test/unit/baro_bmp085_unittest.cc.txt
+++ b/src/test/unit/baro_bmp085_unittest.cc.txt
@@ -186,7 +186,7 @@ extern "C" {
     void RCC_APB2PeriphClockCmd() {}
     void delay(uint32_t) {}
     void delayMicroseconds(uint32_t) {}
-    bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
-    bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+    bool busReadRegisterBuffer(const extDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+    bool busWriteRegister(const extDevice_t*, uint8_t, uint8_t) {return true;}
 
 }

--- a/src/test/unit/baro_bmp280_unittest.cc
+++ b/src/test/unit/baro_bmp280_unittest.cc
@@ -131,8 +131,8 @@ TEST(baroBmp280Test, TestBmp280CalculateZeroP)
 extern "C" {
 
 void delay(uint32_t) {}
-bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
-bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busReadRegisterBuffer(const extDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busWriteRegister(const extDevice_t*, uint8_t, uint8_t) {return true;}
 
 void spiSetDivisor() {
 }

--- a/src/test/unit/baro_ms5611_unittest.cc
+++ b/src/test/unit/baro_ms5611_unittest.cc
@@ -146,8 +146,8 @@ extern "C" {
 void delay(uint32_t) {}
 void delayMicroseconds(uint32_t) {}
 
-bool busReadRegisterBuffer(const busDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
-bool busWriteRegister(const busDevice_t*, uint8_t, uint8_t) {return true;}
+bool busReadRegisterBuffer(const extDevice_t*, uint8_t, uint8_t*, uint8_t) {return true;}
+bool busWriteRegister(const extDevice_t*, uint8_t, uint8_t) {return true;}
 
 void spiSetDivisor() {
 }


### PR DESCRIPTION
Continuation of #1108 (phase 1, now merged).

## What this does

Three commits that complete the identifier rename started in phase 1:

- **G** (`bb15493fa5`) — sweep `busDevice_t` → `extDevice_t` across tree, keep alias
- **H** (`c7ee1f82e2`) — rename `bus`/`busdev` parameter and body identifiers to `dev`
- **H-bis** (`948ba74024`) — drop the transitional `busDevice_t` typedef alias

No logic changes. After this series every driver signature and body uses `extDevice_t *dev` consistently, matching BF 4.5-maintenance naming.

## Testing

- Hover-tested on **FOXEERF722V4** (STM32F7, MPU6000) at phase 2 tip (pre-rebase SHA; same code)
- Build-verified on FOXEERF405, PYRODRONEF7, SKYSTARSF405AIO, HELIOSPRING

## Relationship to later phases

Phase 3 (`refactor/extDevice_t-bus-split`) adds the bus-resource split infrastructure and is waiting for this to merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated device abstraction API and interfaces across sensor drivers (gyroscope, accelerometer, barometer, compass), bus implementations (SPI, I2C), and peripheral drivers (flash, display, receiver) to use a standardized device structure for consistent hardware abstraction throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->