### PR TITLE
refactor(I.4): remove inline busType/instance/handle from extDevice_s; migrate all SPI access sites to dev->bus

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -428,11 +428,7 @@ void mpuDetect(gyroDev_t *gyro) {
     // MPU datasheet specifies 30ms.
     delay(35);
 #if defined(USE_I2C) && !defined(USE_DMA_SPI_DEVICE)
-    if (gyro->dev.busType == BUS_TYPE_NONE) {
-        // if no busType is selected try I2C first.
-        gyro->dev.busType = BUS_TYPE_I2C;
-    }
-    if (gyro->dev.busType == BUS_TYPE_I2C) {
+    if (gyro->dev.bus == NULL || gyro->dev.bus->busType == BUS_TYPE_I2C) {
         i2cBusSetInstance(&gyro->dev, I2C_DEV_TO_CFG(MPU_I2C_INSTANCE));
         gyro->dev.busType_u.i2c.address = MPU_ADDRESS;
         uint8_t sig = 0;
@@ -455,10 +451,14 @@ void mpuDetect(gyroDev_t *gyro) {
             }
             return;
         }
+        // I2C probe failed; reset bus state so SPI detection starts clean.
+        // Without this reset, i2cBusSetInstance will have written dev->busType_u.i2c.device
+        // at union offset 0, aliasing dev->busType_u.spi.csnPin after field removal.
+        gyro->dev.bus = NULL;
+        memset(&gyro->dev.busType_u, 0, sizeof(gyro->dev.busType_u));
     }
 #endif
 #ifdef USE_SPI
-    gyro->dev.busType = BUS_TYPE_SPI;
     detectSPISensorsAndUpdateDetectionResult(gyro);
 #endif
 }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -100,7 +100,7 @@ uint8_t bmi160Detect(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, BMI160_SPI_DIVISOR);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, BMI160_SPI_DIVISOR);
     /* Read this address to activate SPI (see p. 84) */
     spiReadRegMsk(dev, 0x7F);
     delay(100); // Give SPI some time to start up

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -245,7 +245,7 @@ bool bmi160AccRead(accDev_t *acc) {
     uint8_t bmi160_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
     IOLo(acc->dev.busType_u.spi.csnPin);
-    spiTransfer(acc->dev.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
+    spiTransfer(acc->dev.bus->busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
     IOHi(acc->dev.busType_u.spi.csnPin);
     acc->ADCRaw[X] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_XOUT_L]);
     acc->ADCRaw[Y] = (int16_t)((bmi160_rx_buf[IDX_ACCEL_YOUT_H] << 8) | bmi160_rx_buf[IDX_ACCEL_YOUT_L]);
@@ -268,7 +268,7 @@ bool bmi160GyroRead(gyroDev_t *gyro) {
     uint8_t bmi160_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi160_tx_buf[BUFFER_SIZE] = {BMI160_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0};
     IOLo(gyro->dev.busType_u.spi.csnPin);
-    spiTransfer(gyro->dev.busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
+    spiTransfer(gyro->dev.bus->busType_u.spi.instance, bmi160_tx_buf, bmi160_rx_buf, BUFFER_SIZE);   // receive response
     IOHi(gyro->dev.busType_u.spi.csnPin);
     gyro->gyroADCRaw[X] = (int16_t)((bmi160_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi160_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi160_rx_buf[IDX_GYRO_YOUT_L]);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -327,7 +327,7 @@ static bool bmi270AccRead(accDev_t *acc)
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
 
     IOLo(acc->dev.busType_u.spi.csnPin);
-    spiTransfer(acc->dev.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    spiTransfer(acc->dev.bus->busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
     IOHi(acc->dev.busType_u.spi.csnPin);
 
     acc->ADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_XOUT_L]);
@@ -355,7 +355,7 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
 
     IOLo(gyro->dev.busType_u.spi.csnPin);
-    spiTransfer(gyro->dev.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    spiTransfer(gyro->dev.bus->busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
     IOHi(gyro->dev.busType_u.spi.csnPin);
 
     gyro->gyroADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_XOUT_L]);
@@ -390,7 +390,7 @@ static bool bmi270GyroReadFifo(gyroDev_t *gyro)
     // the first sample in the queue. It's possible for the FIFO to be empty so we need to check the
     // length before using the sample.
     IOLo(gyro->dev.busType_u.spi.csnPin);
-    spiTransfer(gyro->dev.busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
+    spiTransfer(gyro->dev.bus->busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
     IOHi(gyro->dev.busType_u.spi.csnPin);
 
     int fifoLength = (uint16_t)((bmi270_rx_buf[IDX_FIFO_LENGTH_H] << 8) | bmi270_rx_buf[IDX_FIFO_LENGTH_L]);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -183,7 +183,7 @@ uint8_t bmi270Detect(const extDevice_t *dev)
     IOHi(dev->busType_u.spi.csnPin);
 #endif
 
-    spiSetDivisor(dev->busType_u.spi.instance, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
+    spiSetDivisor(dev->bus->busType_u.spi.instance, spiCalculateDivider(BMI270_MAX_SPI_CLK_HZ));
     bmi270EnableSPI(dev);
 
     if (bmi270RegisterRead(dev, BMI270_REG_CHIP_ID) == BMI270_CHIP_ID) {
@@ -200,8 +200,8 @@ static void bmi270UploadConfig(const extDevice_t *dev)
 
     // Transfer the config file
     IOLo(dev->busType_u.spi.csnPin);
-    spiTransferByte(dev->busType_u.spi.instance, BMI270_REG_INIT_DATA);
-    spiTransfer(dev->busType_u.spi.instance, bmi270_maximum_fifo_config_file, NULL, sizeof(bmi270_maximum_fifo_config_file));
+    spiTransferByte(dev->bus->busType_u.spi.instance, BMI270_REG_INIT_DATA);
+    spiTransfer(dev->bus->busType_u.spi.instance, bmi270_maximum_fifo_config_file, NULL, sizeof(bmi270_maximum_fifo_config_file));
     IOHi(dev->busType_u.spi.csnPin);
 
     delay(10);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -83,7 +83,7 @@ void icm20649AccInit(accDev_t *acc) {
     // 2,048 LSB/g 16g
     // 1,024 LSB/g 30g
     acc->acc_1G = acc->acc_high_fsr ? 1024 : 2048;
-    spiSetDivisor(acc->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(acc->dev.bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     spiWriteReg(&acc->dev, ICM20649_RA_REG_BANK_SEL, 2 << 4); // config in bank 2
     delay(15);
     const uint8_t acc_fsr = acc->acc_high_fsr ? ICM20649_FSR_30G : ICM20649_FSR_16G;
@@ -105,7 +105,7 @@ bool icm20649SpiAccDetect(accDev_t *acc) {
 
 void icm20649GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_STANDARD); // ensure proper speed
     spiWriteReg(&gyro->dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
     spiWriteReg(&gyro->dev, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20649.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20649.c
@@ -49,13 +49,13 @@ static void icm20649SpiInit(const extDevice_t *dev) {
 #endif
     // all registers can be read/written at full speed (7MHz +-10%)
     // TODO verify that this works at 9MHz and 10MHz on non F7
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
 uint8_t icm20649SpiDetect(const extDevice_t *dev) {
     icm20649SpiInit(dev);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     spiWriteReg(dev, ICM20649_RA_REG_BANK_SEL, 0 << 4); // select bank 0 just to be safe
     delay(15);
     spiWriteReg(dev, ICM20649_RA_PWR_MGMT_1, ICM20649_BIT_RESET);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -107,7 +107,7 @@ bool icm20689SpiAccDetect(accDev_t *acc) {
 
 void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     delay(100);
     spiWriteReg(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
@@ -131,7 +131,7 @@ void icm20689GyroInit(gyroDev_t *gyro) {
 #ifdef USE_MPU_DATA_READY_SIGNAL
     spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
 #endif
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 
 bool icm20689SpiGyroDetect(gyroDev_t *gyro) {

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -47,13 +47,13 @@ static void icm20689SpiInit(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
 uint8_t icm20689SpiDetect(const extDevice_t *dev) {
     icm20689SpiInit(dev);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
@@ -84,7 +84,7 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -163,13 +163,13 @@ static void icm426xxSpiInit(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     hardwareInitialised = true;
 }
 
 uint8_t icm426xxSpiDetect(const extDevice_t *dev) {
     icm426xxSpiInit(dev);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, ICM426xx_BIT_RESET);
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
@@ -194,7 +194,7 @@ uint8_t icm426xxSpiDetect(const extDevice_t *dev) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm426xx.c
@@ -254,7 +254,7 @@ void icm426xxGyroInit(gyroDev_t *gyro)
 {
     mpuGyroInit(gyro);
 
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, spiCalculateDivider(ICM426XX_MAX_SPI_CLK_HZ));
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, spiCalculateDivider(ICM426XX_MAX_SPI_CLK_HZ));
 
     gyro->accDataReg = ICM426XX_RA_ACCEL_DATA_X1;
     gyro->gyroDataReg = ICM426XX_RA_GYRO_DATA_X1;

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -123,7 +123,7 @@ uint8_t mpu6000SpiDetect(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     uint8_t attemptsRemaining = 5;
     do {

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -102,11 +102,11 @@ static bool mpuSpi6000InitDone = false;
 void mpu6000SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     mpu6000AccAndGyroInit(gyro);
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Accel and Gyro DLPF Setting
     spiWriteReg(&gyro->dev, MPU6000_CONFIG, mpuGyroDLPF(gyro));
     delayMicroseconds(1);
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_FAST);  // 18 MHz SPI clock
     mpuGyroRead(gyro);
     if (((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) {
         failureMode(FAILURE_GYRO_INIT_FAILED);
@@ -161,7 +161,7 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro) {
     if (mpuSpi6000InitDone) {
         return;
     }
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
     // Device Reset
     spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, BIT_H_RESET);
     delay(150);
@@ -191,7 +191,7 @@ static void mpu6000AccAndGyroInit(gyroDev_t *gyro) {
     spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
     delayMicroseconds(15);
 #endif
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
     mpuSpi6000InitDone = true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -86,13 +86,13 @@ void mpu6500SpiAccInit(accDev_t *acc) {
 }
 
 void mpu6500SpiGyroInit(gyroDev_t *gyro) {
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_SLOW);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_SLOW);
     delayMicroseconds(1);
     mpu6500GyroInit(gyro);
     // Disable Primary I2C Interface
     spiWriteReg(&gyro->dev, MPU_RA_USER_CTRL, MPU6500_BIT_I2C_IF_DIS);
     delay(100);
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_FAST);
     delayMicroseconds(1);
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -45,7 +45,7 @@ static void mpu6500SpiInit(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_FAST);
 }
 
 uint8_t mpu6500SpiDetect(const extDevice_t *dev) {

--- a/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu9250.c
@@ -54,8 +54,8 @@ static bool mpuSpi9250InitDone = false;
 bool mpu9250SpiWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
     IOLo(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
-    spiTransferByte(dev->busType_u.spi.instance, reg);
-    spiTransferByte(dev->busType_u.spi.instance, data);
+    spiTransferByte(dev->bus->busType_u.spi.instance, reg);
+    spiTransferByte(dev->bus->busType_u.spi.instance, data);
     IOHi(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
     return true;
@@ -64,8 +64,8 @@ bool mpu9250SpiWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) 
 static bool mpu9250SpiSlowReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length) {
     IOLo(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
-    spiTransferByte(dev->busType_u.spi.instance, reg | 0x80); // read transaction
-    spiTransfer(dev->busType_u.spi.instance, NULL, data, length);
+    spiTransferByte(dev->bus->busType_u.spi.instance, reg | 0x80); // read transaction
+    spiTransfer(dev->bus->busType_u.spi.instance, NULL, data, length);
     IOHi(dev->busType_u.spi.csnPin);
     delayMicroseconds(1);
     return true;
@@ -86,11 +86,11 @@ void mpu9250SpiResetGyro(void) {
 void mpu9250SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     mpu9250AccAndGyroInit(gyro);
-    spiResetErrorCounter(gyro->dev.busType_u.spi.instance);
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
+    spiResetErrorCounter(gyro->dev.bus->busType_u.spi.instance);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_FAST); //high speed now that we don't need to write to the slow registers
     mpuGyroRead(gyro);
-    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(gyro->dev.busType_u.spi.instance) != 0) {
-        spiResetErrorCounter(gyro->dev.busType_u.spi.instance);
+    if ((((int8_t)gyro->gyroADCRaw[1]) == -1 && ((int8_t)gyro->gyroADCRaw[0]) == -1) || spiGetErrorCounter(gyro->dev.bus->busType_u.spi.instance) != 0) {
+        spiResetErrorCounter(gyro->dev.bus->busType_u.spi.instance);
         failureMode(FAILURE_GYRO_INIT_FAILED);
     }
 }
@@ -121,7 +121,7 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
     if (mpuSpi9250InitDone) {
         return;
     }
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed for writing to slow registers
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed for writing to slow registers
     mpu9250SpiWriteRegister(&gyro->dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     delay(50);
     mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
@@ -133,7 +133,7 @@ static void mpu9250AccAndGyroInit(gyroDev_t *gyro) {
 #if defined(USE_MPU_DATA_READY_SIGNAL)
     mpu9250SpiWriteRegisterVerify(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); //this resets register MPU_RA_PWR_MGMT_1 and won't read back correctly.
 #endif
-    spiSetDivisor(gyro->dev.busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_FAST);
     mpuSpi9250InitDone = true; //init done
 }
 
@@ -143,7 +143,7 @@ uint8_t mpu9250SpiDetect(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
     mpu9250SpiWriteRegister(dev, MPU_RA_PWR_MGMT_1, MPU9250_BIT_RESET);
     uint8_t attemptsRemaining = 20;
     do {
@@ -156,7 +156,7 @@ uint8_t mpu9250SpiDetect(const extDevice_t *dev) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_FAST);
     return MPU_9250_SPI;
 }
 

--- a/src/main/drivers/barometer/barometer_bmp085.c
+++ b/src/main/drivers/barometer/barometer_bmp085.c
@@ -181,7 +181,7 @@ bool bmp085Detect(const bmp085Config_t *config, baroDev_t *baro) {
 #endif
     delay(20); // datasheet says 10ms, we'll be careful and do 20.
     extDevice_t *dev = &baro->dev;
-    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
+    if ((dev->bus->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         // Default address for BMP085
         dev->busType_u.i2c.address = BMP085_I2C_ADDR;
         defaultAddressApplied = true;

--- a/src/main/drivers/barometer/barometer_bmp280.c
+++ b/src/main/drivers/barometer/barometer_bmp280.c
@@ -54,11 +54,11 @@ STATIC_UNIT_TESTED void bmp280_calculate(int32_t *pressure, int32_t *temperature
 
 void bmp280BusInit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         IOHi(dev->busType_u.spi.csnPin); // Disable
         IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
+        spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
     UNUSED(dev);
@@ -67,7 +67,7 @@ void bmp280BusInit(extDevice_t *dev) {
 
 void bmp280BusDeinit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_BMP280
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         spiPreinitCsByIO(dev->busType_u.spi.csnPin);
     }
 #else
@@ -80,7 +80,7 @@ bool bmp280Detect(baroDev_t *baro) {
     extDevice_t *dev = &baro->dev;
     bool defaultAddressApplied = false;
     bmp280BusInit(dev);
-    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
+    if ((dev->bus->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         // Default address for BMP280
         dev->busType_u.i2c.address = BMP280_I2C_ADDR;
         defaultAddressApplied = true;

--- a/src/main/drivers/barometer/barometer_lps.c
+++ b/src/main/drivers/barometer/barometer_lps.c
@@ -247,7 +247,7 @@ bool lpsDetect(baroDev_t *baro) {
     IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
     IOHi(dev->busType_u.spi.csnPin); // Disable
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD); // Baro can work only on up to 10Mhz SPI bus
     uint8_t temp = 0x00;
     lpsReadCommand(&baro->dev, LPS_WHO_AM_I, &temp, 1);
     if (temp != LPS25_ID && temp != LPS22_ID && temp != LPS33_ID && temp != LPS35_ID) {

--- a/src/main/drivers/barometer/barometer_ms5611.c
+++ b/src/main/drivers/barometer/barometer_ms5611.c
@@ -66,11 +66,11 @@ static uint8_t ms5611_osr = CMD_ADC_4096;
 
 void ms5611BusInit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         IOHi(dev->busType_u.spi.csnPin); // Disable
         IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
+        spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD); // XXX
     }
 #else
     UNUSED(dev);
@@ -79,7 +79,7 @@ void ms5611BusInit(extDevice_t *dev) {
 
 void ms5611BusDeinit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_MS5611
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         spiPreinitCsByIO(dev->busType_u.spi.csnPin);
     }
 #else
@@ -94,7 +94,7 @@ bool ms5611Detect(baroDev_t *baro) {
     delay(10); // No idea how long the chip takes to power-up, but let's make it 10ms
     extDevice_t *dev = &baro->dev;
     ms5611BusInit(dev);
-    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
+    if ((dev->bus->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         // Default address for MS5611
         dev->busType_u.i2c.address = MS5611_I2C_ADDR;
         defaultAddressApplied = true;

--- a/src/main/drivers/barometer/barometer_qmp6988.c
+++ b/src/main/drivers/barometer/barometer_qmp6988.c
@@ -99,11 +99,11 @@ STATIC_UNIT_TESTED void qmp6988_calculate(int32_t *pressure, int32_t *temperatur
 
 void qmp6988BusInit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         IOHi(dev->busType_u.spi.csnPin);
         IOInit(dev->busType_u.spi.csnPin, OWNER_BARO_CS, 0);
         IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+        spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     }
 #else
     UNUSED(dev);
@@ -112,7 +112,7 @@ void qmp6988BusInit(extDevice_t *dev) {
 
 void qmp6988BusDeinit(extDevice_t *dev) {
 #ifdef USE_BARO_SPI_QMP6988
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_IPU);
         IORelease(dev->busType_u.spi.csnPin);
         IOInit(dev->busType_u.spi.csnPin, OWNER_SPI_PREINIT, 0);
@@ -142,7 +142,7 @@ bool qmp6988Detect(baroDev_t *baro) {
     extDevice_t *dev = &baro->dev;
     bool defaultAddressApplied = false;
     qmp6988BusInit(dev);
-    if ((dev->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
+    if ((dev->bus->busType == BUS_TYPE_I2C) && (dev->busType_u.i2c.address == 0)) {
         dev->busType_u.i2c.address = QMP6988_I2C_ADDR;
         defaultAddressApplied = true;
     }

--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -86,18 +86,12 @@ typedef struct busDevice_s {
 } busDevice_t;
 
 // Per-device struct. Carries a back-pointer to the shared busDevice_t
-// (populated by spiSetBusInstance for SPI devices). The inline
-// busType/instance/handle fields are still present and authoritative;
-// removal is deferred pending a safe migration path (see stage-I-revert/SUMMARY.md).
+// (populated by spiSetBusInstance for SPI devices). Bus type and instance
+// are accessed via the bus back-pointer (dev->bus->busType / bus->busType_u.spi.instance).
 typedef struct extDevice_s {
     busDevice_t *bus;
-    busType_e busType;
     union {
         struct extSpi_s {
-            SPI_TypeDef *instance;
-#if defined(USE_HAL_DRIVER)
-            SPI_HandleTypeDef* handle; // cached here for efficiency
-#endif
             IO_t csnPin;
             uint16_t speed;
             bool leadingEdge;

--- a/src/main/drivers/bus_i2c_busdev.c
+++ b/src/main/drivers/bus_i2c_busdev.c
@@ -57,11 +57,6 @@ bool i2cBusSetInstance(extDevice_t *dev, uint32_t device)
     dev->bus->busType = BUS_TYPE_I2C;
     dev->bus->busType_u.i2c.device = I2C_CFG_TO_DEV(device);
 
-    // Transitional: keep inline fields authoritative until access-site
-    // migration lands. EmuFlight's i2cBus* accessors still read inline.
-    dev->busType = BUS_TYPE_I2C;
-    dev->busType_u.i2c.device = I2C_CFG_TO_DEV(device);
-
     return true;
 }
 #endif

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -171,9 +171,6 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
         bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
     }
 
-    // Keep inline fields populated (Stage I.4 deferred — access sites still read these).
-    dev->busType = BUS_TYPE_SPI;
-    dev->busType_u.spi.instance = instance;
     return true;
 }
 

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -201,7 +201,7 @@ void spiDmaEnable(const extDevice_t *dev, bool enable) {
 // Stage M.3 will defer HW application to transfer-start via the DMA init struct.
 void spiSetClkDivisor(const extDevice_t *dev, uint16_t divisor) {
     ((extDevice_t *)dev)->busType_u.spi.speed = divisor;
-    spiSetDivisor(dev->busType_u.spi.instance, divisor);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, divisor);
 }
 
 // Store per-device clock phase/polarity flag.
@@ -257,7 +257,7 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
     bus->curSegment = segments;
 
 #ifdef USE_DMA_SPI_DEVICE
-    if (dev->busType_u.spi.instance == USE_DMA_SPI_DEVICE) {
+    if (dev->bus->busType_u.spi.instance == USE_DMA_SPI_DEVICE) {
         // IMUF9001 custom DMA path: only supports single-segment transfers.
         if (segments[0].len > 0 && segments[1].len == 0) {
             uint8_t *txData = segments[0].u.buffers.txData;
@@ -292,7 +292,7 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
     IOLo(dev->busType_u.spi.csnPin);
 
     for (busSegment_t *seg = segments; seg->len > 0; seg++) {
-        spiTransfer(dev->busType_u.spi.instance,
+        spiTransfer(dev->bus->busType_u.spi.instance,
                     seg->u.buffers.txData,
                     seg->u.buffers.rxData,
                     seg->len);

--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -225,7 +225,7 @@ restart:
 
 static bool ak8963ReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *buf, uint8_t len) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (dev->busType == BUS_TYPE_MPU_SLAVE) {
+    if (dev->bus->busType == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveReadRegisterBuffer(dev, reg, buf, len);
     }
 #endif
@@ -234,7 +234,7 @@ static bool ak8963ReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_
 
 static bool ak8963WriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
-    if (dev->busType == BUS_TYPE_MPU_SLAVE) {
+    if (dev->bus->busType == BUS_TYPE_MPU_SLAVE) {
         return ak8963SlaveWriteRegister(dev, reg, data);
     }
 #endif
@@ -259,7 +259,7 @@ static bool ak8963Read(magDev_t *mag, int16_t *magData) {
     bool ack = false;
     uint8_t buf[7];
     const extDevice_t *dev = &mag->dev;
-    switch (dev->busType) {
+    switch (dev->bus->busType) {
 #if defined(USE_MAG_SPI_AK8963) || defined(USE_MAG_AK8963)
     case BUS_TYPE_I2C:
     case BUS_TYPE_SPI:
@@ -308,7 +308,7 @@ static bool ak8963Init(magDev_t *mag) {
 }
 
 void ak8963BusInit(const extDevice_t *dev) {
-    switch (dev->busType) {
+    switch (dev->bus->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
         UNUSED(dev);
@@ -319,7 +319,7 @@ void ak8963BusInit(const extDevice_t *dev) {
         IOHi(dev->busType_u.spi.csnPin);                                                  // Disable
         IOInit(dev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
         IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-        spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+        spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
         break;
 #endif
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
@@ -337,7 +337,7 @@ void ak8963BusInit(const extDevice_t *dev) {
 }
 
 void ak8963BusDeInit(const extDevice_t *dev) {
-    switch (dev->busType) {
+    switch (dev->bus->busType) {
 #ifdef USE_MAG_AK8963
     case BUS_TYPE_I2C:
         UNUSED(dev);
@@ -361,7 +361,7 @@ void ak8963BusDeInit(const extDevice_t *dev) {
 bool ak8963Detect(magDev_t *mag) {
     uint8_t sig = 0;
     extDevice_t *dev = &mag->dev;
-    if ((dev->busType == BUS_TYPE_I2C || dev->busType == BUS_TYPE_MPU_SLAVE) && dev->busType_u.mpuSlave.address == 0) {
+    if ((dev->bus->busType == BUS_TYPE_I2C || dev->bus->busType == BUS_TYPE_MPU_SLAVE) && dev->busType_u.mpuSlave.address == 0) {
         dev->busType_u.mpuSlave.address = AK8963_MAG_I2C_ADDRESS;
     }
     ak8963BusInit(dev);

--- a/src/main/drivers/compass/compass_ak8975.c
+++ b/src/main/drivers/compass/compass_ak8975.c
@@ -135,7 +135,7 @@ static bool ak8975Read(magDev_t *mag, int16_t *magData) {
 bool ak8975Detect(magDev_t *mag) {
     uint8_t sig = 0;
     extDevice_t *dev = &mag->dev;
-    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+    if (dev->bus->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
         dev->busType_u.i2c.address = AK8975_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(dev, AK8975_MAG_REG_WIA, &sig, 1);

--- a/src/main/drivers/compass/compass_hmc5883l.c
+++ b/src/main/drivers/compass/compass_hmc5883l.c
@@ -186,7 +186,7 @@ static void hmc5883SpiInit(extDevice_t *dev) {
     IOHi(dev->busType_u.spi.csnPin); // Disable
     IOInit(dev->busType_u.spi.csnPin, OWNER_COMPASS_CS, 0);
     IOConfigGPIO(dev->busType_u.spi.csnPin, IOCFG_OUT_PP);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 #endif
 
@@ -218,12 +218,12 @@ bool hmc5883lDetect(magDev_t* mag) {
     extDevice_t *dev = &mag->dev;
     uint8_t sig = 0;
 #ifdef USE_MAG_SPI_HMC5883
-    if (dev->busType == BUS_TYPE_SPI) {
+    if (dev->bus->busType == BUS_TYPE_SPI) {
         hmc5883SpiInit(&mag->dev);
     }
 #endif
 #ifdef USE_MAG_HMC5883
-    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+    if (dev->bus->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
         dev->busType_u.i2c.address = HMC5883_MAG_I2C_ADDRESS;
     }
 #endif

--- a/src/main/drivers/compass/compass_lis3mdl.c
+++ b/src/main/drivers/compass/compass_lis3mdl.c
@@ -128,7 +128,7 @@ static bool lis3mdlInit(magDev_t *mag) {
 bool lis3mdlDetect(magDev_t * mag) {
     extDevice_t *dev = &mag->dev;
     uint8_t sig = 0;
-    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+    if (dev->bus->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
         dev->busType_u.i2c.address = LIS3MDL_MAG_I2C_ADDRESS;
     }
     bool ack = busReadRegisterBuffer(&mag->dev, LIS3MDL_REG_WHO_AM_I, &sig, 1);

--- a/src/main/drivers/compass/compass_qmc5883l.c
+++ b/src/main/drivers/compass/compass_qmc5883l.c
@@ -108,7 +108,7 @@ static bool qmc5883lRead(magDev_t *magDev, int16_t *magData) {
 
 bool qmc5883lDetect(magDev_t *magDev) {
     extDevice_t *dev = &magDev->dev;
-    if (dev->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
+    if (dev->bus->busType == BUS_TYPE_I2C && dev->busType_u.i2c.address == 0) {
         dev->busType_u.i2c.address = QMC5883L_MAG_I2C_ADDRESS;
     }
     // Must write reset first  - don't care about the result

--- a/src/main/drivers/flash.c
+++ b/src/main/drivers/flash.c
@@ -60,8 +60,8 @@ bool flashInit(const flashConfig_t *flashConfig) {
     IOHi(dev->busType_u.spi.csnPin);
 #ifndef FLASH_SPI_SHARED
     //Maximum speed for standard READ command is 20mHz, other commands tolerate 25mHz
-    //spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_FAST);
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD * 2);
+    //spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD * 2);
 #endif
     flashDevice.dev = dev;
     const uint8_t out[] = { SPIFLASH_INSTRUCTION_RDID, 0, 0, 0 };

--- a/src/main/drivers/flash_m25p16.c
+++ b/src/main/drivers/flash_m25p16.c
@@ -91,7 +91,7 @@ static void m25p16_enable(extDevice_t *dev) {
 
 static void m25p16_transfer(extDevice_t *dev, const uint8_t *txData, uint8_t *rxData, int len) {
     m25p16_enable(dev);
-    spiTransfer(dev->busType_u.spi.instance, txData, rxData, len);
+    spiTransfer(dev->bus->busType_u.spi.instance, txData, rxData, len);
     m25p16_disable(dev);
 }
 
@@ -100,7 +100,7 @@ static void m25p16_transfer(extDevice_t *dev, const uint8_t *txData, uint8_t *rx
  */
 static void m25p16_performOneByteCommand(extDevice_t *dev, uint8_t command) {
     m25p16_enable(dev);
-    spiTransferByte(dev->busType_u.spi.instance, command);
+    spiTransferByte(dev->bus->busType_u.spi.instance, command);
     m25p16_disable(dev);
 }
 
@@ -230,8 +230,8 @@ static void m25p16_pageProgramContinue(flashDevice_t *fdevice, const uint8_t *da
     m25p16_waitForReady(fdevice, DEFAULT_TIMEOUT_MILLIS);
     m25p16_writeEnable(fdevice);
     m25p16_enable(fdevice->dev);
-    spiTransfer(fdevice->dev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
-    spiTransfer(fdevice->dev->busType_u.spi.instance, data, NULL, length);
+    spiTransfer(fdevice->dev->bus->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
+    spiTransfer(fdevice->dev->bus->busType_u.spi.instance, data, NULL, length);
     m25p16_disable(fdevice->dev);
     fdevice->currentWriteAddress += length;
 }
@@ -276,8 +276,8 @@ static int m25p16_readBytes(flashDevice_t *fdevice, uint32_t address, uint8_t *b
         return 0;
     }
     m25p16_enable(fdevice->dev);
-    spiTransfer(fdevice->dev->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
-    spiTransfer(fdevice->dev->busType_u.spi.instance, NULL, buffer, length);
+    spiTransfer(fdevice->dev->bus->busType_u.spi.instance, command, NULL, fdevice->isLargeFlash ? 5 : 4);
+    spiTransfer(fdevice->dev->bus->busType_u.spi.instance, NULL, buffer, length);
     m25p16_disable(fdevice->dev);
     return length;
 }

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -175,13 +175,13 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-#define __spiBusTransactionBegin(dev)        {spiSetDivisor((dev)->busType_u.spi.instance, max7456SpiClock);IOLo((dev)->busType_u.spi.csnPin);}
+#define __spiBusTransactionBegin(dev)        {spiSetDivisor((dev)->bus->busType_u.spi.instance, max7456SpiClock);IOLo((dev)->busType_u.spi.csnPin);}
 #else
 #define __spiBusTransactionBegin(dev)        IOLo((dev)->busType_u.spi.csnPin)
 #endif
 
 #ifdef MAX7456_RESTORE_CLK
-#define __spiBusTransactionEnd(dev)       {IOHi((dev)->busType_u.spi.csnPin);spiSetDivisor((dev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
+#define __spiBusTransactionEnd(dev)       {IOHi((dev)->busType_u.spi.csnPin);spiSetDivisor((dev)->bus->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
 #else
 #define __spiBusTransactionEnd(dev)       IOHi((dev)->busType_u.spi.csnPin)
 #endif
@@ -228,11 +228,11 @@ static uint8_t max7456DeviceType;
 static void max7456DrawScreenSlow(void);
 
 static uint8_t max7456Send(uint8_t add, uint8_t data) {
-    spiTransferByte(dev->busType_u.spi.instance, add);
+    spiTransferByte(dev->bus->busType_u.spi.instance, add);
 #ifdef USE_NBD7456
     delayMicroseconds(10);
 #endif
-    return spiTransferByte(dev->busType_u.spi.instance, data);
+    return spiTransferByte(dev->bus->busType_u.spi.instance, data);
 }
 
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -250,7 +250,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
 #endif
     // Common to both channels
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(dev->busType_u.spi.instance->DR));
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(dev->bus->busType_u.spi.instance->DR));
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
@@ -289,7 +289,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
     // Enable SPI TX/RX request
     __spiBusTransactionBegin(dev);
     dmaTransactionInProgress = true;
-    SPI_I2S_DMACmd(dev->busType_u.spi.instance,
+    SPI_I2S_DMACmd(dev->bus->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                    SPI_I2S_DMAReq_Rx |
 #endif
@@ -302,16 +302,16 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         DMA_Cmd(MAX7456_DMA_CHANNEL_RX, DISABLE);
 #endif
         // Make sure SPI DMA transfer is complete
-        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
-        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
+        while (SPI_I2S_GetFlagStatus (dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
+        while (SPI_I2S_GetFlagStatus (dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
-        while (SPI_I2S_GetFlagStatus(dev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            dev->busType_u.spi.instance->DR;
+        while (SPI_I2S_GetFlagStatus(dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
+            dev->bus->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-        SPI_I2S_DMACmd(dev->busType_u.spi.instance,
+        SPI_I2S_DMACmd(dev->bus->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                        SPI_I2S_DMAReq_Rx |
 #endif
@@ -400,7 +400,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     }
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
-    spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
     max7456Send(MAX7456ADD_CMAL, (1 << 6)); // CA[8] bit
     if (max7456Send(MAX7456ADD_CMAL | MAX7456ADD_READ, 0xff) & (1 << 6)) {
         max7456DeviceType = MAX7456_DEVICE_TYPE_AT;
@@ -427,7 +427,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, max7456SpiClock);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, max7456SpiClock);
     // force soft reset on Max7456
     __spiBusTransactionBegin(dev);
     max7456Send(MAX7456ADD_VM0, MAX7456_RESET);
@@ -582,10 +582,10 @@ void max7456DrawScreen(void) {
 #ifdef USE_NBD7456
             for(int k = 0; k < buff_len; k++) {
                 delayMicroseconds(5);
-                spiTransferByte(dev->busType_u.spi.instance, spiBuff[k]);
+                spiTransferByte(dev->bus->busType_u.spi.instance, spiBuff[k]);
             }
 #else // USE_NBD7456
-            spiTransfer(dev->busType_u.spi.instance, spiBuff, NULL, buff_len);
+            spiTransfer(dev->bus->busType_u.spi.instance, spiBuff, NULL, buff_len);
 #endif
             __spiBusTransactionEnd(dev);
 #endif // MAX7456_DMA_CHANNEL_TX

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -175,13 +175,13 @@
 // On shared SPI buss we want to change clock for OSD chip and restore for other devices.
 
 #ifdef MAX7456_SPI_CLK
-#define __spiBusTransactionBegin(dev)        {spiSetDivisor((dev)->busType_u.spi.instance, max7456SpiClock);IOLo((dev)->busType_u.spi.csnPin);}
+#define __spiBusTransactionBegin(dev)        {spiSetDivisor((dev)->bus->busType_u.spi.instance, max7456SpiClock);IOLo((dev)->busType_u.spi.csnPin);}
 #else
 #define __spiBusTransactionBegin(dev)        IOLo((dev)->busType_u.spi.csnPin)
 #endif
 
 #ifdef MAX7456_RESTORE_CLK
-#define __spiBusTransactionEnd(dev)       {IOHi((dev)->busType_u.spi.csnPin);spiSetDivisor((dev)->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
+#define __spiBusTransactionEnd(dev)       {IOHi((dev)->busType_u.spi.csnPin);spiSetDivisor((dev)->bus->busType_u.spi.instance, MAX7456_RESTORE_CLK);}
 #else
 #define __spiBusTransactionEnd(dev)       IOHi((dev)->busType_u.spi.csnPin)
 #endif
@@ -228,9 +228,9 @@ static uint8_t max7456DeviceType;
 static void max7456DrawScreenSlow(void);
 
 static uint8_t max7456Send(uint8_t add, uint8_t data) {
-    spiTransferByte(dev->busType_u.spi.instance, add);
+    spiTransferByte(dev->bus->busType_u.spi.instance, add);
     delayMicroseconds(10);
-    return spiTransferByte(dev->busType_u.spi.instance, data);
+    return spiTransferByte(dev->bus->busType_u.spi.instance, data);
 }
 
 #ifdef MAX7456_DMA_CHANNEL_TX
@@ -248,7 +248,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
 #endif
     // Common to both channels
     DMA_StructInit(&DMA_InitStructure);
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(dev->busType_u.spi.instance->DR));
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)(&(dev->bus->busType_u.spi.instance->DR));
     DMA_InitStructure.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
     DMA_InitStructure.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
@@ -287,7 +287,7 @@ static void max7456SendDma(void* tx_buffer, void* rx_buffer, uint16_t buffer_siz
     // Enable SPI TX/RX request
     __spiBusTransactionBegin(dev);
     dmaTransactionInProgress = true;
-    SPI_I2S_DMACmd(dev->busType_u.spi.instance,
+    SPI_I2S_DMACmd(dev->bus->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                    SPI_I2S_DMAReq_Rx |
 #endif
@@ -300,16 +300,16 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         DMA_Cmd(MAX7456_DMA_CHANNEL_RX, DISABLE);
 #endif
         // Make sure SPI DMA transfer is complete
-        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
-        while (SPI_I2S_GetFlagStatus (dev->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
+        while (SPI_I2S_GetFlagStatus (dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_TXE) == RESET) {};
+        while (SPI_I2S_GetFlagStatus (dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_BSY) == SET) {};
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
-        while (SPI_I2S_GetFlagStatus(dev->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            dev->busType_u.spi.instance->DR;
+        while (SPI_I2S_GetFlagStatus(dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
+            dev->bus->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);
-        SPI_I2S_DMACmd(dev->busType_u.spi.instance,
+        SPI_I2S_DMACmd(dev->bus->busType_u.spi.instance,
 #ifdef MAX7456_DMA_CHANNEL_RX
                        SPI_I2S_DMAReq_Rx |
 #endif
@@ -398,7 +398,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     }
     // Detect device type by writing and reading CA[8] bit at CMAL[6].
     // Do this at half the speed for safety.
-    spiSetDivisor(dev->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, MAX7456_SPI_CLK * 2);
     max7456Send(MAX7456ADD_CMAL, (1 << 6)); // CA[8] bit
     if (max7456Send(MAX7456ADD_CMAL | MAX7456ADD_READ, 0xff) & (1 << 6)) {
         max7456DeviceType = MAX7456_DEVICE_TYPE_AT;
@@ -425,7 +425,7 @@ bool max7456Init(const max7456Config_t *max7456Config, const vcdProfile_t *pVcdP
     UNUSED(max7456Config);
     UNUSED(cpuOverclock);
 #endif
-    spiSetDivisor(dev->busType_u.spi.instance, max7456SpiClock);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, max7456SpiClock);
     // force soft reset on Max7456
     __spiBusTransactionBegin(dev);
     max7456Send(MAX7456ADD_VM0, MAX7456_RESET);
@@ -575,12 +575,12 @@ void max7456DrawScreen(void) {
             max7456SendDma(spiBuff, NULL, buff_len);
 #else
             // __spiBusTransactionBegin(dev);
-            // spiTransfer(dev->busType_u.spi.instance, spiBuff, NULL, buff_len);
+            // spiTransfer(dev->bus->busType_u.spi.instance, spiBuff, NULL, buff_len);
             // __spiBusTransactionEnd(dev);
             __spiBusTransactionBegin(dev);
             for(int k = 0; k < buff_len; k++) {
                 delayMicroseconds(5);
-                spiTransferByte(dev->busType_u.spi.instance, spiBuff[k]);
+                spiTransferByte(dev->bus->busType_u.spi.instance, spiBuff[k]);
             }
             __spiBusTransactionEnd(dev);
 #endif // MAX7456_DMA_CHANNEL_TX

--- a/src/main/drivers/rx/rx_spi.c
+++ b/src/main/drivers/rx/rx_spi.c
@@ -56,12 +56,12 @@ bool rxSpiDeviceInit(const rxSpiConfig_t *rxSpiConfig) {
     IOConfigGPIO(rxCsPin, SPI_IO_CS_CFG);
     dev->busType_u.spi.csnPin = rxCsPin;
     DISABLE_RX();
-    spiSetDivisor(dev->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return true;
 }
 
 uint8_t rxSpiTransferByte(uint8_t data) {
-    return spiTransferByte(dev->busType_u.spi.instance, data);
+    return spiTransferByte(dev->bus->busType_u.spi.instance, data);
 }
 
 uint8_t rxSpiWriteByte(uint8_t data) {

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -161,7 +161,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_HMC5883:
 #if defined(USE_MAG_HMC5883) || defined(USE_MAG_SPI_HMC5883)
-        if (extDev->busType == BUS_TYPE_I2C) {
+        if (extDev->bus->busType == BUS_TYPE_I2C) {
             extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (hmc5883lDetect(dev)) {
@@ -175,7 +175,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_QMC5883:
 #ifdef USE_MAG_QMC5883
-        if (extDev->busType == BUS_TYPE_I2C) {
+        if (extDev->bus->busType == BUS_TYPE_I2C) {
             extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (qmc5883lDetect(dev)) {
@@ -189,7 +189,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8975:
 #ifdef USE_MAG_AK8975
-        if (extDev->busType == BUS_TYPE_I2C) {
+        if (extDev->bus->busType == BUS_TYPE_I2C) {
             extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (ak8975Detect(dev)) {
@@ -203,7 +203,7 @@ bool compassDetect(magDev_t *dev) {
         FALLTHROUGH;
     case MAG_AK8963:
 #if defined(USE_MAG_AK8963) || defined(USE_MAG_SPI_AK8963)
-        if (extDev->busType == BUS_TYPE_I2C) {
+        if (extDev->bus->busType == BUS_TYPE_I2C) {
             extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -141,7 +141,6 @@ bool compassDetect(magDev_t *dev) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE: {
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            extDev->busType = BUS_TYPE_MPU_SLAVE;
             extDev->busType_u.mpuSlave.master = gyroSensorBus();
             extDev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
             extDev->bus->busType = BUS_TYPE_MPU_SLAVE;
@@ -207,7 +206,6 @@ bool compassDetect(magDev_t *dev) {
             extDev->busType_u.i2c.address = compassConfig()->mag_i2c_address;
         }
         if (gyroMpuDetectionResult()->sensor == MPU_9250_SPI) {
-            extDev->busType = BUS_TYPE_MPU_SLAVE;
             extDev->busType_u.mpuSlave.address = compassConfig()->mag_i2c_address;
             extDev->busType_u.mpuSlave.master = gyroSensorBus();
             extDev->bus->busType = BUS_TYPE_MPU_SLAVE;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -700,10 +700,7 @@ bool gyroInit(void) {
 #ifdef GYRO_1_ALIGN
     gyroSensor1.gyroDev.gyroAlign = GYRO_1_ALIGN;
 #endif
-    gyroSensor1.gyroDev.dev.busType = BUS_TYPE_SPI;
-    if (!spiSetBusInstance(&gyroSensor1.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_1_SPI_BUS))) {
-        gyroSensor1.gyroDev.dev.busType = BUS_TYPE_NONE;
-    }
+    spiSetBusInstance(&gyroSensor1.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_1_SPI_BUS));
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor1);
         if (!ret) {
@@ -727,10 +724,7 @@ bool gyroInit(void) {
 #ifdef GYRO_2_ALIGN
     gyroSensor2.gyroDev.gyroAlign = GYRO_2_ALIGN;
 #endif
-    gyroSensor2.gyroDev.dev.busType = BUS_TYPE_SPI;
-    if (!spiSetBusInstance(&gyroSensor2.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_2_SPI_BUS))) {
-        gyroSensor2.gyroDev.dev.busType = BUS_TYPE_NONE;
-    }
+    spiSetBusInstance(&gyroSensor2.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_2_SPI_BUS));
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
         ret = gyroInitSensor(&gyroSensor2);
         if (!ret) {


### PR DESCRIPTION
## Summary

- **Stage I.4** of the `extDevice_t` architectural refactor — removes the three inline redundant fields (`busType_e busType`, `SPI_TypeDef *instance`, `SPI_HandleTypeDef *handle`) from `extDevice_s` and all dual-write bookkeeping from the bus setters.
- All SPI `instance` reads were migrated to `dev->bus->busType_u.spi.instance` across 14 incremental commits (I.4.b–I.4.j.5) before the fields were removed.
- Bus type dispatch now exclusively via `dev->bus->busType`; per-device config (`csnPin`, `speed`, `leadingEdge`) retained in `extDevice_t`.

## Root cause of previous I.4 brick (resolved)

Earlier attempts to remove these fields bricked PYRODRONEF7 (F7/MPU6000). Root cause:

Removing `instance` and `handle` from `extSpi_s` moved `csnPin` to **union offset 0**, aliasing `busType_u.i2c.device`. For non-`USE_DUAL_GYRO` SPI targets, `mpuDetect` runs an I2C auto-probe (bus is NULL before detection). `i2cBusSetInstance` writes `busType_u.i2c.device` (≈ 1–2) to offset 0, corrupting `csnPin`. The `csnPin == IO_NONE` guard in `detectSPISensorsAndUpdateDetectionResult` then evaluates false (non-zero ≠ IO_NONE), so the CS pin is never assigned from `MPU6000_CS_PIN`. `IOLo(corrupted_csnPin)` → hardfault → brick.

**Fix (I.4.k):** after a failed I2C probe in `mpuDetect`, reset `dev->bus = NULL` and `memset(&dev->busType_u, 0, ...)` before falling through to SPI detection. This clears the alias and restores the `IO_NONE` invariant.

## Commits in this PR

| Commit | Description |
|---|---|
| `a628679` | I.4.b: migrate barometer_lps SPI instance |
| `bd9af0b` | I.4.c: migrate barometer_bmp280 busType/instance |
| `c2b1713` | I.4.d: migrate barometer_ms5611 + barometer_qmp6988 |
| `c8643cb` | I.4.e: migrate barometer_bmp085, flash.c, flash_m25p16 |
| `ca6e6d1` | I.4.f: migrate max7456 + nbd7456 |
| `b5c043c` | I.4.g: migrate rx_spi |
| `a3c3dac` | I.4.h: migrate bus_spi.c reads |
| `67ccdf0` | I.4.i: migrate compass drivers |
| `03353cc`–`753c3b3` | I.4.j.1–j.5: migrate all gyro/acc SPI instance paths |
| `16d1d69` | I.4.k: remove fields + fix mpuDetect union reset |

## Test plan

- [x] `make test` — unit tests pass
- [x] Bench targets (8): HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 — all compile clean, zero new warnings
- [x] Compile targets (4): MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 — clean
- [x] Unique targets (11): CRAZYFLIE2 ANYFCF7 ELLE0 F4BY STM32F4DISCOVERY NUCLEOF446RE BEEBRAIN_PRO BEEBRAIN_LITE AG3XF4 AG3XF7 COLIBRI — clean
- [x] Hardware bench verified by author (TUNERCF405 BMI270, PYRODRONEF7 F7/MPU6000)

AI Generated comment — Claude AI (Anthropic) assisted with root-cause analysis and implementation of the union-reset fix.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal device bus configuration access patterns across sensor drivers (accelerometer, gyro, barometer, compass, flash, and OSD). Changes standardize how bus settings are referenced throughout the codebase without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->