### PR TITLE
refactor(bus): Stage M - DMA infrastructure scaffold (BF 4.5-maintenance parity)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -261,7 +261,7 @@ FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
 FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     uint8_t data[7];
-    const bool ack = spiReadWriteBuf(&gyro->dev, dataToSend, data, 7);
+    const bool ack = spiReadWriteBufRB(&gyro->dev, (uint8_t *)dataToSend, data, 7);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -102,10 +102,10 @@ uint8_t bmi160Detect(const extDevice_t *dev) {
 #endif
     spiSetDivisor(dev->busType_u.spi.instance, BMI160_SPI_DIVISOR);
     /* Read this address to activate SPI (see p. 84) */
-    spiReadReg(dev, 0x7F);
+    spiReadRegMsk(dev, 0x7F);
     delay(100); // Give SPI some time to start up
     /* Check the chip ID */
-    if (spiReadReg(dev, BMI160_REG_CHIPID) != 0xd1) {
+    if (spiReadRegMsk(dev, BMI160_REG_CHIPID) != 0xd1) {
         return MPU_NONE;
     }
     BMI160Detected = true;
@@ -144,7 +144,7 @@ static int32_t BMI160_Config(const extDevice_t *dev) {
     spiWriteReg(dev, BMI160_REG_CMD, BMI160_PMU_CMD_PMU_ACC_NORMAL);
     delay(5); // can take up to 3.8ms
     // Verify that normal power mode was entered
-    uint8_t pmu_status = spiReadReg(dev, BMI160_REG_PMU_STAT);
+    uint8_t pmu_status = spiReadRegMsk(dev, BMI160_REG_PMU_STAT);
     if ((pmu_status & 0x3C) != 0x14) {
         return -3;
     }
@@ -160,7 +160,7 @@ static int32_t BMI160_Config(const extDevice_t *dev) {
     spiWriteReg(dev, BMI160_REG_GYR_RANGE, BMI160_RANGE_2000DPS);
     delay(1);
     // Enable offset compensation
-    uint8_t val = spiReadReg(dev, BMI160_REG_OFFSET_0);
+    uint8_t val = spiReadRegMsk(dev, BMI160_REG_OFFSET_0);
     spiWriteReg(dev, BMI160_REG_OFFSET_0, val | 0xC0);
     // Enable data ready interrupt
     spiWriteReg(dev, BMI160_REG_INT_EN1, BMI160_INT_EN1_DRDY);
@@ -182,7 +182,7 @@ static int32_t BMI160_do_foc(const extDevice_t *dev) {
     spiWriteReg(dev, BMI160_REG_CMD, BMI160_CMD_START_FOC);
     // Wait for FOC to complete
     for (int i = 0; i < 50; i++) {
-        val = spiReadReg(dev, BMI160_REG_STATUS);
+        val = spiReadRegMsk(dev, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_FOC_RDY) {
             break;
         }
@@ -192,12 +192,12 @@ static int32_t BMI160_do_foc(const extDevice_t *dev) {
         return -3;
     }
     // Program NVM
-    val = spiReadReg(dev, BMI160_REG_CONF);
+    val = spiReadRegMsk(dev, BMI160_REG_CONF);
     spiWriteReg(dev, BMI160_REG_CONF, val | BMI160_REG_CONF_NVM_PROG_EN);
     spiWriteReg(dev, BMI160_REG_CMD, BMI160_CMD_PROG_NVM);
     // Wait for NVM programming to complete
     for (int i = 0; i < 50; i++) {
-        val = spiReadReg(dev, BMI160_REG_STATUS);
+        val = spiReadRegMsk(dev, BMI160_REG_STATUS);
         if (val & BMI160_REG_STATUS_NVM_RDY) {
             break;
         }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -150,7 +150,7 @@ static uint8_t bmi270RegisterRead(const extDevice_t *dev, bmi270Register_e regis
 {
     uint8_t data[2] = { 0, 0 };
 
-    if (spiReadRegBuf(dev, registerId, data, 2)) {
+    if (spiReadRegMskBufRB(dev, registerId, data, 2)) {
         return data[1];
     } else {
         return 0;

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -63,7 +63,7 @@ uint8_t icm20649SpiDetect(const extDevice_t *dev) {
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(dev, ICM20649_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadRegMsk(dev, ICM20649_RA_WHO_AM_I);
         if (whoAmI == ICM20649_WHO_AM_I_CONST) {
             icmDetected = ICM_20649_SPI;
         } else {
@@ -151,7 +151,7 @@ bool icm20649SpiGyroDetect(gyroDev_t *gyro) {
 bool icm20649GyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {ICM20649_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
     uint8_t data[7];
-    const bool ack = spiReadWriteBuf(&gyro->dev, dataToSend, data, 7);
+    const bool ack = spiReadWriteBufRB(&gyro->dev, (uint8_t *)dataToSend, data, 7);
     if (!ack) {
         return false;
     }
@@ -163,7 +163,7 @@ bool icm20649GyroReadSPI(gyroDev_t *gyro) {
 
 bool icm20649AccRead(accDev_t *acc) {
     uint8_t data[6];
-    const bool ack = spiReadRegBuf(&acc->dev, ICM20649_RA_ACCEL_XOUT_H, data, 6);
+    const bool ack = spiReadRegMskBufRB(&acc->dev, ICM20649_RA_ACCEL_XOUT_H, data, 6);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -59,7 +59,7 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM20601_WHO_AM_I_CONST:
             icmDetected = ICM_20601_SPI;

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -175,7 +175,7 @@ uint8_t icm426xxSpiDetect(const extDevice_t *dev) {
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM42605_WHO_AM_I_CONST:
             icmDetected = ICM_42605_SPI;
@@ -289,7 +289,7 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 
     spiWriteReg(&gyro->dev, ICM426XX_RA_INT_SOURCE0, ICM426XX_UI_DRDY_INT1_EN_ENABLED);
 
-    uint8_t intConfig1Value = spiReadReg(&gyro->dev, ICM426XX_RA_INT_CONFIG1);
+    uint8_t intConfig1Value = spiReadRegMsk(&gyro->dev, ICM426XX_RA_INT_CONFIG1);
     // Datasheet says: "User should change setting to 0 from default setting of 1, for proper INT1 and INT2 pin operation"
     intConfig1Value &= ~(1 << ICM426XX_INT_ASYNC_RESET_BIT);
     intConfig1Value |= (ICM426XX_INT_TPULSE_DURATION_8 | ICM426XX_INT_TDEASSERT_DISABLED);
@@ -298,7 +298,7 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 
     // Disable AFSR to prevent stalls in gyro output
     // ICM426XX_INTF_CONFIG1 location in user bank 0
-    uint8_t intfConfig1Value = spiReadReg(&gyro->dev, ICM426XX_INTF_CONFIG1);
+    uint8_t intfConfig1Value = spiReadRegMsk(&gyro->dev, ICM426XX_INTF_CONFIG1);
     intfConfig1Value &= ~ICM426XX_INTF_CONFIG1_AFSR_MASK;
     intfConfig1Value |= ICM426XX_INTF_CONFIG1_AFSR_DISABLE;
     spiWriteReg(&gyro->dev, ICM426XX_INTF_CONFIG1, intfConfig1Value);
@@ -335,7 +335,7 @@ bool icm426xxGyroReadSPI(gyroDev_t *gyro)
     //uint8_t data[7];
     STATIC_DMA_DATA_AUTO uint8_t data[7];
 
-    const bool ack = spiReadWriteBuf(&gyro->dev, dataToSend, data, 7);
+    const bool ack = spiReadWriteBufRB(&gyro->dev, dataToSend, data, 7);
     if (!ack) {
         return false;
     }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -128,7 +128,7 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev) {
     uint8_t attemptsRemaining = 5;
     do {
         delay(150);
-        const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
+        const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
         if (whoAmI == MPU6000_WHO_AM_I_CONST) {
             break;
         }
@@ -136,7 +136,7 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    const uint8_t productID = spiReadReg(dev, MPU_RA_PRODUCT_ID);
+    const uint8_t productID = spiReadRegMsk(dev, MPU_RA_PRODUCT_ID);
     /* look for a product ID we recognise */
     // verify product revision
     switch (productID) {

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -50,7 +50,7 @@ static void mpu6500SpiInit(const extDevice_t *dev) {
 
 uint8_t mpu6500SpiDetect(const extDevice_t *dev) {
     mpu6500SpiInit(dev);
-    const uint8_t whoAmI = spiReadReg(dev, MPU_RA_WHO_AM_I);
+    const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
     uint8_t mpuDetected = MPU_NONE;
     switch (whoAmI) {
     case MPU6500_WHO_AM_I_CONST:

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -148,7 +148,7 @@ uint8_t mpu9250SpiDetect(const extDevice_t *dev) {
     uint8_t attemptsRemaining = 20;
     do {
         delay(150);
-        const uint8_t in = spiReadReg(dev, MPU_RA_WHO_AM_I);
+        const uint8_t in = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
         if (in == MPU9250_WHO_AM_I_CONST || in == MPU9255_WHO_AM_I_CONST) {
             break;
         }

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -200,7 +200,7 @@ bool lpsReadCommand(extDevice_t *dev, uint8_t cmd, uint8_t *data, uint8_t len) {
 bool lpsWriteVerify(extDevice_t *dev, uint8_t cmd, uint8_t byte) {
     uint8_t temp = 0xff;
     spiWriteReg(dev, cmd, byte);
-    spiReadRegBuf(dev, cmd, &temp, 1);
+    spiReadRegBuf(dev, cmd | 0x80, &temp, 1);
     if (byte == temp) return true;
     return false;
 }

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -190,11 +190,13 @@ static uint32_t rawP = 0;
 static uint16_t rawT = 0;
 
 bool lpsWriteCommand(extDevice_t *dev, uint8_t cmd, uint8_t byte) {
-    return spiWriteReg(dev, cmd, byte);
+    spiWriteReg(dev, cmd, byte);
+    return true;
 }
 
 bool lpsReadCommand(extDevice_t *dev, uint8_t cmd, uint8_t *data, uint8_t len) {
-    return spiReadRegBuf(dev, cmd | 0x80 | 0x40, data, len);
+    spiReadRegBuf(dev, cmd | 0x80 | 0x40, data, len);
+    return true;
 }
 
 bool lpsWriteVerify(extDevice_t *dev, uint8_t cmd, uint8_t byte) {

--- a/src/main/drivers/bus.c
+++ b/src/main/drivers/bus.c
@@ -27,18 +27,54 @@
 #include "drivers/bus_i2c_busdev.h"
 #include "drivers/bus_spi.h"
 
+// Raw register access (register number passed as-is, no masking).
+// For SPI: uses the RB variant so it returns false if the bus is busy.
+bool busRawWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+#ifdef USE_SPI
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        return spiWriteRegRB(dev, reg, data);
+    }
+#endif
+    return busWriteRegister(dev, reg, data);
+}
+
+bool busRawWriteRegisterStart(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+#ifdef USE_SPI
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        return spiWriteRegRB(dev, reg, data);
+    }
+#endif
+    return busWriteRegisterStart(dev, reg, data);
+}
+
+bool busRawReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+#ifdef USE_SPI
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        return spiReadRegBufRB(dev, reg, data, length);
+    }
+#endif
+    return busReadRegisterBuffer(dev, reg, data, length);
+}
+
+bool busRawReadRegisterBufferStart(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+#ifdef USE_SPI
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        return spiReadRegBufRB(dev, reg, data, length);
+    }
+#endif
+    return busReadRegisterBufferStart(dev, reg, data, length);
+}
+
+// Write register, masking register address with 0x7f.
 bool busWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
-#ifdef USE_DMA_SPI_DEVICE
-    return spiWriteReg(dev, reg & 0x7f, data);
-#else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(reg);
     UNUSED(data);
 #endif
-    switch (dev->busType) {
+    switch (dev->bus->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        return spiWriteReg(dev, reg & 0x7f, data);
+        return spiWriteRegRB(dev, reg & 0x7f, data);
 #endif
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
@@ -47,22 +83,23 @@ bool busWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
     default:
         return false;
     }
-#endif
 }
 
+bool busWriteRegisterStart(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    return busWriteRegister(dev, reg, data);
+}
+
+// Read register buffer, OR'ing register address with 0x80 for SPI read convention.
 bool busReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
-#ifdef USE_DMA_SPI_DEVICE
-    return spiReadRegBuf(dev, reg | 0x80, data, length);
-#else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(reg);
     UNUSED(data);
     UNUSED(length);
 #endif
-    switch (dev->busType) {
+    switch (dev->bus->busType) {
 #ifdef USE_SPI
     case BUS_TYPE_SPI:
-        return spiReadRegBuf(dev, reg | 0x80, data, length);
+        return spiReadRegBufRB(dev, reg | 0x80, data, length);
 #endif
 #ifdef USE_I2C
     case BUS_TYPE_I2C:
@@ -71,23 +108,44 @@ bool busReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, u
     default:
         return false;
     }
-#endif
+}
+
+bool busReadRegisterBufferStart(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+    return busReadRegisterBuffer(dev, reg, data, length);
 }
 
 uint8_t busReadRegister(const extDevice_t *dev, uint8_t reg) {
-#ifdef USE_DMA_SPI_DEVICE
-    uint8_t data;
-    busReadRegisterBuffer(dev, reg, &data, 1);
-    return data;
-#else
 #if !defined(USE_SPI) && !defined(USE_I2C)
     UNUSED(dev);
     UNUSED(reg);
-    return false;
+    return 0;
 #else
     uint8_t data;
     busReadRegisterBuffer(dev, reg, &data, 1);
     return data;
 #endif
+}
+
+// busBusy is for I2C async operation polling. SPI transfers always complete before returning
+// (via spiWait), so from the bus abstraction perspective SPI is never busy.
+bool busBusy(const extDevice_t *dev, bool *error) {
+    UNUSED(error);
+#ifdef USE_SPI
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        return false;
+    }
+#else
+    UNUSED(dev);
+#endif
+    return false;
+}
+
+void busDeviceRegister(const extDevice_t *dev) {
+#ifdef USE_SPI
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        spiBusDeviceRegister(dev);
+    }
+#else
+    UNUSED(dev);
 #endif
 }

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -24,20 +24,31 @@
 
 #include "drivers/bus_i2c.h"
 #include "drivers/io_types.h"
+#ifndef UNIT_TEST
+#include "drivers/dma.h"
+#endif
 
 typedef enum {
     BUS_TYPE_NONE = 0,
     BUS_TYPE_I2C,
     BUS_TYPE_SPI,
-    BUS_TYPE_MPU_SLAVE // Slave I2C on SPI master
+    BUS_TYPE_MPU_SLAVE, // Slave I2C on SPI master
+    BUS_TYPE_GYRO_AUTO, // Only used by acc/gyro bus auto detection code
 } busType_e;
+
+typedef enum {
+    BUS_READY,
+    BUS_BUSY,
+    BUS_ABORT
+} busStatus_e;
 
 struct extDevice_s;
 
+struct busSegment_s;
+
 // Shared bus-resource struct. Represents an SPI, I2C, or MPU-slave peripheral;
 // one instance per physical bus. Does NOT carry per-device addressing (CS pin,
-// I2C slave address). Matches Betaflight 4.5-maintenance layout minus the
-// DMA/segment fields which are a later phase.
+// I2C slave address). Matches Betaflight 4.5-maintenance layout.
 typedef struct busDevice_s {
     busType_e busType;
     union {
@@ -46,6 +57,8 @@ typedef struct busDevice_s {
 #if defined(USE_HAL_DRIVER)
             SPI_HandleTypeDef* handle; // cached here for efficiency
 #endif
+            uint16_t speed;
+            bool leadingEdge;
         } spi;
         struct busI2C_s {
             I2CDevice device;
@@ -54,13 +67,28 @@ typedef struct busDevice_s {
             const struct extDevice_s *master;
         } mpuSlave;
     } busType_u;
+    bool useDMA;
+    uint8_t deviceCount;
+#ifndef UNIT_TEST
+    // dmaChannelDescriptor_t requires dma.h which is not available in unit test builds
+    dmaChannelDescriptor_t *dmaTx;
+    dmaChannelDescriptor_t *dmaRx;
+#if defined(STM32F7)
+    LL_DMA_InitTypeDef *initTx;
+    LL_DMA_InitTypeDef *initRx;
+#else
+    DMA_InitTypeDef    *initTx;
+    DMA_InitTypeDef    *initRx;
+#endif
+#endif // UNIT_TEST
+    volatile struct busSegment_s *volatile curSegment;
+    bool initSegment;
 } busDevice_t;
 
 // Per-device struct. Carries a back-pointer to the shared busDevice_t
-// (populated by spiSetBusInstance for SPI devices; NULL for I2C and
-// MPU-slave devices until their bus-resource split lands). The inline
-// instance/device fields are still present and authoritative in this
-// sub-commit; Stage I.4 migrates access sites to prefer dev->bus.
+// (populated by spiSetBusInstance for SPI devices). The inline
+// busType/instance/handle fields are still present and authoritative;
+// Stage I.4 will remove them once a safe migration path is confirmed.
 typedef struct extDevice_s {
     busDevice_t *bus;
     busType_e busType;
@@ -71,7 +99,8 @@ typedef struct extDevice_s {
             SPI_HandleTypeDef* handle; // cached here for efficiency
 #endif
             IO_t csnPin;
-
+            uint16_t speed;
+            bool leadingEdge;
 #if defined(USE_GYRO_IMUF9001)
             IO_t rstPin;
 #endif
@@ -85,12 +114,61 @@ typedef struct extDevice_s {
             uint8_t address;
         } mpuSlave;
     } busType_u;
+#ifndef UNIT_TEST
+    // Per-device DMA init cache — reduces inter-segment setup time (BF 4.5-m pattern).
+    // Pointer stored in bus->initTx/initRx so the bus driver always references the
+    // current device's cache.
+#if defined(STM32F7)
+    LL_DMA_InitTypeDef initTx;
+    LL_DMA_InitTypeDef initRx;
+#else
+    DMA_InitTypeDef    initTx;
+    DMA_InitTypeDef    initRx;
+#endif
+#endif // UNIT_TEST
+    bool useDMA;
+    uint8_t *txBuf, *rxBuf;
+    uint32_t callbackArg;
 } extDevice_t;
+
+/* Each SPI access may comprise multiple segments (e.g. reg-write then data-read),
+ * each described by one busSegment_t entry terminated by a sentinel with len == 0.
+ * negateCS controls whether CS is deasserted between segments.
+ * callback (if non-NULL) is called after each segment completes; its return value
+ * may request BUS_BUSY (repeat), BUS_ABORT (skip remaining), or BUS_READY (advance).
+ */
+typedef struct busSegment_s {
+    union {
+        struct {
+            uint8_t *txData;
+            uint8_t *rxData;
+        } buffers;
+        struct {
+            const struct extDevice_s *dev;
+            volatile struct busSegment_s *segments;
+        } link;
+    } u;
+    int len;
+    bool negateCS;
+    busStatus_e (*callback)(uint32_t arg);
+} busSegment_t;
 
 #ifdef TARGET_BUS_INIT
 void targetBusInit(void);
 #endif
 
+// Register access with register number passed as-is (no masking)
+bool busRawWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool busRawWriteRegisterStart(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool busRawReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+bool busRawReadRegisterBufferStart(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+
+// Write: register masked with 0x7f; Read: register OR'd with 0x80
 bool busWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool busWriteRegisterStart(const extDevice_t *dev, uint8_t reg, uint8_t data);
 bool busReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+bool busReadRegisterBufferStart(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t busReadRegister(const extDevice_t *dev, uint8_t reg);
+
+bool busBusy(const extDevice_t *dev, bool *error);
+void busDeviceRegister(const extDevice_t *dev);

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -88,7 +88,7 @@ typedef struct busDevice_s {
 // Per-device struct. Carries a back-pointer to the shared busDevice_t
 // (populated by spiSetBusInstance for SPI devices). The inline
 // busType/instance/handle fields are still present and authoritative;
-// Stage I.4 will remove them once a safe migration path is confirmed.
+// removal is deferred pending a safe migration path (see stage-I-revert/SUMMARY.md).
 typedef struct extDevice_s {
     busDevice_t *bus;
     busType_e busType;
@@ -136,6 +136,8 @@ typedef struct extDevice_s {
  * negateCS controls whether CS is deasserted between segments.
  * callback (if non-NULL) is called after each segment completes; its return value
  * may request BUS_BUSY (repeat), BUS_ABORT (skip remaining), or BUS_READY (advance).
+ * Stage M.1 sync path advances unconditionally; BUS_ABORT/BUS_BUSY only honored
+ * by the async DMA path (Stage M.3).
  */
 typedef struct busSegment_s {
     union {

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -35,17 +35,17 @@
 #ifdef USE_DMA_SPI_DEVICE
 #ifndef GYRO_READ_TIMEOUT
 #define GYRO_READ_TIMEOUT 20
-#endif //GYRO_READ_TIMEOUT
+#endif
 #include "drivers/dma_spi.h"
 #include "drivers/time.h"
-#endif //USE_DMA_SPI_DEVICE
+#endif
+
+static uint8_t spiRegisteredDeviceCount = 0;
 
 FAST_RAM_ZERO_INIT spiDevice_t spiDevice[SPIDEV_COUNT];
 
-// Bus-abstraction layer: one busDevice_t per SPI peripheral. Shared by every
-// extDevice_t that uses this bus. Populated by spiInit() on successful init
-// of each SPI peripheral. Not statically initialised — zero-init is fine
-// because unused slots stay BUS_TYPE_NONE.
+// One busDevice_t per SPI peripheral. Shared by all extDevice_t instances on that bus.
+// Populated by spiInit(); zero-init is correct (unused slots stay BUS_TYPE_NONE).
 FAST_RAM_ZERO_INIT static busDevice_t spiBusDevice[SPIDEV_COUNT];
 
 busDevice_t *spiBusByDevice(SPIDevice device) {
@@ -113,10 +113,6 @@ bool spiInit(SPIDevice device) {
         break;
     }
     if (ok) {
-        // Populate bus-abstraction resource for this peripheral. Later stages
-        // migrate extDevice_t to dereference dev->bus->busType_u.spi.instance
-        // instead of the per-device inline copy. Route through spiBusByDevice()
-        // so the write shares the read path's bounds check.
         busDevice_t *bus = spiBusByDevice(device);
         if (bus) {
             bus->busType = BUS_TYPE_SPI;
@@ -124,6 +120,7 @@ bool spiInit(SPIDevice device) {
 #if defined(USE_HAL_DRIVER)
             bus->busType_u.spi.handle = &spiDevice[device].hspi;
 #endif
+            bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
         }
     }
     return ok;
@@ -138,32 +135,331 @@ uint32_t spiTimeoutUserCallback(SPI_TypeDef *instance) {
     return spiDevice[device].errorCount;
 }
 
+// Mark this bus as SPI using a 1-based CLI device id (BF 4.5-maintenance convention).
+// Returns false if device is 0 (disabled), out of range, or the peripheral is absent.
+bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
+    if ((device == 0) || (device > SPIDEV_COUNT)) {
+        return false;
+    }
+    SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(device));
+    if (instance == NULL) {
+        return false;
+    }
 
-FAST_CODE bool spiReadWriteBuf(const extDevice_t *dev, const uint8_t *txData, uint8_t *rxData, int length) {
+    dev->bus = spiBusByDevice(SPI_CFG_TO_DEV(device));
+
+    // By default each device uses DMA if the bus supports it (bus->useDMA starts false
+    // until spiInitBusDMA enables it when channels are allocated).
+    dev->useDMA = true;
+
+    if (dev->bus->busType == BUS_TYPE_SPI) {
+        // Bus already initialised by a prior call — increment device count.
+        dev->bus->deviceCount++;
+    } else {
+        busDevice_t *bus = dev->bus;
+        bus->busType = BUS_TYPE_SPI;
+        bus->busType_u.spi.instance = instance;
+#if defined(USE_HAL_DRIVER)
+        bus->busType_u.spi.handle = &spiDevice[SPI_CFG_TO_DEV(device)].hspi;
+#endif
+        bus->useDMA = false;
+        bus->deviceCount = 1;
+#ifndef UNIT_TEST
+        bus->initTx = &dev->initTx;
+        bus->initRx = &dev->initRx;
+#endif
+        bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+    }
+
+    // Keep inline fields populated (Stage I.4 deferred — access sites still read these).
+    dev->busType = BUS_TYPE_SPI;
+    dev->busType_u.spi.instance = instance;
+    return true;
+}
+
+// Stub: DMA channel allocation requires dma_reqmap infrastructure (Stage M.3).
+void spiInitBusDMA(void) {
+}
+
+bool spiIsBusy(const extDevice_t *dev) {
+    return (dev->bus->curSegment != (busSegment_t *)BUS_SPI_FREE);
+}
+
+void spiWait(const extDevice_t *dev) {
+    while (spiIsBusy(dev));
+}
+
+void spiRelease(const extDevice_t *dev) {
+    IOHi(dev->busType_u.spi.csnPin);
+}
+
+void spiDmaEnable(const extDevice_t *dev, bool enable) {
+    ((extDevice_t *)dev)->useDMA = enable;
+}
+
+// Store per-device clock divisor and apply it immediately to the SPI peripheral.
+// Stage M.3 will defer HW application to transfer-start via the DMA init struct.
+void spiSetClkDivisor(const extDevice_t *dev, uint16_t divisor) {
+    ((extDevice_t *)dev)->busType_u.spi.speed = divisor;
+    spiSetDivisor(dev->busType_u.spi.instance, divisor);
+}
+
+// Store per-device clock phase/polarity flag.
+// HW re-configuration at transfer-start deferred to Stage M.3.
+void spiSetClkPhasePolarity(const extDevice_t *dev, bool leadingEdge) {
+    ((extDevice_t *)dev)->busType_u.spi.leadingEdge = leadingEdge;
+}
+
+bool spiUseDMA(const extDevice_t *dev) {
+    if (!dev->bus->useDMA || !dev->useDMA) {
+        return false;
+    }
+#ifndef UNIT_TEST
+    return dev->bus->dmaRx != NULL;
+#else
+    return false;
+#endif
+}
+
+bool spiUseSDO_DMA(const extDevice_t *dev) {
+    return dev->bus->useDMA && dev->useDMA;
+}
+
+void spiBusDeviceRegister(const extDevice_t *dev) {
+    UNUSED(dev);
+    spiRegisteredDeviceCount++;
+}
+
+uint8_t spiGetRegisteredDeviceCount(void) {
+    return spiRegisteredDeviceCount;
+}
+
+uint8_t spiGetExtDeviceCount(const extDevice_t *dev) {
+    return dev->bus->deviceCount;
+}
+
+void spiLinkSegments(const extDevice_t *dev, busSegment_t *firstSegment, busSegment_t *secondSegment) {
+    busSegment_t *endSegment;
+    for (endSegment = firstSegment; endSegment->len; endSegment++);
+    endSegment->u.link.dev = dev;
+    endSegment->u.link.segments = secondSegment;
+}
+
+// Synchronous segment-based SPI transfer.
+// Processes each segment in order: asserts CS once, transfers data, deasserts CS
+// according to negateCS. The USE_DMA_SPI_DEVICE (IMUF9001) single-segment DMA path
+// is preserved as a special case; multi-segment always uses synchronous spiTransfer.
+void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
+    busDevice_t *bus = dev->bus;
+
+    spiWait(dev);
+
+    bus->curSegment = segments;
+
 #ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
-        uint32_t timeoutCheck = millis();
-        memcpy(dmaTxBuffer, (uint8_t *)txData, length);
-        dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, length, 1);
-        while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
-            if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
-                //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(dev->busType_u.spi.csnPin);
-                return false;
+    if (dev->busType_u.spi.instance == USE_DMA_SPI_DEVICE) {
+        // IMUF9001 custom DMA path: only supports single-segment transfers.
+        if (segments[0].len > 0 && segments[1].len == 0) {
+            uint8_t *txData = segments[0].u.buffers.txData;
+            uint8_t *rxData = segments[0].u.buffers.rxData;
+            int len = segments[0].len;
+            uint32_t timeoutCheck = millis();
+            if (txData) {
+                memcpy(dmaTxBuffer, txData, len);
+            } else {
+                memset(dmaTxBuffer, 0xFF, len);
+            }
+            dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, len, 1);
+            while (dmaSpiReadStatus != DMA_SPI_READ_DONE) {
+                if (millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
+                    IOHi(dev->busType_u.spi.csnPin);
+                    break;
+                }
+            }
+            if (rxData) {
+                memcpy(rxData, dmaRxBuffer, len);
+            }
+            if (segments[0].callback) {
+                segments[0].callback(dev->callbackArg);
+            }
+            bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+            return;
+        }
+    }
+#endif
+
+    // Synchronous path: assert CS, process all segments, handle CS per negateCS flag.
+    IOLo(dev->busType_u.spi.csnPin);
+
+    for (busSegment_t *seg = segments; seg->len > 0; seg++) {
+        spiTransfer(dev->busType_u.spi.instance,
+                    seg->u.buffers.txData,
+                    seg->u.buffers.rxData,
+                    seg->len);
+
+        if (seg->callback) {
+            seg->callback(dev->callbackArg);
+        }
+
+        if (seg->negateCS) {
+            IOHi(dev->busType_u.spi.csnPin);
+            if ((seg + 1)->len > 0) {
+                IOLo(dev->busType_u.spi.csnPin);
             }
         }
-        memcpy((uint8_t *)rxData, dmaRxBuffer, length);
-    } else {
-        IOLo(dev->busType_u.spi.csnPin);
-        spiTransfer(dev->busType_u.spi.instance, txData, rxData, length);
-        IOHi(dev->busType_u.spi.csnPin);
+    }
+
+    bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+}
+
+void spiReadWriteBuf(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, int len) {
+    busSegment_t segments[] = {
+        {.u.buffers = {txData, rxData}, len, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+}
+
+bool spiReadWriteBufRB(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, int length) {
+    if (spiIsBusy(dev)) {
+        return false;
+    }
+    spiReadWriteBuf(dev, txData, rxData, length);
+    return true;
+}
+
+uint8_t spiReadWrite(const extDevice_t *dev, uint8_t data) {
+    uint8_t retval;
+    busSegment_t segments[] = {
+        {.u.buffers = {&data, &retval}, sizeof(data), true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+    return retval;
+}
+
+uint8_t spiReadWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    uint8_t retval;
+    busSegment_t segments[] = {
+        {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+        {.u.buffers = {&data, &retval}, sizeof(data), true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+    return retval;
+}
+
+void spiWrite(const extDevice_t *dev, uint8_t data) {
+    busSegment_t segments[] = {
+        {.u.buffers = {&data, NULL}, sizeof(data), true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+}
+
+void spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    busSegment_t segments[] = {
+        {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+        {.u.buffers = {&data, NULL}, sizeof(data), true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+}
+
+bool spiWriteRegRB(const extDevice_t *dev, uint8_t reg, uint8_t data) {
+    if (spiIsBusy(dev)) {
+        return false;
+    }
+    spiWriteReg(dev, reg, data);
+    return true;
+}
+
+void spiWriteRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint32_t length) {
+    busSegment_t segments[] = {
+        {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+        {.u.buffers = {data, NULL}, length, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+}
+
+void spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+    busSegment_t segments[] = {
+        {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+        {.u.buffers = {NULL, data}, length, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+}
+
+bool spiReadRegBufRB(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+    if (spiIsBusy(dev)) {
+        return false;
+    }
+    spiReadRegBuf(dev, reg, data, length);
+    return true;
+}
+
+bool spiReadRegMskBufRB(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
+    return spiReadRegBufRB(dev, reg | 0x80, data, length);
+}
+
+uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg) {
+    uint8_t data;
+    busSegment_t segments[] = {
+        {.u.buffers = {&reg, NULL}, sizeof(reg), false, NULL},
+        {.u.buffers = {NULL, &data}, sizeof(data), true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(dev, &segments[0]);
+    spiWait(dev);
+    return data;
+}
+
+uint8_t spiReadRegMsk(const extDevice_t *dev, uint8_t reg) {
+    return spiReadReg(dev, reg | 0x80);
+}
+
+uint16_t spiCalculateDivider(uint32_t freq) {
+#if defined(STM32F4) || defined(STM32G4) || defined(STM32F7)
+    uint32_t spiClk = SystemCoreClock / 2;
+#elif defined(STM32H7)
+    uint32_t spiClk = 100000000;
+#elif defined(AT32F4)
+    if (freq > 36000000) {
+        freq = 36000000;
+    }
+    uint32_t spiClk = system_core_clock / 2;
+#else
+#error "Base SPI clock not defined for this architecture"
+#endif
+    uint16_t divisor = 2;
+    spiClk >>= 1;
+    for (; (spiClk > freq) && (divisor < 256); divisor <<= 1, spiClk >>= 1);
+    return divisor;
+}
+
+uint32_t spiCalculateClock(uint16_t spiClkDivisor) {
+#if defined(STM32F4) || defined(STM32G4) || defined(STM32F7)
+    uint32_t spiClk = SystemCoreClock / 2;
+#elif defined(STM32H7)
+    uint32_t spiClk = 100000000;
+#elif defined(AT32F4)
+    uint32_t spiClk = system_core_clock / 2;
+    if ((spiClk / spiClkDivisor) > 36000000) {
+        return 36000000;
     }
 #else
-    IOLo(dev->busType_u.spi.csnPin);
-    spiTransfer(dev->busType_u.spi.instance, txData, rxData, length);
-    IOHi(dev->busType_u.spi.csnPin);
+#error "Base SPI clock not defined for this architecture"
 #endif
-    return true;
+    return spiClk / spiClkDivisor;
 }
 
 uint16_t spiGetErrorCounter(SPI_TypeDef *instance) {
@@ -179,143 +475,6 @@ void spiResetErrorCounter(SPI_TypeDef *instance) {
     if (device != SPIINVALID) {
         spiDevice[device].errorCount = 0;
     }
-}
-
-FAST_CODE bool spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data) {
-#ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
-        uint32_t timeoutCheck = millis();
-        dmaTxBuffer[0] = reg;
-        dmaTxBuffer[1] = data;
-        dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, 2, 1);
-        while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
-            if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
-                //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(dev->busType_u.spi.csnPin);
-                return false;
-            }
-        }
-    } else {
-        IOLo(dev->busType_u.spi.csnPin);
-        spiTransferByte(dev->busType_u.spi.instance, reg);
-        spiTransferByte(dev->busType_u.spi.instance, data);
-        IOHi(dev->busType_u.spi.csnPin);
-    }
-#else
-    IOLo(dev->busType_u.spi.csnPin);
-    spiTransferByte(dev->busType_u.spi.instance, reg);
-    spiTransferByte(dev->busType_u.spi.instance, data);
-    IOHi(dev->busType_u.spi.csnPin);
-#endif
-    return true;
-}
-
-FAST_CODE bool spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
-#ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
-        uint32_t timeoutCheck = millis();
-        dmaTxBuffer[0] = reg | 0x80;
-        dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, length + 1, 1);
-        while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
-            if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
-                //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(dev->busType_u.spi.csnPin);
-                return false;
-            }
-        }
-        memcpy(data, dmaRxBuffer + 1, length);
-    } else {
-        IOLo(dev->busType_u.spi.csnPin);
-        spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
-        spiTransfer(dev->busType_u.spi.instance, NULL, data, length);
-        IOHi(dev->busType_u.spi.csnPin);
-    }
-#else
-    IOLo(dev->busType_u.spi.csnPin);
-    spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(dev->busType_u.spi.instance, NULL, data, length);
-    IOHi(dev->busType_u.spi.csnPin);
-#endif
-    return true;
-}
-
-FAST_CODE uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg) {
-#ifdef USE_DMA_SPI_DEVICE
-    if(USE_DMA_SPI_DEVICE == dev->busType_u.spi.instance) {
-        uint32_t timeoutCheck = millis();
-        dmaTxBuffer[0] = reg | 0x80;
-        dmaSpiTransmitReceive(dmaTxBuffer, dmaRxBuffer, 2, 1);
-        while(dmaSpiReadStatus != DMA_SPI_READ_DONE) {
-            if(millis() - timeoutCheck > GYRO_READ_TIMEOUT) {
-                //GYRO_READ_TIMEOUT ms max, read failed, cleanup spi and return 0
-                IOHi(dev->busType_u.spi.csnPin);
-                return 0;
-            }
-        }
-        return dmaRxBuffer[1];
-    } else {
-        uint8_t data;
-        IOLo(dev->busType_u.spi.csnPin);
-        spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
-        spiTransfer(dev->busType_u.spi.instance, NULL, &data, 1);
-        IOHi(dev->busType_u.spi.csnPin);
-        return data;
-    }
-#else
-    uint8_t data;
-    IOLo(dev->busType_u.spi.csnPin);
-    spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(dev->busType_u.spi.instance, NULL, &data, 1);
-    IOHi(dev->busType_u.spi.csnPin);
-    return data;
-#endif
-}
-
-// Mark this bus as being SPI given a 1-based CLI device id (BF 4.5-maintenance
-// convention). Validates device range, looks up the SPI_TypeDef via
-// spiInstanceByDevice, and wires both the inline extDevice_t.busType_u.spi
-// fields and the dev->bus back-pointer populated by spiInit().
-bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
-    if ((device == 0) || (device > SPIDEV_COUNT)) {
-        return false;
-    }
-    SPI_TypeDef *instance = spiInstanceByDevice(SPI_CFG_TO_DEV(device));
-    if (instance == NULL) {
-        return false;
-    }
-    dev->busType = BUS_TYPE_SPI;
-    dev->busType_u.spi.instance = instance;
-    dev->bus = spiBusByDevice(SPI_CFG_TO_DEV(device));
-    return true;
-}
-
-
-// icm42688p and bmi270 porting
-uint16_t spiCalculateDivider(uint32_t freq)
-{
-#if defined(STM32F4) || defined(STM32G4) || defined(STM32F7)
-    uint32_t spiClk = SystemCoreClock / 2;
-#elif defined(STM32H7)
-    uint32_t spiClk = 100000000;
-#elif defined(AT32F4)
-    if(freq > 36000000){
-        freq = 36000000;
-    }
-    uint32_t spiClk = system_core_clock / 2;
-#else
-#error "Base SPI clock not defined for this architecture"
-#endif
-    uint16_t divisor = 2;
-    spiClk >>= 1;
-    for (; (spiClk > freq) && (divisor < 256); divisor <<= 1, spiClk >>= 1);
-    return divisor;
-}
-
-// Wait for bus to become free, then read a byte of data where the register is bitwise OR'ed with 0x80
-// EmuFlight codebase is old.  Bitwise or 0x80 is redundant here as spiReadReg already contains such.
-uint8_t spiReadRegMsk(const extDevice_t *dev, uint8_t reg)
-{
-    return spiReadReg(dev, reg | 0x80);
 }
 
 #endif

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -114,28 +114,73 @@ SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
 // Bus-abstraction accessor. Returns a pointer to the shared busDevice_t that
 // represents the given SPI peripheral (populated by spiInit()). Returns NULL
-// for invalid devices. Used by Stage I.3+ to wire extDevice_t.bus.
+// for invalid devices.
 busDevice_t *spiBusByDevice(SPIDevice device);
 
-bool spiReadWriteBuf(const extDevice_t *dev, const uint8_t *txData, uint8_t *rxData, int length);
-
-bool spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data);
-bool spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
-uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg);
-
-// Mark an extDevice_t as belonging to an SPI bus, using the 1-based CLI
-// device id (1 == SPI1, 2 == SPI2, ...). Matches Betaflight 4.5-maintenance
-// spiSetBusInstance signature so callers that already carry the config id
-// can stop round-tripping through spiInstanceByDevice. Returns false if
-// device is 0 (disabled) or out of range, or if the peripheral slot is
-// not backed by a real SPI_TypeDef on this target.
+// Mark an extDevice_t as belonging to an SPI bus, using the 1-based CLI device id.
+// Returns false if device is 0 (disabled), out of range, or the peripheral is absent.
 bool spiSetBusInstance(extDevice_t *dev, uint32_t device);
 
+// Called after all devices are initialised to enable SPI DMA where channels are available.
+// Stage M.1: stub — DMA channel allocation requires dma_reqmap (Stage M.3).
+void spiInitBusDMA(void);
+
+// Determine the divisor / clock for a given frequency
+uint16_t spiCalculateDivider(uint32_t freq);
+uint32_t spiCalculateClock(uint16_t spiClkDivisor);
+
+// Per-device clock and phase settings.
+// spiSetClkDivisor also immediately applies the divisor to the SPI peripheral
+// (synchronous path; Stage M.3 will defer to transfer-start via DMA init struct).
+void spiSetClkDivisor(const extDevice_t *dev, uint16_t divider);
+void spiSetClkPhasePolarity(const extDevice_t *dev, bool leadingEdge);
+
+// Enable/disable DMA on a specific device. Enabled by default; a no-op in Stage M.1
+// (DMA transfers are not yet active; bus->useDMA stays false until spiInitBusDMA).
+void spiDmaEnable(const extDevice_t *dev, bool enable);
+
+// Segment-based async SPI API (matches BF 4.5-maintenance).
+// Stage M.1: spiSequence executes synchronously; spiIsBusy always returns false
+// after spiSequence returns; spiWait is a no-op.
+void spiSequence(const extDevice_t *dev, busSegment_t *segments);
+void spiWait(const extDevice_t *dev);
+void spiRelease(const extDevice_t *dev);
+bool spiIsBusy(const extDevice_t *dev);
+void spiLinkSegments(const extDevice_t *dev, busSegment_t *firstSegment, busSegment_t *secondSegment);
+
+/*
+ * Routine naming convention:
+ *  spi[Read][Write][Reg][Msk][Buf][RB]
+ *
+ *  Read:      Perform a read, returning the value read unless 'Buf'
+ *  Write:     Perform a write
+ *  ReadWrite: Perform both, returning the value read unless 'Buf'
+ *  Reg:       Register number 'reg' written first
+ *  Msk:       Register OR'd with 0x80 (device signals read via bit 7)
+ *  Buf:       Pass data of given length by reference
+ *  RB:        Return false immediately if bus busy, else complete and return true
+ */
+uint8_t spiReadReg(const extDevice_t *dev, uint8_t reg);
+uint8_t spiReadRegMsk(const extDevice_t *dev, uint8_t reg);
+void spiReadRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+bool spiReadRegBufRB(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+bool spiReadRegMskBufRB(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
+
+void spiWrite(const extDevice_t *dev, uint8_t data);
+void spiWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data);
+bool spiWriteRegRB(const extDevice_t *dev, uint8_t reg, uint8_t data);
+void spiWriteRegBuf(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint32_t length);
+
+uint8_t spiReadWrite(const extDevice_t *dev, uint8_t data);
+uint8_t spiReadWriteReg(const extDevice_t *dev, uint8_t reg, uint8_t data);
+void spiReadWriteBuf(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, int len);
+bool spiReadWriteBufRB(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, int length);
+
+bool spiUseDMA(const extDevice_t *dev);
+bool spiUseSDO_DMA(const extDevice_t *dev);
+void spiBusDeviceRegister(const extDevice_t *dev);
+uint8_t spiGetRegisteredDeviceCount(void);
+uint8_t spiGetExtDeviceCount(const extDevice_t *dev);
 
 struct spiPinConfig_s;
 void spiPinConfigure(const struct spiPinConfig_s *pConfig);
-
-// Determine the divisor to use for a given bus frequency
-uint16_t spiCalculateDivider(uint32_t freq);
-
-uint8_t spiReadRegMsk(const extDevice_t *dev, uint8_t reg);

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -22,7 +22,6 @@
 
 #include "drivers/bus.h"
 #include "drivers/io_types.h"
-#include "drivers/bus.h"
 #include "drivers/rcc_types.h"
 
 #include "pg/pg.h"

--- a/src/main/drivers/bus_spi_impl.h
+++ b/src/main/drivers/bus_spi_impl.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+// Sentinel value stored in bus->curSegment when no DMA transfer is in progress.
+#define BUS_SPI_FREE 0x0
+
 #if defined(STM32F1) || defined(STM32F3) || defined(STM32F4)
 #define MAX_SPI_PIN_SEL 2
 #else
@@ -76,3 +79,12 @@ extern spiDevice_t spiDevice[SPIDEV_COUNT];
 
 void spiInitDevice(SPIDevice device);
 uint32_t spiTimeoutUserCallback(SPI_TypeDef *instance);
+
+// Platform-internal DMA functions — implemented in bus_spi_ll.c / bus_spi_stdperiph.c.
+// Stage M.1: these are stubs; Stage M.3 will provide full DMA implementations.
+void spiSequenceStart(const extDevice_t *dev);
+void spiInternalInitStream(const extDevice_t *dev, bool preInit);
+void spiInternalStartDMA(const extDevice_t *dev);
+void spiInternalStopDMA(const extDevice_t *dev);
+void spiInternalResetStream(dmaChannelDescriptor_t *descriptor);
+void spiInternalResetDescriptors(busDevice_t *bus);

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -195,6 +195,15 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     return true;
 }
 
+// Platform-internal DMA functions — stubs for Stage M.1.
+// Stage M.3 will provide full implementations once dma_reqmap is ported.
+void spiSequenceStart(const extDevice_t *dev) { UNUSED(dev); }
+void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
+void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }
+void spiInternalStopDMA(const extDevice_t *dev) { UNUSED(dev); }
+void spiInternalResetStream(dmaChannelDescriptor_t *descriptor) { UNUSED(descriptor); }
+void spiInternalResetDescriptors(busDevice_t *bus) { UNUSED(bus); }
+
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor) {
 #if !(defined(STM32F1) || defined(STM32F3))
     // SPI2 and SPI3 are on APB1/AHB1 which PCLK is half that of APB2/AHB2.

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -29,6 +29,7 @@
 #include "drivers/bus.h"
 #include "drivers/bus_spi.h"
 #include "drivers/bus_spi_impl.h"
+#include "drivers/dma.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
 #include "drivers/rcc.h"
@@ -153,7 +154,8 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     return true;
 }
 
-// Platform-internal DMA function stubs for Stage M.1.
+// Platform-internal DMA functions — stubs for Stage M.1.
+// Stage M.3 will provide full implementations once dma_reqmap is ported.
 void spiSequenceStart(const extDevice_t *dev) { UNUSED(dev); }
 void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
 void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -153,6 +153,14 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     return true;
 }
 
+// Platform-internal DMA function stubs for Stage M.1.
+void spiSequenceStart(const extDevice_t *dev) { UNUSED(dev); }
+void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
+void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }
+void spiInternalStopDMA(const extDevice_t *dev) { UNUSED(dev); }
+void spiInternalResetStream(dmaChannelDescriptor_t *descriptor) { UNUSED(descriptor); }
+void spiInternalResetDescriptors(busDevice_t *bus) { UNUSED(bus); }
+
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor) {
 #define BR_BITS ((BIT(5) | BIT(4) | BIT(3)))
 #if !(defined(STM32F1) || defined(STM32F3))

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -168,8 +168,7 @@ static bool ak8963SlaveCompleteRead(const extDevice_t *slavedev, uint8_t *buf) {
         delayMicroseconds(timeRemaining);
     }
     queuedRead.waiting = false;
-    spiReadRegBuf(dev, MPU_RA_EXT_SENS_DATA_00 | 0x80, buf, queuedRead.len);     // read I2C buffer
-    return true;
+    return spiReadRegMskBufRB(dev, MPU_RA_EXT_SENS_DATA_00, buf, queuedRead.len);     // read I2C buffer
 }
 
 static bool ak8963SlaveReadData(const extDevice_t *dev, uint8_t *buf) {

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -113,7 +113,7 @@ static bool ak8963SlaveReadRegisterBuffer(const extDevice_t *slavedev, uint8_t r
     ak8963SpiWriteRegisterDelay(dev, MPU_RA_I2C_SLV0_CTRL, (len & 0x0F) | I2C_SLV0_EN);     // read number of bytes
     delay(4);
     __disable_irq();
-    bool ack = spiReadRegBuf(dev, MPU_RA_EXT_SENS_DATA_00, buf, len);            // read I2C
+    bool ack = spiReadRegMskBufRB(dev, MPU_RA_EXT_SENS_DATA_00, buf, len);
     __enable_irq();
     return ack;
 }
@@ -168,7 +168,7 @@ static bool ak8963SlaveCompleteRead(const extDevice_t *slavedev, uint8_t *buf) {
         delayMicroseconds(timeRemaining);
     }
     queuedRead.waiting = false;
-    spiReadRegBuf(dev, MPU_RA_EXT_SENS_DATA_00, buf, queuedRead.len);            // read I2C buffer
+    spiReadRegBuf(dev, MPU_RA_EXT_SENS_DATA_00 | 0x80, buf, queuedRead.len);     // read I2C buffer
     return true;
 }
 

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -71,7 +71,7 @@ bool flashInit(const flashConfig_t *flashConfig) {
      */
     uint8_t in[4] = { 0 };
     // Clearing the CS bit terminates the command early so we don't have to read the chip UID:
-    spiReadWriteBuf(dev, out, in, sizeof(out));
+    spiReadWriteBuf(dev, (uint8_t *)out, in, sizeof(out));
     // Manufacturer, memory type, and capacity
     uint32_t chipID = (in[1] << 16) | (in[2] << 8) | (in[3]);
 #ifdef USE_FLASH_M25P16


### PR DESCRIPTION
## Stage M.1 — DMA infrastructure scaffold (BF 4.5-maintenance parity)

Adds the structural and API scaffold for async DMA SPI transfers, matching the Betaflight 4.5-maintenance bus architecture. Stage M.1 executes synchronously; async DMA (Stage M.3) follows.

### Commits

| SHA | Description |
|---|---|
| `82e706e4c5` | M.1.a — `bus.h` struct/type scaffold + `bus_spi_impl.h` `BUS_SPI_FREE` sentinel |
| `8a22a15685` | M.1.b — BF-parity SPI API scaffold + fix all `spiReadReg*` masking (21 sites, 11 files) |
| `02963be589` | CodeRabbit review fixes |
| `2f67df0847` | fix(baro): `lpsWriteCommand`/`lpsReadCommand` — return void SPI callers (WORMFC + F7X2 targets) |

### What Stage M.1 adds

**`bus.h` / `bus_spi_impl.h` (M.1.a):**
- `busStatus_e` (BUS_READY/BUS_BUSY/BUS_ABORT), `BUS_TYPE_GYRO_AUTO`
- DMA fields in `busDevice_s` and `extDevice_s` (behind `#ifndef UNIT_TEST`)
- `busSegment_t` transfer descriptor
- `BUS_SPI_FREE` sentinel + platform-internal stub declarations

**`bus_spi.h` / `bus_spi.c` / `bus.c` (M.1.b):**
- `spiSetBusInstance`, `spiInitBusDMA` (stub), `spiSequence` (synchronous), `spiWait`, `spiRelease`, `spiIsBusy`, `spiDmaEnable`
- All `*RB` variants: `spiReadRegBufRB`, `spiReadRegMskBufRB`, `spiWriteRegRB`, `spiReadWriteBufRB`
- `spiCalculateClock`, `spiLinkSegments`, `spiUseDMA`, `spiUseSDO_DMA`, `spiBusDeviceRegister`
- `bus.c`: `busRaw*`, `*Start`, `busBusy`, `busDeviceRegister`; all dispatch sites → `dev->bus->busType`
- Platform stubs in `bus_spi_ll.c` + `bus_spi_stdperiph.c`

**`spiReadReg*` masking fix (M.1.b):**
BF-aligned `spiReadReg`/`spiReadRegBuf`/`spiReadRegBufRB` send `reg` as-is; callers own the `|0x80`. Old EF versions applied it internally — silent behavior regression. Fixed 21 call sites across 11 driver files.

**WORMFC / F7X2 build fix:**
`spiWriteReg` and `spiReadRegBuf` are `void` in the BF-aligned API. `lpsWriteCommand`/`lpsReadCommand` were returning their value — compile error on targets with `USE_BARO_LPS`. Fixed to call + `return true`.

### Verification

- Unit tests: ✅ 38 binaries PASS (`CCACHE_DISABLE=1 make test`)
- Build: ✅ 8 targets zero warnings (HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, MATEKF411, NBDHMBF4PRO, FOXEERF722V4, FOXEERF405) + WORMFC ✅
- Bench: ✅ **5/5** PASS — FOXEERF405, PYRODRONEF7, HELIOSPRING, TUNERCF405 (brick-victim gate), SKYSTARSF405AIO — 2026-04-24

### BF-alignment deviations (accepted)

- `spiSequence` synchronous — async DMA deferred to Stage M.3
- `spiSetClkDivisor` applies immediately — BF defers to transfer-start via DMA init struct (Stage M.3)
- Inline `busType`/`instance`/`handle` retained in `extDevice_s` — Stage I.4 deferred
- `dma.h` guarded `#ifndef UNIT_TEST` — EF unit test platform lacks DMA types

### Related issues

- #1122 — `bus_spi_impl.h` not self-contained (BF 4.5-m identical; out-of-scope)
- #1124 — `bus_spi.c` CWE-120 `memcpy` in IMUF9001 path (pre-existing; out-of-scope)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured SPI bus abstraction layer to support segmented transfers and improved DMA capabilities across sensor drivers.
  * Updated sensor communication protocols to use enhanced register read/write operations for improved reliability and bandwidth efficiency.
  * Refactored internal bus driver architecture to better manage simultaneous device operations and transfer states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->