### PR TITLE
refactor(bus): Stage M.3.c — port dma_reqmap infrastructure (BF 4.5-m parity)

### DIFF
--- a/make/mcu/STM32F4.mk
+++ b/make/mcu/STM32F4.mk
@@ -170,6 +170,7 @@ MCU_COMMON_SRC = \
             drivers/bus_i2c_stm32f10x.c \
             drivers/bus_spi_stdperiph.c \
             drivers/dma_stm32f4xx.c \
+            drivers/dma_reqmap_mcu.c \
             drivers/inverter.c \
             drivers/light_ws2811strip_stdperiph.c \
             drivers/transponder_ir_io_stdperiph.c \

--- a/make/mcu/STM32F7.mk
+++ b/make/mcu/STM32F7.mk
@@ -163,6 +163,7 @@ MCU_COMMON_SRC = \
             drivers/audio_stm32f7xx.c \
             drivers/bus_i2c_hal.c \
             drivers/dma_stm32f7xx.c \
+            drivers/dma_reqmap_mcu.c \
             drivers/light_ws2811strip_hal.c \
             drivers/transponder_ir_io_hal.c \
             drivers/bus_spi_ll.c \

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -22,6 +22,9 @@
 
 #include "resource.h"
 
+// Opaque DMA engine handle used by dma_reqmap (matches BF 4.5-maintenance).
+typedef struct dmaResource_s dmaResource_t;
+
 struct dmaChannelDescriptor_s;
 typedef void (*dmaCallbackHandlerFuncPtr)(struct dmaChannelDescriptor_s *channelDescriptor);
 

--- a/src/main/drivers/dma_reqmap.h
+++ b/src/main/drivers/dma_reqmap.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "platform.h"
+
+#include "drivers/dma.h"
+#include "drivers/io_types.h"
+
+#include "dma_reqmap_mcu.h"
+
+typedef uint16_t dmaCode_t;
+
+typedef struct dmaChannelSpec_s {
+    dmaCode_t      code;
+    dmaResource_t *ref;
+    uint32_t       channel;
+} dmaChannelSpec_t;
+
+#define DMA_CODE(dma, stream, chanreq) ((dma << 12)|(stream << 8)|(chanreq << 0))
+#define DMA_CODE_CONTROLLER(code) ((code >> 12) & 0xf)
+#define DMA_CODE_STREAM(code) ((code >> 8) & 0xf)
+#define DMA_CODE_CHANNEL(code) ((code >> 0) & 0xff)
+#define DMA_CODE_REQUEST(code) DMA_CODE_CHANNEL(code)
+
+typedef enum {
+    DMA_PERIPH_SPI_SDO,
+    DMA_PERIPH_SPI_SDI,
+    DMA_PERIPH_ADC,
+    DMA_PERIPH_SDIO,
+    DMA_PERIPH_UART_TX,
+    DMA_PERIPH_UART_RX,
+    DMA_PERIPH_TIMUP,
+} dmaPeripheral_e;
+
+typedef int8_t dmaoptValue_t;
+
+#define DMA_OPT_UNUSED (-1)
+
+struct timerHardware_s;
+
+dmaoptValue_t dmaoptByTag(ioTag_t ioTag);
+const dmaChannelSpec_t *dmaGetChannelSpecByPeripheral(dmaPeripheral_e device, uint8_t index, int8_t opt);
+const dmaChannelSpec_t *dmaGetChannelSpecByTimerValue(TIM_TypeDef *tim, uint8_t channel, dmaoptValue_t dmaopt);
+const dmaChannelSpec_t *dmaGetChannelSpecByTimer(const struct timerHardware_s *timer);
+dmaoptValue_t dmaGetOptionByTimer(const struct timerHardware_s *timer);

