### PR TITLE
refactor(bus): Stage L.2 - rename gyro *_SPI_INSTANCE to *_SPI_BUS + remove forwarder

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -279,7 +279,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     // note, when USE_DUAL_GYRO is enabled the gyro->dev must already be initialised.
 #ifdef USE_GYRO_SPI_MPU6000
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->dev, MPU6000_SPI_INSTANCE);
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(MPU6000_SPI_BUS));
 #endif
 #ifdef MPU6000_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6000_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -292,7 +292,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_MPU6500
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->dev, MPU6500_SPI_INSTANCE);
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(MPU6500_SPI_BUS));
 #endif
 #ifdef MPU6500_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU6500_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -305,8 +305,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_IMUF9001
-#ifdef IMUF9001_SPI_INSTANCE
-    spiBusSetInstance(&gyro->dev, IMUF9001_SPI_INSTANCE);
+#ifdef IMUF9001_SPI_BUS
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(IMUF9001_SPI_BUS));
 #else
 #error IMUF9001 is SPI only
 #endif
@@ -329,7 +329,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef  USE_GYRO_SPI_MPU9250
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->dev, MPU9250_SPI_INSTANCE);
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(MPU9250_SPI_BUS));
 #endif
 #ifdef MPU9250_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(MPU9250_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -342,8 +342,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_SPI_ICM20649
-#ifdef ICM20649_SPI_INSTANCE
-    spiBusSetInstance(&gyro->dev, ICM20649_SPI_INSTANCE);
+#ifdef ICM20649_SPI_BUS
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM20649_SPI_BUS));
 #endif
 #ifdef ICM20649_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20649_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -356,7 +356,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_GYRO_SPI_ICM20689
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->dev, ICM20689_SPI_INSTANCE);
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM20689_SPI_BUS));
 #endif
 #ifdef ICM20689_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20689_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -369,8 +369,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_SPI_ICM42605
-#ifdef ICM42605_SPI_INSTANCE
-    spiBusSetInstance(&gyro->dev, ICM42605_SPI_INSTANCE);
+#ifdef ICM42605_SPI_BUS
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM42605_SPI_BUS));
 #endif
 #ifdef ICM42605_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42605_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -382,8 +382,8 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_SPI_ICM42688P
-#ifdef ICM42688P_SPI_INSTANCE
-    spiBusSetInstance(&gyro->dev, ICM42688P_SPI_INSTANCE);
+#ifdef ICM42688P_SPI_BUS
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM42688P_SPI_BUS));
 #endif
 #ifdef ICM42688P_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42688P_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -396,7 +396,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_ACCGYRO_BMI160
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->dev, BMI160_SPI_INSTANCE);
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(BMI160_SPI_BUS));
 #endif
 #ifdef BMI160_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI160_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -409,7 +409,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
 #endif
 #ifdef USE_ACCGYRO_BMI270
 #ifndef USE_DUAL_GYRO
-    spiBusSetInstance(&gyro->dev, BMI270_SPI_INSTANCE);
+    spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(BMI270_SPI_BUS));
 #endif
 #ifdef BMI270_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(BMI270_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -57,7 +57,7 @@ typedef struct busDevice_s {
 } busDevice_t;
 
 // Per-device struct. Carries a back-pointer to the shared busDevice_t
-// (populated by spiBusSetInstance for SPI devices; NULL for I2C and
+// (populated by spiSetBusInstance for SPI devices; NULL for I2C and
 // MPU-slave devices until their bus-resource split lands). The inline
 // instance/device fields are still present and authoritative in this
 // sub-commit; Stage I.4 migrates access sites to prefer dev->bus.

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -289,21 +289,6 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
     return true;
 }
 
-void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance) {
-    SPIDevice device = spiDeviceByInstance(instance);
-    if (device != SPIINVALID && spiSetBusInstance(dev, SPI_DEV_TO_CFG(device))) {
-        return;
-    }
-    // Forwarding failed: either the instance does not map to a known SPI
-    // peripheral (e.g. target.h references SPI1 but USE_SPI_DEVICE_1 is
-    // disabled) or spiSetBusInstance rejected the device id. Preserve
-    // pre-Stage-L behaviour: set busType and cache the inline instance
-    // pointer; clear dev->bus so Stage I.3+ code that dereferences it
-    // hits a clean null deref rather than a silent stale-bus access.
-    dev->busType = BUS_TYPE_SPI;
-    dev->busType_u.spi.instance = instance;
-    dev->bus = NULL;
-}
 
 // icm42688p and bmi270 porting
 uint16_t spiCalculateDivider(uint32_t freq)

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -131,12 +131,6 @@ uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg);
 // not backed by a real SPI_TypeDef on this target.
 bool spiSetBusInstance(extDevice_t *dev, uint32_t device);
 
