### PR TITLE
refactor(bus): Stage L-drivers - spiSetBusInstance BF-convention

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -291,18 +291,18 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
 
 void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance) {
     SPIDevice device = spiDeviceByInstance(instance);
-    if (device != SPIINVALID) {
-        (void)spiSetBusInstance(dev, SPI_DEV_TO_CFG(device));
+    if (device != SPIINVALID && spiSetBusInstance(dev, SPI_DEV_TO_CFG(device))) {
         return;
     }
-    // Instance does not map to a known SPI peripheral on this target
-    // (e.g. target.h references SPI1 but USE_SPI_DEVICE_1 is disabled).
-    // Preserve pre-Stage-L behaviour: set busType and cache the inline
-    // instance pointer; leave dev->bus NULL so Stage I.3+ code that
-    // dereferences dev->bus hits a clear null deref rather than a silent
-    // wrong-peripheral access.
+    // Forwarding failed: either the instance does not map to a known SPI
+    // peripheral (e.g. target.h references SPI1 but USE_SPI_DEVICE_1 is
+    // disabled) or spiSetBusInstance rejected the device id. Preserve
+    // pre-Stage-L behaviour: set busType and cache the inline instance
+    // pointer; clear dev->bus so Stage I.3+ code that dereferences it
+    // hits a clean null deref rather than a silent stale-bus access.
     dev->busType = BUS_TYPE_SPI;
     dev->busType_u.spi.instance = instance;
+    dev->bus = NULL;
 }
 
 // icm42688p and bmi270 porting

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -271,15 +271,38 @@ FAST_CODE uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg) {
 #endif
 }
 
-void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance) {
+// Mark this bus as being SPI given a 1-based CLI device id (BF 4.5-maintenance
+// convention). Validates device range, looks up the SPI_TypeDef via
+// spiInstanceByDevice, and wires both the inline extDevice_t.busType_u.spi
+// fields and the dev->bus back-pointer populated by spiInit().
+bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
+    if ((device == 0) || (device > SPIDEV_COUNT)) {
+        return false;
+    }
+    SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(device));
+    if (instance == NULL) {
+        return false;
+    }
     dev->busType = BUS_TYPE_SPI;
     dev->busType_u.spi.instance = instance;
-    // Wire the bus-abstraction back-pointer. spiInit() must have already
-    // populated spiBusDevice[] for this peripheral; if the caller passes an
-    // instance that does not map to a known SPI device, bus stays NULL and
-    // callers that rely on dev->bus will hit a clear null deref at first
-    // use rather than a silent wrong-peripheral access.
-    dev->bus = spiBusByDevice(spiDeviceByInstance(instance));
+    dev->bus = spiBusByDevice(SPI_CFG_TO_DEV(device));
+    return true;
+}
+
+void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance) {
+    SPIDevice device = spiDeviceByInstance(instance);
+    if (device != SPIINVALID) {
+        (void)spiSetBusInstance(dev, SPI_DEV_TO_CFG(device));
+        return;
+    }
+    // Instance does not map to a known SPI peripheral on this target
+    // (e.g. target.h references SPI1 but USE_SPI_DEVICE_1 is disabled).
+    // Preserve pre-Stage-L behaviour: set busType and cache the inline
+    // instance pointer; leave dev->bus NULL so Stage I.3+ code that
+    // dereferences dev->bus hits a clear null deref rather than a silent
+    // wrong-peripheral access.
+    dev->busType = BUS_TYPE_SPI;
+    dev->busType_u.spi.instance = instance;
 }
 
 // icm42688p and bmi270 porting

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -122,6 +122,20 @@ bool spiReadWriteBuf(const extDevice_t *dev, const uint8_t *txData, uint8_t *rxD
 bool spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data);
 bool spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg);
