### PR TITLE
refactor(bus): Stage M.3.a/b — port spiSequenceStart polled path (BF 4.5-m parity)

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -194,11 +194,9 @@ void spiDmaEnable(const extDevice_t *dev, bool enable) {
     ((extDevice_t *)dev)->useDMA = enable;
 }
 
-// Store per-device clock divisor and apply it immediately to the SPI peripheral.
-// Stage M.3 will defer HW application to transfer-start via the DMA init struct.
+// Store per-device clock divisor; hardware applied at spiSequenceStart time.
 void spiSetClkDivisor(const extDevice_t *dev, uint16_t divisor) {
     ((extDevice_t *)dev)->busType_u.spi.speed = divisor;
-    spiSetDivisor(dev->bus->busType_u.spi.instance, divisor);
 }
 
 // Store per-device clock phase/polarity flag.
@@ -242,10 +240,6 @@ void spiLinkSegments(const extDevice_t *dev, busSegment_t *firstSegment, busSegm
     endSegment->u.link.segments = secondSegment;
 }
 
-// Synchronous segment-based SPI transfer.
-// Processes each segment in order: asserts CS once, transfers data, deasserts CS
-// according to negateCS. The USE_DMA_SPI_DEVICE (IMUF9001) single-segment DMA path
-// is preserved as a special case; multi-segment always uses synchronous spiTransfer.
 void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
     busDevice_t *bus = dev->bus;
 
@@ -285,28 +279,7 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
     }
 #endif
 