--- a/src/main/drivers/dma_reqmap_mcu.c
+++ b/src/main/drivers/dma_reqmap_mcu.c
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "platform.h"
+
+#include "common/utils.h"
+
+#include "drivers/bus_spi.h"
+#include "drivers/dma_reqmap.h"
+
+// SPI peripheral → DMA stream/channel mapping for F4/F7.
+// Guarded by USE_SPI so the table is always non-empty when compiled.
+// Other MCU families or targets without USE_SPI fall through to the NULL stub.
+
+#if (defined(STM32F4) || defined(STM32F7)) && defined(USE_SPI)
+
+typedef struct dmaPeripheralMapping_s {
+    dmaPeripheral_e  device;
+    uint8_t          index;
+    dmaChannelSpec_t channelSpec[MAX_PERIPHERAL_DMA_OPTIONS];
+} dmaPeripheralMapping_t;
+
+#if defined(STM32F4)
+#define DMA(d, s, c) { DMA_CODE(d, s, c), (dmaResource_t *)DMA ## d ## _Stream ## s, DMA_Channel_ ## c }
+#elif defined(STM32F7)
+#define DMA(d, s, c) { DMA_CODE(d, s, c), (dmaResource_t *)DMA ## d ## _Stream ## s, DMA_CHANNEL_ ## c }
+#endif
+
+static const dmaPeripheralMapping_t dmaPeripheralMapping[] = {
+    // SPI1: opt 0 preference differs between F745/F746/F765 and other F4/F7 variants.
+#if defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx)
+    { DMA_PERIPH_SPI_SDO, SPIDEV_1, { DMA(2, 5, 3), DMA(2, 3, 3) } },
+    { DMA_PERIPH_SPI_SDI, SPIDEV_1, { DMA(2, 2, 3), DMA(2, 0, 3) } },
+#else
+    { DMA_PERIPH_SPI_SDO, SPIDEV_1, { DMA(2, 3, 3), DMA(2, 5, 3) } },
+    { DMA_PERIPH_SPI_SDI, SPIDEV_1, { DMA(2, 0, 3), DMA(2, 2, 3) } },
+#endif
+    { DMA_PERIPH_SPI_SDO, SPIDEV_2, { DMA(1, 4, 0) } },
+    { DMA_PERIPH_SPI_SDI, SPIDEV_2, { DMA(1, 3, 0) } },
+    { DMA_PERIPH_SPI_SDO, SPIDEV_3, { DMA(1, 5, 0), DMA(1, 7, 0) } },
+    { DMA_PERIPH_SPI_SDI, SPIDEV_3, { DMA(1, 0, 0), DMA(1, 2, 0) } },
+
+#if defined(STM32F411xE) || defined(STM32F745xx) || defined(STM32F746xx) || defined(STM32F765xx) || defined(STM32F722xx)
+    { DMA_PERIPH_SPI_SDO, SPIDEV_4, { DMA(2, 1, 4), DMA(2, 4, 5) } },
+    { DMA_PERIPH_SPI_SDI, SPIDEV_4, { DMA(2, 0, 4), DMA(2, 3, 5) } },
+#endif
+};
+
+#undef DMA
+
+const dmaChannelSpec_t *dmaGetChannelSpecByPeripheral(dmaPeripheral_e device, uint8_t index, int8_t opt)
+{
+    if (opt < 0 || opt >= MAX_PERIPHERAL_DMA_OPTIONS) {
+        return NULL;
+    }
+
+    for (unsigned i = 0; i < ARRAYLEN(dmaPeripheralMapping); i++) {
+        const dmaPeripheralMapping_t *periph = &dmaPeripheralMapping[i];
+        if (periph->device == device && periph->index == index && periph->channelSpec[opt].ref) {
+            return &periph->channelSpec[opt];
+        }
+    }
+
+    return NULL;
+}
+
+#else  // No SPI, F1/F3, or other unsupported MCU family → no DMA for SPI.
+
+const dmaChannelSpec_t *dmaGetChannelSpecByPeripheral(dmaPeripheral_e device, uint8_t index, int8_t opt)
+{
+    UNUSED(device);
+    UNUSED(index);
+    UNUSED(opt);
+    return NULL;
+}
+
+#endif  // (STM32F4 || STM32F7) && USE_SPI
+
+
+// Timer-DMA spec functions are not used in EF's SPI refactor.
+// Stubs satisfy the declared interface; full implementation deferred.
+
+dmaoptValue_t dmaoptByTag(ioTag_t ioTag)
+{
+    UNUSED(ioTag);
+    return DMA_OPT_UNUSED;
+}
+
+const dmaChannelSpec_t *dmaGetChannelSpecByTimerValue(TIM_TypeDef *tim, uint8_t channel, dmaoptValue_t dmaopt)
+{
+    UNUSED(tim);
+    UNUSED(channel);
+    UNUSED(dmaopt);
+    return NULL;
+}
+
+const dmaChannelSpec_t *dmaGetChannelSpecByTimer(const struct timerHardware_s *timer)
+{
+    UNUSED(timer);
+    return NULL;
+}
+
+dmaoptValue_t dmaGetOptionByTimer(const struct timerHardware_s *timer)
+{
+    UNUSED(timer);
+    return DMA_OPT_UNUSED;
+}

