### PR TITLE
refactor(bus): Stage J - I2C bus-resource split (infra + 3 sites)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -34,6 +34,7 @@
 
 #include "drivers/bus.h"
 #include "drivers/bus_i2c.h"
+#include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
@@ -432,7 +433,7 @@ void mpuDetect(gyroDev_t *gyro) {
         gyro->dev.busType = BUS_TYPE_I2C;
     }
     if (gyro->dev.busType == BUS_TYPE_I2C) {
-        gyro->dev.busType_u.i2c.device = MPU_I2C_INSTANCE;
+        i2cBusSetInstance(&gyro->dev, I2C_DEV_TO_CFG(MPU_I2C_INSTANCE));
         gyro->dev.busType_u.i2c.address = MPU_ADDRESS;
         uint8_t sig = 0;
         bool ack = busReadRegisterBuffer(&gyro->dev, MPU_RA_WHO_AM_I, &sig, 1);

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -42,4 +42,26 @@ uint8_t i2cBusReadRegister(const extDevice_t *dev, uint8_t reg) {
     i2cRead(dev->busType_u.i2c.device, dev->busType_u.i2c.address, reg, 1, &data);
     return data;
 }
+
+bool i2cBusSetInstance(extDevice_t *dev, uint32_t device)
+{
+    // I2C bus-resource array; function-local static matches BF 4.5-maintenance
+    // layout (bus_i2c_busdev.c:i2cBusSetInstance). Persistent across calls.
+    static busDevice_t i2cBus[I2CDEV_COUNT];
+
+    if ((device < 1) || (device > I2CDEV_COUNT)) {
+        return false;
+    }
+
+    dev->bus = &i2cBus[I2C_CFG_TO_DEV(device)];
+    dev->bus->busType = BUS_TYPE_I2C;
+    dev->bus->busType_u.i2c.device = I2C_CFG_TO_DEV(device);
+
+    // Transitional: keep inline fields authoritative until access-site
+    // migration lands. EmuFlight's i2cBus* accessors still read inline.
+    dev->busType = BUS_TYPE_I2C;
+    dev->busType_u.i2c.device = I2C_CFG_TO_DEV(device);
+
+    return true;
+}
 #endif

--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -23,3 +23,9 @@
 bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
 bool i2cBusReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t i2cBusReadRegister(const extDevice_t *dev, uint8_t reg);
+// Associate a device with an I2C bus (BF 4.5-maintenance signature). device
+// is 1-indexed CFG form (1..I2CDEV_COUNT); returns false on out-of-range.
+// Populates dev->bus back-pointer AND inline dev->busType / busType_u.i2c.device
+// so both BF-sourced access paths and EmuFlight's existing inline accessors
+// resolve. Inline address is caller's responsibility.
+bool i2cBusSetInstance(extDevice_t *dev, uint32_t device);

--- a/src/main/sensors/barometer.c
+++ b/src/main/sensors/barometer.c
@@ -30,6 +30,7 @@
 #include "pg/pg_ids.h"
 
 #include "drivers/bus.h"
+#include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
 #include "drivers/io.h"
 
@@ -151,8 +152,7 @@ bool baroDetect(baroDev_t *dev, baroSensor_e baroHardwareToUse) {
     switch (barometerConfig()->baro_bustype) {
     case BUS_TYPE_I2C:
 #ifdef USE_I2C
-        dev->dev.busType = BUS_TYPE_I2C;
-        dev->dev.busType_u.i2c.device = I2C_CFG_TO_DEV(barometerConfig()->baro_i2c_device);
+        i2cBusSetInstance(&dev->dev, barometerConfig()->baro_i2c_device);
         dev->dev.busType_u.i2c.address = barometerConfig()->baro_i2c_address;
 #endif
         break;

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -33,6 +33,7 @@
 #include "drivers/bus_i2c.h"
 #include "drivers/bus_spi.h"
 #include "drivers/bus.h"
+#include "drivers/bus_i2c_busdev.h"
 #include "drivers/accgyro/accgyro_mpu.h"
 #include "drivers/compass/compass.h"
 #include "drivers/compass/compass_ak8975.h"
@@ -124,8 +125,7 @@ bool compassDetect(magDev_t *dev) {
     switch (compassConfig()->mag_bustype) {
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
-        extDev->busType = BUS_TYPE_I2C;
-        extDev->busType_u.i2c.device = I2C_CFG_TO_DEV(compassConfig()->mag_i2c_device);
+        i2cBusSetInstance(extDev, compassConfig()->mag_i2c_device);
         extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
 #endif
         break;


### PR DESCRIPTION
## Summary

Fifth in a series of refactors aligning EmuFlight's bus / `extDevice_t` architecture with Betaflight 4.5-maintenance. Builds on #1108 (naming), #1111 (type sweep), #1113 (SPI bus-resource split), #1114 (SPI init-site migration).

This PR introduces the Betaflight-convention `i2cBusSetInstance(extDevice_t *dev, uint32_t device)` entry point and migrates the three I2C init sites (baro, compass, MPU-slave-over-I2C) to use it. It is the I2C parallel of phase 3's SPI infra (#1113) plus Stage L-drivers' init-site migration (#1114), combined into one PR because the I2C call-site count is small.

### What changes

- **`src/main/drivers/bus_i2c_busdev.h`** — declare `bool i2cBusSetInstance(extDevice_t *, uint32_t)`. Matches BF 4.5 signature exactly.
- **`src/main/drivers/bus_i2c_busdev.c`** — implement `i2cBusSetInstance`: function-local `static busDevice_t i2cBus[I2CDEV_COUNT]` (matches BF layout — BF uses function-local for I2C and file-global for SPI). Validates `device` is in `1..I2CDEV_COUNT`; returns `false` out of range. Populates BOTH `dev->bus->*` (BF-parity) AND inline `dev->busType` + `dev->busType_u.i2c.device` (transitional — EmuFlight's existing `i2cBus*` accessors still read inline fields).
- **`src/main/sensors/barometer.c`** — replace `busType = BUS_TYPE_I2C; busType_u.i2c.device = I2C_CFG_TO_DEV(...)` writes with `i2cBusSetInstance(&dev->dev, barometerConfig()->baro_i2c_device)`. Address write remains inline.
- **`src/main/sensors/compass.c`** — same pattern. Also reorders the `bus_i2c_busdev.h` include to come after `bus.h` (header is not self-contained — uses `extDevice_t` without including `bus.h`; same latent issue as BF 4.5-maintenance; per the scope-boundary rule from #1111, fixed the caller, filed the header fix as #1115).
- **`src/main/drivers/accgyro/accgyro_mpu.c`** — same pattern for the I2C-over-MPU init path. `MPU_I2C_INSTANCE` is in 0-indexed DEV form (`I2CDEV_1` = 0), wrapped with `I2C_DEV_TO_CFG()` for the 1-indexed parameter.

**Intentionally unchanged:**

- `io/dashboard.c` (`dashBoardBus`) — never goes through `busRead/Write` dispatch (the OLED driver reads inline fields directly via `i2cWrite`), so migrating would add risk for no BF-paste value.
- Access-site migration of `i2cBusWriteRegister` / `i2cBusReadRegisterBuffer` / `i2cBusReadRegister` from inline `dev->busType_u.i2c.device` to `dev->bus->busType_u.i2c.device`. This is the I2C equivalent of Stage I.4's SPI field removal — same brick class — deferred until a reproducible hypothesis exists (see phase-3 post-mortem referenced in #1113).

**No target.h changes in this PR.**

## Verification

**Build matrix** (`CCACHE_DISABLE=1`, zero new compiler warnings, zero errors):

- `make test` PASS (38 binaries)
- `HELIOSPRING` (STM32F7, IMUF9001)
- `TUNERCF405` (STM32F405 — I.4 brick-victim gate)
- `SKYSTARSF405AIO` (STM32F405, BMI270)
- `PYRODRONEF7` (STM32F7, MPU6000)
- `MATEKF411` (STM32F411)
- `NBDHMBF4PRO` (STM32F405)
- `FOXEERF722V4` (STM32F722)
- `FOXEERF405` (STM32F405)

**Bench verification** (2026-04-22, pre-commit on content-equivalent tree):

- **HELIOSPRING** — PASS.
- **TUNERCF405** — PASS. Brick-victim gate cleared.
- **SKYSTARSF405AIO** — PASS.
- **PYRODRONEF7** — PASS.
- **FOXEERF405** — PASS.

Five-target bench across three MCU families (F4 / F7 / F7-IMUF) and two gyro families (MPU-series + BMI270) — same matrix as #1113 and #1114.

## Why this approach

Phase 3 (#1113) added the infrastructure for BF's split-bus architecture on the SPI side; Stage L-drivers (#1114) migrated the SPI init sites to the BF-convention `spiSetBusInstance`. This PR applies the same pattern to I2C — but because the I2C init-site count is small (3 sites, all `busType` + `.i2c.device` double-writes at init), the infra and the call-site migration are bundled into one PR rather than split across two as on the SPI side.

Keeping the inline `busType_u.i2c.device` writes alongside the new `dev->bus->` population means existing EmuFlight `i2cBus*` accessors (which still read inline) work unchanged, and BF-sourced driver code that reads `dev->bus->busType_u.i2c.device` also resolves. A future stage will migrate the access sites — deferred per the Stage I.4 risk class.

## Test plan

- [x] \`make test\`
- [x] Eight-target build matrix with zero warnings
- [x] TUNERCF405 bench (brick-victim gate)
- [x] HELIOSPRING bench
- [x] SKYSTARSF405AIO bench
- [x] PYRODRONEF7 bench
- [x] FOXEERF405 bench

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined I2C device initialization across sensor drivers for improved code consistency and maintainability. Internal infrastructure updates with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->