-    // Synchronous path: assert CS, process all segments, handle CS per negateCS flag.
-    IOLo(dev->busType_u.spi.csnPin);
-
-    for (busSegment_t *seg = segments; seg->len > 0; seg++) {
-        spiTransfer(dev->bus->busType_u.spi.instance,
-                    seg->u.buffers.txData,
-                    seg->u.buffers.rxData,
-                    seg->len);
-
-        if (seg->callback) {
-            seg->callback(dev->callbackArg);
-        }
-
-        if (seg->negateCS) {
-            IOHi(dev->busType_u.spi.csnPin);
-            if ((seg + 1)->len > 0) {
-                IOLo(dev->busType_u.spi.csnPin);
-            }
-        }
-    }
-
-    bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+    spiSequenceStart(dev);
 }
 
 void spiReadWriteBuf(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, int len) {

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -128,9 +128,7 @@ void spiInitBusDMA(void);
 uint16_t spiCalculateDivider(uint32_t freq);
 uint32_t spiCalculateClock(uint16_t spiClkDivisor);
 
-// Per-device clock and phase settings.
-// spiSetClkDivisor also immediately applies the divisor to the SPI peripheral
-// (synchronous path; Stage M.3 will defer to transfer-start via DMA init struct).
+// Per-device clock and phase settings; hardware applied at spiSequenceStart time.
 void spiSetClkDivisor(const extDevice_t *dev, uint16_t divider);
 void spiSetClkPhasePolarity(const extDevice_t *dev, bool leadingEdge);
 
@@ -138,9 +136,9 @@ void spiSetClkPhasePolarity(const extDevice_t *dev, bool leadingEdge);
 // (DMA transfers are not yet active; bus->useDMA stays false until spiInitBusDMA).
 void spiDmaEnable(const extDevice_t *dev, bool enable);
 
-// Segment-based async SPI API (matches BF 4.5-maintenance).
-// Stage M.1: spiSequence executes synchronously; spiIsBusy always returns false
-// after spiSequence returns; spiWait is a no-op.
+// Segment-based SPI API (matches BF 4.5-maintenance).
+// Dispatches via spiSequenceStart: polled when bus->useDMA is false,
+// DMA when enabled by spiInitBusDMA.
 void spiSequence(const extDevice_t *dev, busSegment_t *segments);
 void spiWait(const extDevice_t *dev);
 void spiRelease(const extDevice_t *dev);

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -73,6 +73,24 @@ spiDevice_t spiDevice[SPIDEV_COUNT];
 #endif
 
 #define SPI_DEFAULT_TIMEOUT 10
+#define SPI_DMA_THRESHOLD 8
+
+#ifdef STM32F7
+#define IS_DTCM(p) (((uint32_t)(p) & 0xffff0000) == 0x20000000)
+#endif
+
+static uint32_t spiDivisorToBRbits(SPI_TypeDef *instance, uint16_t divisor)
+{
+#if !(defined(STM32F1) || defined(STM32F3))
+    if (instance == SPI2 || instance == SPI3) {
+        divisor /= 2;
+    }
+#else
+    UNUSED(instance);
+#endif
+    // divisor | 0x100 ensures non-zero; ffs maps power-of-2 divisor to prescaler index.
+    return (ffs(divisor | 0x100) - 2) << SPI_CR1_BR_Pos;
+}
 
 void spiInitDevice(SPIDevice device) {
     spiDevice_t *spi = &(spiDevice[device]);
@@ -195,9 +213,120 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     return true;
 }
 
-// Platform-internal DMA functions — stubs for Stage M.1.
-// Stage M.3 will provide full implementations once dma_reqmap is ported.
-void spiSequenceStart(const extDevice_t *dev) { UNUSED(dev); }
+// DMA transfer setup and start (BF 4.5-maintenance parity).
+// Handles per-device speed and polarity switching, then dispatches to DMA path
+// (when bus->useDMA is enabled by spiInitBusDMA, Stage M.3.d) or polled path.
+FAST_CODE void spiSequenceStart(const extDevice_t *dev)
+{
+    busDevice_t *bus = dev->bus;
+    SPI_TypeDef *instance = bus->busType_u.spi.instance;
+    spiDevice_t *spi = &spiDevice[spiDeviceByInstance(instance)];
+    bool dmaSafe = dev->useDMA;
+    uint32_t xferLen = 0;
+    uint32_t segmentCount = 0;
+
+    bus->initSegment = true;
+
+    LL_SPI_Disable(instance);
+
+    if (dev->busType_u.spi.speed != bus->busType_u.spi.speed) {
+        LL_SPI_SetBaudRatePrescaler(instance, spiDivisorToBRbits(instance, dev->busType_u.spi.speed));
+        bus->busType_u.spi.speed = dev->busType_u.spi.speed;
+    }
+
+    if (dev->busType_u.spi.leadingEdge != bus->busType_u.spi.leadingEdge) {
+        if (dev->busType_u.spi.leadingEdge) {
+            IOConfigGPIOAF(IOGetByTag(spi->sck), SPI_IO_AF_SCK_CFG_LOW, spi->sckAF);
+            LL_SPI_SetClockPhase(instance, LL_SPI_PHASE_1EDGE);
+            LL_SPI_SetClockPolarity(instance, LL_SPI_POLARITY_LOW);
+        } else {
+            IOConfigGPIOAF(IOGetByTag(spi->sck), SPI_IO_AF_SCK_CFG_HIGH, spi->sckAF);
+            LL_SPI_SetClockPhase(instance, LL_SPI_PHASE_2EDGE);
+            LL_SPI_SetClockPolarity(instance, LL_SPI_POLARITY_HIGH);
+        }
+        bus->busType_u.spi.leadingEdge = dev->busType_u.spi.leadingEdge;
+    }
+
+    LL_SPI_Enable(instance);
+
+    // Scan the segment list for DMA safety (cache alignment, DTCM region).
+    for (busSegment_t *checkSegment = (busSegment_t *)bus->curSegment; checkSegment->len; checkSegment++) {
+        if ((checkSegment->u.buffers.rxData) && (bus->dmaRx == (dmaChannelDescriptor_t *)NULL)) {
+            dmaSafe = false;
+            break;
+        }
+#ifdef STM32F7
+        // Non-DTCM Rx buffers must be cache-line aligned for DMA on F7.
+        if ((checkSegment->u.buffers.rxData) && !IS_DTCM(checkSegment->u.buffers.rxData) &&
+            (((uint32_t)checkSegment->u.buffers.rxData & 31) || (checkSegment->len & 31))) {
+            dmaSafe = false;
+            break;
+        }
+#endif
+        segmentCount++;
+        xferLen += checkSegment->len;
+    }
+
+    // Use DMA if available and safe (dead path until spiInitBusDMA sets bus->useDMA, Stage M.3.d).
+    if (bus->useDMA && dmaSafe && ((segmentCount > 1) ||
+                                    (xferLen >= SPI_DMA_THRESHOLD) ||
+                                    !bus->curSegment[segmentCount].negateCS)) {
+        spiInternalInitStream(dev, false);
+        IOLo(dev->busType_u.spi.csnPin);
+        spiInternalStartDMA(dev);
+    } else {
+        busSegment_t *lastSegment = NULL;
+        bool segmentComplete;
+
+        while (bus->curSegment->len) {
+            if (!lastSegment || lastSegment->negateCS) {
+                IOLo(dev->busType_u.spi.csnPin);
+            }
+
+            spiTransfer(instance,
+                        bus->curSegment->u.buffers.txData,
+                        bus->curSegment->u.buffers.rxData,
+                        bus->curSegment->len);
+
+            if (bus->curSegment->negateCS) {
+                IOHi(dev->busType_u.spi.csnPin);
+            }
+
+            segmentComplete = true;
+            if (bus->curSegment->callback) {
+                switch (bus->curSegment->callback(dev->callbackArg)) {
+                case BUS_BUSY:
+                    segmentComplete = false;
+                    break;
+                case BUS_ABORT:
+                    bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+                    return;
+                case BUS_READY:
+                default:
+                    break;
+                }
+            }
+            if (segmentComplete) {
+                lastSegment = (busSegment_t *)bus->curSegment;
+                bus->curSegment++;
+            }
+        }
+
+        if (bus->curSegment->u.link.dev) {
+            busSegment_t *endSegment = (busSegment_t *)bus->curSegment;
+            const extDevice_t *nextDev = endSegment->u.link.dev;
+            busSegment_t *nextSegments = (busSegment_t *)endSegment->u.link.segments;
+            bus->curSegment = nextSegments;
+            endSegment->u.link.dev = NULL;
+            endSegment->u.link.segments = NULL;
+            spiSequenceStart(nextDev);
+        } else {
+            bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+        }
+    }
+}
+
+// Platform-internal DMA functions — stubs until Stage M.3.d (dma_reqmap + spiInitBusDMA).
 void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
 void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }
 void spiInternalStopDMA(const extDevice_t *dev) { UNUSED(dev); }

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -154,9 +154,118 @@ bool spiTransfer(SPI_TypeDef *instance, const uint8_t *txData, uint8_t *rxData, 
     return true;
 }
 