-// Legacy SPI_TypeDef*-based entry point. Thin forwarder over
-// spiSetBusInstance(). Still used by 12 Pattern-A call sites in
-// gyro.c / accgyro_mpu.c that pass target.h MACRO_SPI_INSTANCE tokens
-// (raw SPI1/SPI2/...). Scheduled for removal once Stage L.2 migrates
-// target macros to *_SPI_BUS integer ids.
-void spiBusSetInstance(extDevice_t *dev, SPI_TypeDef *instance);
 
 struct spiPinConfig_s;
 void spiPinConfigure(const struct spiPinConfig_s *pConfig);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -701,7 +701,9 @@ bool gyroInit(void) {
     gyroSensor1.gyroDev.gyroAlign = GYRO_1_ALIGN;
 #endif
     gyroSensor1.gyroDev.dev.busType = BUS_TYPE_SPI;
-    spiSetBusInstance(&gyroSensor1.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_1_SPI_BUS));
+    if (!spiSetBusInstance(&gyroSensor1.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_1_SPI_BUS))) {
+        gyroSensor1.gyroDev.dev.busType = BUS_TYPE_NONE;
+    }
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor1);
         if (!ret) {
@@ -726,7 +728,9 @@ bool gyroInit(void) {
     gyroSensor2.gyroDev.gyroAlign = GYRO_2_ALIGN;
 #endif
     gyroSensor2.gyroDev.dev.busType = BUS_TYPE_SPI;
-    spiSetBusInstance(&gyroSensor2.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_2_SPI_BUS));
+    if (!spiSetBusInstance(&gyroSensor2.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_2_SPI_BUS))) {
+        gyroSensor2.gyroDev.dev.busType = BUS_TYPE_NONE;
+    }
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor2);
         if (!ret) {

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -701,7 +701,7 @@ bool gyroInit(void) {
     gyroSensor1.gyroDev.gyroAlign = GYRO_1_ALIGN;
 #endif
     gyroSensor1.gyroDev.dev.busType = BUS_TYPE_SPI;
-    spiBusSetInstance(&gyroSensor1.gyroDev.dev, GYRO_1_SPI_INSTANCE);
+    spiSetBusInstance(&gyroSensor1.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_1_SPI_BUS));
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor1);
         if (!ret) {
@@ -726,7 +726,7 @@ bool gyroInit(void) {
     gyroSensor2.gyroDev.gyroAlign = GYRO_2_ALIGN;
 #endif
     gyroSensor2.gyroDev.dev.busType = BUS_TYPE_SPI;
-    spiBusSetInstance(&gyroSensor2.gyroDev.dev, GYRO_2_SPI_INSTANCE);
+    spiSetBusInstance(&gyroSensor2.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_2_SPI_BUS));
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor2);
         if (!ret) {


### PR DESCRIPTION
## Summary

- Renames all 12 gyro-specific `*_SPI_INSTANCE` macro families to `*_SPI_BUS` across 353 `target.h` files (e.g. `GYRO_1_SPI_INSTANCE SPI1` → `GYRO_1_SPI_BUS SPIDEV_1`, `MPU6000_SPI_INSTANCE SPI3` → `MPU6000_SPI_BUS SPIDEV_3`)
- Migrates the 12 Pattern-A call sites in `gyro.c` + `accgyro_mpu.c` from `spiBusSetInstance(dev, MACRO_SPI_INSTANCE)` → `spiSetBusInstance(dev, SPI_DEV_TO_CFG(MACRO_SPI_BUS))`; updates 4 `#ifdef MACRO_SPI_INSTANCE` guards to `#ifdef MACRO_SPI_BUS`
- Deletes the temporary `spiBusSetInstance(extDevice_t *, SPI_TypeDef *)` forwarder added in Stage L-drivers (#1114) — no callers remain

## Why

After this stage, EmuFlight target files use `GYRO_1_SPI_BUS SPIDEV_1` — matching Betaflight 4.5-m target naming. New BF target configs now paste without renaming the gyro SPI macro. This completes the goal of Stage L-drivers: the forwarder was always a temporary shim to allow incremental migration.

Non-gyro macros (`MAX7456_SPI_INSTANCE`, `FLASH_SPI_INSTANCE`, `SDCARD_SPI_INSTANCE`, `RX_SPI_INSTANCE`, `BMP280_SPI_INSTANCE`, `BARO_SPI_INSTANCE`) are **not renamed** — their non-target call sites in `pg/*.c` and `bus_spi_*.c` still pass `SPI_TypeDef *` and are out of this stage's scope.

## Special cases

- **DARWINF722HD**: `GYRO_2_SPI_BUS SPIINVALID` (was `false`; `SPI_DEV_TO_CFG(-1) = 0` causes `spiSetBusInstance` to return false, preserving the old NULL-bus fallback path)
- **REVO**: `ICM20601_SPI_INSTANCE SPI1` → `ICM20601_SPI_BUS SPIDEV_1` (target-only alias not in the 12-family list; `GYRO_2_SPI_BUS` chains through it)

## Part of extDevice_t refactor series

#1108 → #1111 → #1113 → #1114 (L-drivers) → #1116 (J) → #1117 (K) → **this PR (L.2)**

## Test plan

- [x] `make test`: 38/38 binaries PASS, 0 FAIL
- [x] 9-target build zero warnings: HELIOSPRING, TUNERCF405 (brick-victim gate), SKYSTARSF405AIO, PYRODRONEF7, MATEKF411, NBDHMBF4PRO, FOXEERF722V4, FOXEERF405, ALIENFLIGHTF4 (added for `USE_MAG_AK8963`+`USE_GYRO_SPI_MPU9250` coverage per Stage K CI lesson)
- [x] Bench PASS: all 5 unsoldered FCs (HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized SPI bus configuration for gyroscope and accelerometer sensors, removing legacy instance-based fallback.
  * Sensor detection and initialization now use a single bus-selection method; failed bus configuration will mark the sensor as unavailable, improving detection accuracy and reducing inconsistent sensor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->