+
+// Mark an extDevice_t as belonging to an SPI bus, using the 1-based CLI
+// device id (1 == SPI1, 2 == SPI2, ...). Matches Betaflight 4.5-maintenance
+// spiSetBusInstance signature so callers that already carry the config id
+// can stop round-tripping through spiInstanceByDevice. Returns false if
+// device is 0 (disabled) or out of range, or if the peripheral slot is
+// not backed by a real SPI_TypeDef on this target.
+bool spiSetBusInstance(extDevice_t *dev, uint32_t device);
+
+// Legacy SPI_TypeDef*-based entry point. Thin forwarder over
+// spiSetBusInstance(). Still used by 12 Pattern-A call sites in
+// gyro.c / accgyro_mpu.c that pass target.h MACRO_SPI_INSTANCE tokens
+// (raw SPI1/SPI2/...). Scheduled for removal once Stage L.2 migrates
+// target macros to *_SPI_BUS integer ids.
 void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance);
 
 struct spiPinConfig_s;

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -52,12 +52,9 @@ bool flashInit(const flashConfig_t *flashConfig) {
     if (!IOIsFreeOrPreinit(dev->busType_u.spi.csnPin)) {
         return false;
     }
-    dev->busType = BUS_TYPE_SPI;
-    SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(flashConfig->spiDevice));
-    if (!instance) {
+    if (!spiSetBusInstance(dev, flashConfig->spiDevice)) {
         return false;
     }
-    spiBusSetInstance(dev, instance);
     IOInit(dev->busType_u.spi.csnPin, OWNER_FLASH_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -395,7 +395,9 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     IOInit(dev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
-    spiSetBusInstance(dev, max7456Config->spiDevice);
+    if (!spiSetBusInstance(dev, max7456Config->spiDevice)) {
+        return false;
+    }
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
     spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -395,7 +395,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     IOInit(dev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
-    spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
+    spiSetBusInstance(dev, max7456Config->spiDevice);
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
     spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -393,7 +393,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     IOInit(dev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
-    spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(max7456Config->spiDevice)));
+    spiSetBusInstance(dev, max7456Config->spiDevice);
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
     spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -393,7 +393,9 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     IOInit(dev->busType_u.spi.csnPin, OWNER_OSD_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
-    spiSetBusInstance(dev, max7456Config->spiDevice);
+    if (!spiSetBusInstance(dev, max7456Config->spiDevice)) {
+        return false;
+    }
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
     spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -48,10 +48,9 @@ static extDevice_t *dev = &rxSpiDevice;
 #define ENABLE_RX()     {IOLo(dev->busType_u.spi.csnPin);}
 
 bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig) {
-    if (!rxSpiConfig->spibus) {
+    if (!spiSetBusInstance(dev, rxSpiConfig->spibus)) {
         return false;
     }
-    spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(rxSpiConfig->spibus)));
     const IO_t rxCsPin = IOGetByTag(rxSpiConfig->csnTag);
     IOInit(rxCsPin, OWNER_RX_SPI_CS, 0);
     IOConfigGPIO(rxCsPin, SPI_IO_CS_CFG);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -159,7 +159,7 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse) {
     case BUS_TYPE_SPI:
 #ifdef USE_SPI
         dev->dev.busType = BUS_TYPE_SPI;
-        spiBusSetInstance(&dev->dev, spiInstanceByDevice(SPI_CFG_TO_DEV(barometerConfig()->baro_spi_device)));
+        spiSetBusInstance(&dev->dev, barometerConfig()->baro_spi_device);
         dev->dev.busType_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
 #endif
         break;

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -158,8 +158,9 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse) {
         break;
     case BUS_TYPE_SPI:
 #ifdef USE_SPI
-        dev->dev.busType = BUS_TYPE_SPI;
-        spiSetBusInstance(&dev->dev, barometerConfig()->baro_spi_device);
+        if (!spiSetBusInstance(&dev->dev, barometerConfig()->baro_spi_device)) {
+            return false;
+        }
         dev->dev.busType_u.spi.csnPin = IOGetByTag(barometerConfig()->baro_spi_csn);
 #endif
         break;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -132,7 +132,7 @@ bool compassDetect(magDev_t *dev) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
         extDev->busType = BUS_TYPE_SPI;
-        spiBusSetInstance(extDev, spiInstanceByDevice(SPI_CFG_TO_DEV(compassConfig()->mag_spi_device)));
+        spiSetBusInstance(extDev, compassConfig()->mag_spi_device);
         extDev->busType_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
 #endif
         break;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -131,8 +131,9 @@ bool compassDetect(magDev_t *dev) {
         break;
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        extDev->busType = BUS_TYPE_SPI;
-        spiSetBusInstance(extDev, compassConfig()->mag_spi_device);
+        if (!spiSetBusInstance(extDev, compassConfig()->mag_spi_device)) {
+            return false;
+        }
         extDev->busType_u.spi.csnPin = IOGetByTag(compassConfig()->mag_spi_csn);
 #endif
         break;


### PR DESCRIPTION
## Summary

Fourth in a series of refactors aligning EmuFlight's bus / `extDevice_t` architecture with Betaflight 4.5-maintenance. Builds on #1108 (naming), #1111 (type sweep), #1113 (SPI bus-resource split).

This PR introduces the Betaflight-convention `spiSetBusInstance(extDevice_t *dev, uint32_t device)` entry point (id-based, returns `bool`) and migrates six drivers to use it. EmuFlight's existing `spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *)` is reimplemented as a thin forwarder — the remaining 12 call sites (`gyro.c`, `accgyro_mpu.c`) keep using the legacy `MACRO_SPI_INSTANCE` pattern for now and will migrate in a later stage.

### What changes

- **`src/main/drivers/bus_spi.h`** — declare `bool spiSetBusInstance(extDevice_t *, uint32_t)`; existing `void spiBusSetInstance(extDevice_t *, SPI_TypeDef *)` kept for transitional callers.
- **`src/main/drivers/bus_spi.c`** — implement `spiSetBusInstance` with BF's validation (`device == 0 || device > SPIDEV_COUNT → false`). Reimplement `spiBusSetInstance` as a thin forwarder (`spiDeviceByInstance → SPI_DEV_TO_CFG → spiSetBusInstance`), with a fallback path for `SPIINVALID` that preserves pre-Stage-L behaviour (set busType + inline instance, leave `dev->bus` NULL).
- **`src/main/sensors/barometer.c`**, **`src/main/sensors/compass.c`**, **`src/main/drivers/max7456.c`**, **`src/main/drivers/nbd7456.c`** — collapse `spiBusSetInstance(dev, spiInstanceByDevice(SPI_CFG_TO_DEV(config->X)))` round-trips into `spiSetBusInstance(dev, config->X)`.
- **`src/main/drivers/rx/rx_spi.c`** — collapse `if (!spibus) return false; spiBusSetInstance(...)` into `if (!spiSetBusInstance(dev, rxSpiConfig->spibus)) return false;` (new function rejects `device == 0`, replacing the manual guard).
- **`src/main/drivers/flash.c`** — collapse manual `spiInstanceByDevice` / NULL-check / `spiBusSetInstance` into `if (!spiSetBusInstance(dev, flashConfig->spiDevice)) return false;`.

**Intentionally unchanged** — Pattern-A gyro/accgyro call sites in `gyro.c` and `accgyro_mpu.c` (12 sites). They still call `spiBusSetInstance(&gyro->dev, MACRO_SPI_INSTANCE)` and route through the forwarder unchanged. A follow-up stage will migrate the target.h macros from `*_SPI_INSTANCE SPIn` to `*_SPI_BUS SPIDEV_n` across ~200 targets and switch these call sites to the new signature — mass-sed + per-target bench work, deferred to keep this PR reviewable.

**No target.h changes in this PR.**

## Verification

**Build matrix** (`CCACHE_DISABLE=1`, zero new compiler warnings, zero errors):

- `make test` PASS (38 binaries)
- `HELIOSPRING` (STM32F7, IMUF9001)
- `TUNERCF405` (STM32F405 — I.4 brick-victim gate)
- `SKYSTARSF405AIO` (STM32F405, BMI270)
- `PYRODRONEF7` (STM32F7, MPU6000)
- `MATEKF411` (STM32F411)
- `NBDHMBF4PRO` (STM32F405, `nbd7456.c`)
- `FOXEERF722V4` (STM32F722)

**Bench verification** (2026-04-21):

- **HELIOSPRING** — PASS.
- **TUNERCF405** — PASS. Brick-victim gate cleared (precommit bench, then re-verified at commit).
- **SKYSTARSF405AIO** — PASS.
- **PYRODRONEF7** — PASS.
- **FOXEERF405** — PASS.

Five-target bench across three MCU families (F4 / F7 / F7-IMUF) and two gyro families (MPU-series + BMI270) — matches the phase-3 bench matrix breadth.

## Why this approach

EmuFlight's pre-refactor entry point took an `SPI_TypeDef *` instance pointer derived from `*_SPI_INSTANCE` target.h macros. Betaflight's takes a config-form id directly. Migrating the driver call sites (where the caller already holds the config id) removes four of the six round-trips through `spiInstanceByDevice(SPI_CFG_TO_DEV(...))`; the other two (`rx_spi`, `flash`) also got manual NULL-guard cleanup that's now covered by the new function's validation.

Keeping the legacy `spiBusSetInstance(extDevice_t *, SPI_TypeDef *)` as a forwarder means the 12 remaining Pattern-A call sites (which use `MACRO_SPI_INSTANCE` pointer expansions) still compile unchanged. A future stage will sweep the target.h macros and retire the forwarder.

## Test plan

- [x] `make test`
- [x] Seven-target build matrix with zero warnings
- [x] TUNERCF405 bench (brick-victim gate)
- [x] HELIOSPRING bench
- [x] SKYSTARSF405AIO bench
- [x] PYRODRONEF7 bench
- [x] FOXEERF405 bench

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal SPI bus initialization logic to centralize device validation and improve code maintainability across multiple drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->