-// Platform-internal DMA functions — stubs for Stage M.1.
-// Stage M.3 will provide full implementations once dma_reqmap is ported.
-void spiSequenceStart(const extDevice_t *dev) { UNUSED(dev); }
+#define SPI_DMA_THRESHOLD 8
+
+// DMA transfer setup and start (BF 4.5-maintenance parity, stdperiph API).
+// Handles per-device speed and polarity switching, then dispatches to DMA path
+// (when bus->useDMA is enabled by spiInitBusDMA, Stage M.3.d) or polled path.
+FAST_CODE void spiSequenceStart(const extDevice_t *dev)
+{
+    busDevice_t *bus = dev->bus;
+    SPI_TypeDef *instance = bus->busType_u.spi.instance;
+    bool dmaSafe = dev->useDMA;
+    uint32_t xferLen = 0;
+    uint32_t segmentCount = 0;
+
+    bus->initSegment = true;
+
+    SPI_Cmd(instance, DISABLE);
+
+    if (dev->busType_u.spi.speed != bus->busType_u.spi.speed) {
+#define BR_BITS ((BIT(5) | BIT(4) | BIT(3)))
+        uint16_t divisor = dev->busType_u.spi.speed;
+#if !(defined(STM32F1) || defined(STM32F3))
+        if (instance == SPI2 || instance == SPI3) {
+            divisor /= 2;
+        }
+#endif
+        instance->CR1 = (instance->CR1 & ~BR_BITS) | (divisor ? ((ffs(divisor | 0x100) - 2) << 3) : 0);
+#undef BR_BITS
+        bus->busType_u.spi.speed = dev->busType_u.spi.speed;
+    }
+
+    if (dev->busType_u.spi.leadingEdge != bus->busType_u.spi.leadingEdge) {
+        // F3/F4 have no SCK_CFG_LOW/HIGH GPIO variant — only CR1 CPOL/CPHA updated.
+        if (dev->busType_u.spi.leadingEdge) {
+            instance->CR1 &= ~(SPI_CPOL_High | SPI_CPHA_2Edge);
+        } else {
+            instance->CR1 |= (SPI_CPOL_High | SPI_CPHA_2Edge);
+        }
+        bus->busType_u.spi.leadingEdge = dev->busType_u.spi.leadingEdge;
+    }
+
+    SPI_Cmd(instance, ENABLE);
+
+    // Scan the segment list for DMA safety.
+    for (busSegment_t *checkSegment = (busSegment_t *)bus->curSegment; checkSegment->len; checkSegment++) {
+        if ((checkSegment->u.buffers.rxData) && (bus->dmaRx == (dmaChannelDescriptor_t *)NULL)) {
+            dmaSafe = false;
+            break;
+        }
+        segmentCount++;
+        xferLen += checkSegment->len;
+    }
+
+    // Use DMA if available and safe (dead path until spiInitBusDMA sets bus->useDMA, Stage M.3.d).
+    if (bus->useDMA && dmaSafe && ((segmentCount > 1) ||
+                                    (xferLen >= SPI_DMA_THRESHOLD) ||
+                                    !bus->curSegment[segmentCount].negateCS)) {
+        spiInternalInitStream(dev, false);
+        IOLo(dev->busType_u.spi.csnPin);
+        spiInternalStartDMA(dev);
+    } else {
+        busSegment_t *lastSegment = NULL;
+        bool segmentComplete;
+
+        while (bus->curSegment->len) {
+            if (!lastSegment || lastSegment->negateCS) {
+                IOLo(dev->busType_u.spi.csnPin);
+            }
+
+            spiTransfer(instance,
+                        bus->curSegment->u.buffers.txData,
+                        bus->curSegment->u.buffers.rxData,
+                        bus->curSegment->len);
+
+            if (bus->curSegment->negateCS) {
+                IOHi(dev->busType_u.spi.csnPin);
+            }
+
+            segmentComplete = true;
+            if (bus->curSegment->callback) {
+                switch (bus->curSegment->callback(dev->callbackArg)) {
+                case BUS_BUSY:
+                    segmentComplete = false;
+                    break;
+                case BUS_ABORT:
+                    bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+                    return;
+                case BUS_READY:
+                default:
+                    break;
+                }
+            }
+            if (segmentComplete) {
+                lastSegment = (busSegment_t *)bus->curSegment;
+                bus->curSegment++;
+            }
+        }
+
+        if (bus->curSegment->u.link.dev) {
+            busSegment_t *endSegment = (busSegment_t *)bus->curSegment;
+            const extDevice_t *nextDev = endSegment->u.link.dev;
+            busSegment_t *nextSegments = (busSegment_t *)endSegment->u.link.segments;
+            bus->curSegment = nextSegments;
+            endSegment->u.link.dev = NULL;
+            endSegment->u.link.segments = NULL;
+            spiSequenceStart(nextDev);
+        } else {
+            bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+        }
+    }
+}
+
+// Platform-internal DMA functions — stubs until Stage M.3.d (dma_reqmap + spiInitBusDMA).
 void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
 void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }
 void spiInternalStopDMA(const extDevice_t *dev) { UNUSED(dev); }

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -26,6 +26,9 @@
 
 #ifdef USE_SPI
 