--- a/src/main/drivers/dma_reqmap_mcu.h
+++ b/src/main/drivers/dma_reqmap_mcu.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#if defined(STM32H7) || defined(STM32G4)
+#define MAX_PERIPHERAL_DMA_OPTIONS 16
+#define MAX_TIMER_DMA_OPTIONS 16
+#else
+#define MAX_PERIPHERAL_DMA_OPTIONS 2
+#define MAX_TIMER_DMA_OPTIONS 3
+#endif


### PR DESCRIPTION
## Summary

- Add `dma_reqmap.h`, `dma_reqmap_mcu.h`, `dma_reqmap_mcu.c`: maps SPI peripheral + direction → DMA stream/channel for F4/F7 targets, prerequisite for `spiInitBusDMA` (M.3.d).
- Add `dmaResource_t` opaque typedef to `dma.h` matching BF 4.5-maintenance.
- SPI1–4 stream/channel table matches BF 4.5-m `dma_reqmap_mcu.c` F4/F7 section exactly.
- `(STM32F4||STM32F7)&&USE_SPI` guard prevents zero-size array violations on no-SPI targets (e.g. CRAZYFLIE2).
- Timer-DMA functions are stubs — EF does not implement the BF CLI DMA configurator. Documented as DEV-002 in `bf-deviations.md`.

## BF-equivalence

Analogous BF file: `src/main/drivers/stm32/dma_reqmap_mcu.c` + `drivers/dma_reqmap.h`. SPI mapping entries and type definitions are a direct port of the F4/F7 section. DEV-002 deviation (no `USE_DMA_SPEC` guard) is intentional and documented.

## Classification

**Tier 1 — Structural/infrastructure addition. No runtime behavior change.**

`spiInitBusDMA` remains a stub; DMA is not yet active. This PR only adds the lookup table and types that M.3.d will call.

## Test plan

- [x] `make test` — all unit tests pass
- [x] Bench targets (8): HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 — zero new warnings
- [x] Compile targets (4): MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 — zero new warnings
- [x] Unique targets (11): CRAZYFLIE2 ANYFCF7 ELLE0 F4BY STM32F4DISCOVERY NUCLEOF446RE BEEBRAIN_PRO BEEBRAIN_LITE AG3XF4 AG3XF7 COLIBRI — zero new warnings
- [x] Physical bench test (USB enumeration + gyro verified): HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 (2026-04-28 13:26–13:31)

AI Generated comment — Claude AI (Sonnet 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added DMA request mapping infrastructure for STM32F4, F7, H7, and G4 microcontrollers, enabling improved Direct Memory Access (DMA) channel configuration and peripheral mapping support.
  * Integrated build system updates to include DMA driver components in firmware compilation for affected MCU families.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->