+// STM32F405 CCM SRAM (0x10000000–0x1000FFFF) is inaccessible by DMA1/2.
+#define IS_CCM(p) (((uint32_t)(p) & 0xffff0000) == 0x10000000)
+
 #include "drivers/bus.h"
 #include "drivers/bus_spi.h"
 #include "drivers/bus_spi_impl.h"
@@ -186,10 +189,9 @@ FAST_CODE void spiSequenceStart(const extDevice_t *dev)
 
     if (dev->busType_u.spi.leadingEdge != bus->busType_u.spi.leadingEdge) {
         // F3/F4 have no SCK_CFG_LOW/HIGH GPIO variant — only CR1 CPOL/CPHA updated.
-        if (dev->busType_u.spi.leadingEdge) {
-            instance->CR1 &= ~(SPI_CPOL_High | SPI_CPHA_2Edge);
-        } else {
-            instance->CR1 |= (SPI_CPOL_High | SPI_CPHA_2Edge);
+        instance->CR1 &= ~(SPI_CPOL_High | SPI_CPHA_2Edge);
+        if (!dev->busType_u.spi.leadingEdge) {
+            instance->CR1 |= SPI_CPOL_High | SPI_CPHA_2Edge;
         }
         bus->busType_u.spi.leadingEdge = dev->busType_u.spi.leadingEdge;
     }
@@ -197,8 +199,10 @@ FAST_CODE void spiSequenceStart(const extDevice_t *dev)
     SPI_Cmd(instance, ENABLE);
 
     // Scan the segment list for DMA safety.
+    // CCM SRAM is inaccessible by DMA on F4 — reject any buffer in that region.
     for (busSegment_t *checkSegment = (busSegment_t *)bus->curSegment; checkSegment->len; checkSegment++) {
-        if ((checkSegment->u.buffers.rxData) && (bus->dmaRx == (dmaChannelDescriptor_t *)NULL)) {
+        if (((checkSegment->u.buffers.rxData) && (IS_CCM(checkSegment->u.buffers.rxData) || (bus->dmaRx == (dmaChannelDescriptor_t *)NULL))) ||
+            ((checkSegment->u.buffers.txData) && IS_CCM(checkSegment->u.buffers.txData))) {
             dmaSafe = false;
             break;
         }


### PR DESCRIPTION
## Summary

Ports `spiSequenceStart` polled-path dispatch from BF 4.5-maintenance to both LL (F7) and stdperiph (F4/F3/F1) backends. This is the polled-path portion of Stage M.3; DMA work (M.3.c–f) continues on the same branch after merge.

**Three commits:**
- `5545a12d27` — `bus_spi_ll.c`: replace no-op stub with full polled+DMA-dispatch implementation
- `69f59f7f6a` — `bus_spi_stdperiph.c`: same for stdperiph backend; fixes FOXEERF405/TUNERCF405/SKYSTARSF405AIO no-USB brick caused by the M.3.a stub gap
- `58dfab6257` — `bus_spi_stdperiph.c`: BF-alignment fixes (IS_CCM DMA safety check; polarity clear-then-OR)

**Behavioral changes vs pre-M.3:**
- `spiSequence` is now a thin wrapper (set `curSegment`, call `spiSequenceStart`) matching BF architecture; the inline per-segment loop is removed from `bus_spi.c`
- CS handling: correct `lastSegment->negateCS` pattern — CS held across segments when `negateCS=false` (was incorrectly toggled before)
- Callback: `BUS_BUSY`/`BUS_ABORT`/`BUS_READY` switch correctly handled (was silently discarded pre-M.3)
- Speed and polarity now applied at transfer-start inside `spiSequenceStart` rather than immediately at `spiSetClkDivisor` call time
- `IS_CCM` macro added: F4 CCM SRAM excluded from DMA-safe set (latent correctness fix for M.3.d)

**DMA path:** `bus->useDMA` stays `false` until `spiInitBusDMA` (M.3.d). All DMA branches in `spiSequenceStart` are dead code for now — polled path always taken.

## Test plan

**AI Generated comment** — Classification: Tier 2 (behavioral — SPI transfer dispatch changed).

- [x] Zero new warnings, 23 targets (8 bench + 4 compile + 11 unique), `make test` passes
- [x] Gyro/accel functional verified on `58dfab6257` (Configurator sensors tab):
  - HELIOSPRING (F4/IMUF9001), FOXEERF405 (F4), TUNERCF405 (F4/BMI270), SKYSTARSF405AIO (F4/BMI270)
  - PYRODRONEF7 (F7), FOXEERF722V4 (F7), TMOTORF7 (F7)
- [ ] APEXF7 — not tested (covered by two other F7 targets)
- [ ] Baro/mag — hardware unavailable; SPI segment path confirmed by gyro
- [ ] Motor arming test — polled-path timing identical to pre-M.3; not a new risk vector
- [x] BF-equivalence verified against `betaflight/src/main/drivers/stm32/bus_spi_ll.c` and `bus_spi_stdperiph.c` (4.5-maintenance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored SPI bus driver sequencing to defer hardware configuration until transfer initiation, enabling improved asynchronous operations.
  * Enhanced DMA support for SPI transfers with intelligent fallback to polled mode based on transfer characteristics.
  * Improved overall SPI bus efficiency through optimized hardware configuration timing and segment-based transfer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->