### PR TITLE
refactor(bus): Stage M.3.d–g — async DMA SPI implementation (BF 4.5-m parity)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -260,7 +260,7 @@ FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
 
 FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro) {
     static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    uint8_t data[7];
+    static uint8_t data[7];
     const bool ack = spiReadWriteBufRB(&gyro->dev, (uint8_t *)dataToSend, data, 7);
     if (!ack) {
         return false;

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -351,12 +351,14 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
         BUFFER_SIZE,
     };
 
-    uint8_t bmi270_rx_buf[BUFFER_SIZE];
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
-
-    IOLo(gyro->dev.busType_u.spi.csnPin);
-    spiTransfer(gyro->dev.bus->busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->dev.busType_u.spi.csnPin);
+    static uint8_t bmi270_rx_buf[BUFFER_SIZE];
+    busSegment_t segments[] = {
+        {.u.buffers = {(uint8_t *)bmi270_tx_buf, bmi270_rx_buf}, BUFFER_SIZE, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(&gyro->dev, &segments[0]);
+    spiWait(&gyro->dev);
 
     gyro->gyroADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_XOUT_L]);
     gyro->gyroADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_YOUT_L]);
@@ -384,14 +386,13 @@ static bool bmi270GyroReadFifo(gyroDev_t *gyro)
 
     bool dataRead = false;
     static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_FIFO_LENGTH_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    uint8_t bmi270_rx_buf[BUFFER_SIZE];
-
-    // Burst read the FIFO length followed by the next 6 bytes containing the gyro axis data for
-    // the first sample in the queue. It's possible for the FIFO to be empty so we need to check the
-    // length before using the sample.
-    IOLo(gyro->dev.busType_u.spi.csnPin);
-    spiTransfer(gyro->dev.bus->busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(gyro->dev.busType_u.spi.csnPin);
+    static uint8_t bmi270_rx_buf[BUFFER_SIZE];
+    busSegment_t segments[] = {
+        {.u.buffers = {(uint8_t *)bmi270_tx_buf, bmi270_rx_buf}, BUFFER_SIZE, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+    spiSequence(&gyro->dev, &segments[0]);
+    spiWait(&gyro->dev);
 
     int fifoLength = (uint16_t)((bmi270_rx_buf[IDX_FIFO_LENGTH_H] << 8) | bmi270_rx_buf[IDX_FIFO_LENGTH_L]);
 

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -267,7 +267,7 @@ FAST_CODE static void spiRxIrqHandler(dmaChannelDescriptor_t *descriptor)
 
     spiInternalStopDMA(dev);
 
-#ifdef __DCACHE_PRESENT
+#ifdef STM32F7
     if (bus->curSegment->u.buffers.rxData) {
         SCB_InvalidateDCache_by_Addr(
             (uint32_t *)((uint32_t)bus->curSegment->u.buffers.rxData & ~CACHE_LINE_MASK),

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -26,6 +26,18 @@
 
 #ifdef USE_SPI
 
+// Transmit-only DMA path: used when a bus has a Tx DMA channel but no Rx channel.
+// Applicable to F4/F7; not needed on H7/G4 where full-duplex DMA is always available.
+#if defined(STM32F4) || defined(STM32F7)
+#define USE_TX_IRQ_HANDLER
+#endif
+
+// F7 cache-line constants for DMA buffer maintenance (32-byte L1D cache lines on Cortex-M7).
+#ifdef STM32F7
+#define CACHE_LINE_SIZE  32
+#define CACHE_LINE_MASK  (CACHE_LINE_SIZE - 1)
+#endif
+
 #include "drivers/bus.h"
 #include "drivers/bus_spi.h"
 #include "drivers/bus_spi_impl.h"
@@ -178,6 +190,115 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
     return true;
 }
 
+// Shared segment-completion handler called from spiRxIrqHandler / spiTxIrqHandler.
+// Advances the segment list, starts the next DMA transfer, or marks the bus free.
+FAST_CODE static void spiIrqHandler(const extDevice_t *dev)
+{
+    busDevice_t *bus = dev->bus;
+    busSegment_t *nextSegment;
+
+    if (bus->curSegment->callback) {
+        switch (bus->curSegment->callback(dev->callbackArg)) {
+        case BUS_BUSY:
+            bus->curSegment--;
+            spiInternalInitStream(dev, true);
+            break;
+        case BUS_ABORT:
+            nextSegment = (busSegment_t *)bus->curSegment + 1;
+            while (nextSegment->len != 0) {
+                bus->curSegment = nextSegment;
+                nextSegment = (busSegment_t *)bus->curSegment + 1;
+            }
+            break;
+        case BUS_READY:
+        default:
+            break;
+        }
+    }
+
+    nextSegment = (busSegment_t *)bus->curSegment + 1;
+
+    if (nextSegment->len == 0) {
+        if (nextSegment->u.link.dev) {
+            const extDevice_t *nextDev = nextSegment->u.link.dev;
+            busSegment_t *nextSegments = (busSegment_t *)nextSegment->u.link.segments;
+            bus->curSegment = nextSegments;
+            nextSegment->u.link.dev = NULL;
+            nextSegment->u.link.segments = NULL;
+            spiSequenceStart(nextDev);
+        } else {
+            bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
+        }
+    } else {
+        bool negateCS = bus->curSegment->negateCS;
+        bus->curSegment = nextSegment;
+
+        if (bus->initSegment) {
+            spiInternalInitStream(dev, false);
+            bus->initSegment = false;
+        }
+
+        if (negateCS) {
+            IOLo(dev->busType_u.spi.csnPin);
+        }
+
+        spiInternalStartDMA(dev);
+        spiInternalInitStream(dev, true);
+    }
+}
+
+// DMA Rx TC IRQ handler — fires when SPI Rx DMA transfer completes.
+// Negates CS, stops DMA, invalidates cache on F7, then advances the segment list.
+FAST_CODE static void spiRxIrqHandler(dmaChannelDescriptor_t *descriptor)
+{
+    const extDevice_t *dev = (const extDevice_t *)descriptor->userParam;
+
+    if (!dev) {
+        return;
+    }
+
+    busDevice_t *bus = dev->bus;
+
+    if (bus->curSegment->negateCS) {
+        IOHi(dev->busType_u.spi.csnPin);
+    }
+
+    spiInternalStopDMA(dev);
+
+#ifdef __DCACHE_PRESENT
+    if (bus->curSegment->u.buffers.rxData) {
+        SCB_InvalidateDCache_by_Addr(
+            (uint32_t *)((uint32_t)bus->curSegment->u.buffers.rxData & ~CACHE_LINE_MASK),
+            (((uint32_t)bus->curSegment->u.buffers.rxData & CACHE_LINE_MASK) +
+              bus->curSegment->len - 1 + CACHE_LINE_SIZE) & ~CACHE_LINE_MASK);
+    }
+#endif
+
+    spiIrqHandler(dev);
+}
+
+#ifdef USE_TX_IRQ_HANDLER
+// DMA Tx TC IRQ handler — used for Tx-only DMA buses (no Rx channel).
+FAST_CODE static void spiTxIrqHandler(dmaChannelDescriptor_t *descriptor)
+{
+    const extDevice_t *dev = (const extDevice_t *)descriptor->userParam;
+
+    if (!dev) {
+        return;
+    }
+
+    busDevice_t *bus = dev->bus;
+
+    spiInternalStopDMA(dev);
+
+    if (bus->curSegment->negateCS) {
+        IOHi(dev->busType_u.spi.csnPin);
+    }
+
+    spiIrqHandler(dev);
+}
+#endif
+
 void spiInitBusDMA(void)
 {
 #if (defined(STM32F4) || defined(STM32F7)) && defined(USE_SPI)
@@ -227,7 +348,16 @@ void spiInitBusDMA(void)
             spiInternalResetStream(bus->dmaRx);
             spiInternalResetStream(bus->dmaTx);
             spiInternalResetDescriptors(bus);
-            // IRQ handler registration and bus->useDMA = true deferred to Stage M.3.e
+            dmaSetHandler(dmaRxIdentifier, spiRxIrqHandler, NVIC_PRIO_SPI_DMA, 0);
+            // bus->useDMA = true deferred to Stage M.3.f (requires ATOMIC_BLOCK in spiSequence first)
+#ifdef USE_TX_IRQ_HANDLER
+        } else if (dmaTxIdentifier) {
+            bus->dmaRx = (dmaChannelDescriptor_t *)NULL;
+            spiInternalResetStream(bus->dmaTx);
+            spiInternalResetDescriptors(bus);
+            dmaSetHandler(dmaTxIdentifier, spiTxIrqHandler, NVIC_PRIO_SPI_DMA, 0);
+            // bus->useDMA = true deferred to Stage M.3.f
+#endif
         } else {
             bus->dmaRx = NULL;
             bus->dmaTx = NULL;

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -29,6 +29,10 @@
 #include "drivers/bus.h"
 #include "drivers/bus_spi.h"
 #include "drivers/bus_spi_impl.h"
+#include "drivers/dma.h"
+#include "drivers/dma_reqmap.h"
+#include "drivers/nvic.h"
+#include "drivers/resource.h"
 #include "drivers/exti.h"
 #include "drivers/io.h"
 #include "drivers/rcc.h"
@@ -174,8 +178,62 @@ bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
     return true;
 }
 
-// Stub: DMA channel allocation requires dma_reqmap infrastructure (Stage M.3).
-void spiInitBusDMA(void) {
+void spiInitBusDMA(void)
+{
+#if (defined(STM32F4) || defined(STM32F7)) && defined(USE_SPI)
+    for (uint32_t device = 0; device < SPIDEV_COUNT; device++) {
+        busDevice_t *bus = &spiBusDevice[device];
+
+        if (bus->busType != BUS_TYPE_SPI) {
+            continue;
+        }
+
+        dmaIdentifier_e dmaTxIdentifier = DMA_NONE;
+        dmaIdentifier_e dmaRxIdentifier = DMA_NONE;
+
+        for (uint8_t opt = 0; opt < MAX_PERIPHERAL_DMA_OPTIONS; opt++) {
+            const dmaChannelSpec_t *dmaTxChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_SDO, device, opt);
+            if (dmaTxChannelSpec) {
+                dmaTxIdentifier = dmaGetIdentifier((DMA_Stream_TypeDef *)dmaTxChannelSpec->ref);
+                if (!dmaAllocate(dmaTxIdentifier, OWNER_SPI_SDO, device + 1)) {
+                    dmaTxIdentifier = DMA_NONE;
+                    continue;
+                }
+                bus->dmaTx = dmaGetDescriptorByIdentifier(dmaTxIdentifier);
+                bus->dmaTx->stream  = DMA_DEVICE_INDEX(dmaTxIdentifier);
+                bus->dmaTx->channel = dmaTxChannelSpec->channel;
+                dmaEnable(dmaTxIdentifier);
+                break;
+            }
+        }
+
+        for (uint8_t opt = 0; opt < MAX_PERIPHERAL_DMA_OPTIONS; opt++) {
+            const dmaChannelSpec_t *dmaRxChannelSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_SDI, device, opt);
+            if (dmaRxChannelSpec) {
+                dmaRxIdentifier = dmaGetIdentifier((DMA_Stream_TypeDef *)dmaRxChannelSpec->ref);
+                if (!dmaAllocate(dmaRxIdentifier, OWNER_SPI_SDI, device + 1)) {
+                    dmaRxIdentifier = DMA_NONE;
+                    continue;
+                }
+                bus->dmaRx = dmaGetDescriptorByIdentifier(dmaRxIdentifier);
+                bus->dmaRx->stream  = DMA_DEVICE_INDEX(dmaRxIdentifier);
+                bus->dmaRx->channel = dmaRxChannelSpec->channel;
+                dmaEnable(dmaRxIdentifier);
+                break;
+            }
+        }
+
+        if (dmaTxIdentifier && dmaRxIdentifier) {
+            spiInternalResetStream(bus->dmaRx);
+            spiInternalResetStream(bus->dmaTx);
+            spiInternalResetDescriptors(bus);
+            // IRQ handler registration and bus->useDMA = true deferred to Stage M.3.e
+        } else {
+            bus->dmaRx = NULL;
+            bus->dmaTx = NULL;
+        }
+    }
+#endif
 }
 
 bool spiIsBusy(const extDevice_t *dev) {

--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -24,6 +24,8 @@
 
 #include "platform.h"
 
+#include "build/atomic.h"
+
 #ifdef USE_SPI
 
 // Transmit-only DMA path: used when a bus has a Tx DMA channel but no Rx channel.
@@ -349,14 +351,14 @@ void spiInitBusDMA(void)
             spiInternalResetStream(bus->dmaTx);
             spiInternalResetDescriptors(bus);
             dmaSetHandler(dmaRxIdentifier, spiRxIrqHandler, NVIC_PRIO_SPI_DMA, 0);
-            // bus->useDMA = true deferred to Stage M.3.f (requires ATOMIC_BLOCK in spiSequence first)
+            bus->useDMA = true;
 #ifdef USE_TX_IRQ_HANDLER
         } else if (dmaTxIdentifier) {
             bus->dmaRx = (dmaChannelDescriptor_t *)NULL;
             spiInternalResetStream(bus->dmaTx);
             spiInternalResetDescriptors(bus);
             dmaSetHandler(dmaTxIdentifier, spiTxIrqHandler, NVIC_PRIO_SPI_DMA, 0);
-            // bus->useDMA = true deferred to Stage M.3.f
+            bus->useDMA = true;
 #endif
         } else {
             bus->dmaRx = NULL;
@@ -431,13 +433,11 @@ void spiLinkSegments(const extDevice_t *dev, busSegment_t *firstSegment, busSegm
 void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
     busDevice_t *bus = dev->bus;
 
-    spiWait(dev);
-
-    bus->curSegment = segments;
-
 #ifdef USE_DMA_SPI_DEVICE
     if (dev->bus->busType_u.spi.instance == USE_DMA_SPI_DEVICE) {
-        // IMUF9001 custom DMA path: only supports single-segment transfers.
+        // IMUF9001 blocking custom DMA — incompatible with non-blocking segment queuing.
+        spiWait(dev);
+        bus->curSegment = segments;
         if (segments[0].len > 0 && segments[1].len == 0) {
             uint8_t *txData = segments[0].u.buffers.txData;
             uint8_t *rxData = segments[0].u.buffers.rxData;
@@ -464,8 +464,47 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
             bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
             return;
         }
+        spiSequenceStart(dev);
+        return;
     }
 #endif
+
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) {
+        if (spiIsBusy(dev)) {
+            busSegment_t *endSegment;
+
+            // Find the last segment of the new transfer
+            for (endSegment = segments; endSegment->len; endSegment++);
+
+            // Safe to discard the volatile qualifier as we're in an atomic block
+            busSegment_t *endCmpSegment = (busSegment_t *)bus->curSegment;
+
+            if (endCmpSegment) {
+                while (true) {
+                    // Find the last segment of the current transfer
+                    for (; endCmpSegment->len; endCmpSegment++);
+
+                    if (endCmpSegment == endSegment) {
+                        // Same segment list queued twice; abort.
+                        return;
+                    }
+
+                    if (endCmpSegment->u.link.dev == NULL) {
+                        break;
+                    } else {
+                        endCmpSegment = (busSegment_t *)endCmpSegment->u.link.segments;
+                    }
+                }
+
+                endCmpSegment->u.link.dev = dev;
+                endCmpSegment->u.link.segments = segments;
+            }
+
+            return;
+        } else {
+            bus->curSegment = segments;
+        }
+    }
 
     spiSequenceStart(dev);
 }

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -326,12 +326,169 @@ FAST_CODE void spiSequenceStart(const extDevice_t *dev)
     }
 }
 
-// Platform-internal DMA functions — stubs until Stage M.3.d (dma_reqmap + spiInitBusDMA).
-void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
-void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }
-void spiInternalStopDMA(const extDevice_t *dev) { UNUSED(dev); }
-void spiInternalResetStream(dmaChannelDescriptor_t *descriptor) { UNUSED(descriptor); }
-void spiInternalResetDescriptors(busDevice_t *bus) { UNUSED(bus); }
+#ifdef STM32F7
+#define CACHE_LINE_SIZE  32
+#define CACHE_LINE_MASK  (CACHE_LINE_SIZE - 1)
+#endif
+
+void spiInternalResetDescriptors(busDevice_t *bus)
+{
+    LL_DMA_InitTypeDef *initTx = bus->initTx;
+
+    LL_DMA_StructInit(initTx);
+    initTx->Channel = bus->dmaTx->channel;
+    initTx->Mode = LL_DMA_MODE_NORMAL;
+    initTx->Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
+    initTx->PeriphOrM2MSrcAddress = (uint32_t)&bus->busType_u.spi.instance->DR;
+    initTx->Priority = LL_DMA_PRIORITY_LOW;
+    initTx->PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    initTx->PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
+    initTx->MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
+
+    if (bus->dmaRx) {
+        LL_DMA_InitTypeDef *initRx = bus->initRx;
+
+        LL_DMA_StructInit(initRx);
+        initRx->Channel = bus->dmaRx->channel;
+        initRx->Mode = LL_DMA_MODE_NORMAL;
+        initRx->Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
+        initRx->PeriphOrM2MSrcAddress = (uint32_t)&bus->busType_u.spi.instance->DR;
+        initRx->Priority = LL_DMA_PRIORITY_LOW;
+        initRx->PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+        initRx->PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
+    }
+}
+
+void spiInternalResetStream(dmaChannelDescriptor_t *descriptor)
+{
+    LL_DMA_DisableStream(descriptor->dma, descriptor->stream);
+    while (LL_DMA_IsEnabledStream(descriptor->dma, descriptor->stream));
+    DMA_CLEAR_FLAG(descriptor, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+}
+
+void spiInternalInitStream(const extDevice_t *dev, bool preInit)
+{
+    static uint8_t dummyTxByte = 0xff;
+    static uint8_t dummyRxByte;
+    busDevice_t *bus = dev->bus;
+
+    busSegment_t *segment = (busSegment_t *)bus->curSegment;
+
+    if (preInit) {
+        segment++;
+        if (segment->len == 0) {
+            return;
+        }
+    }
+
+    int len = segment->len;
+    uint8_t *txData = segment->u.buffers.txData;
+    LL_DMA_InitTypeDef *initTx = bus->initTx;
+
+    if (txData) {
+#ifdef __DCACHE_PRESENT
+        if (!IS_DTCM(txData)) {
+            SCB_CleanDCache_by_Addr(
+                (uint32_t *)((uint32_t)txData & ~CACHE_LINE_MASK),
+                (((uint32_t)txData & CACHE_LINE_MASK) + len - 1 + CACHE_LINE_SIZE) & ~CACHE_LINE_MASK);
+        }
+#endif
+        initTx->MemoryOrM2MDstAddress = (uint32_t)txData;
+        initTx->MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
+    } else {
+        initTx->MemoryOrM2MDstAddress = (uint32_t)&dummyTxByte;
+        initTx->MemoryOrM2MDstIncMode = LL_DMA_MEMORY_NOINCREMENT;
+    }
+    initTx->NbData = len;
+
+    if (bus->dmaRx) {
+        uint8_t *rxData = segment->u.buffers.rxData;
+        LL_DMA_InitTypeDef *initRx = bus->initRx;
+
+        if (rxData) {
+#ifdef __DCACHE_PRESENT
+            if (!IS_DTCM(rxData)) {
+                SCB_CleanInvalidateDCache_by_Addr(
+                    (uint32_t *)((uint32_t)rxData & ~CACHE_LINE_MASK),
+                    (((uint32_t)rxData & CACHE_LINE_MASK) + len - 1 + CACHE_LINE_SIZE) & ~CACHE_LINE_MASK);
+            }
+#endif
+            initRx->MemoryOrM2MDstAddress = (uint32_t)rxData;
+            initRx->MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
+        } else {
+            initRx->MemoryOrM2MDstAddress = (uint32_t)&dummyRxByte;
+            initRx->MemoryOrM2MDstIncMode = LL_DMA_MEMORY_NOINCREMENT;
+        }
+        initRx->NbData = len;
+    }
+}
+
+void spiInternalStartDMA(const extDevice_t *dev)
+{
+    busDevice_t *bus = dev->bus;
+    dmaChannelDescriptor_t *dmaTx = bus->dmaTx;
+    dmaChannelDescriptor_t *dmaRx = bus->dmaRx;
+
+    if (dmaRx) {
+        dmaRx->userParam = (uint32_t)dev;
+
+        DMA_CLEAR_FLAG(dmaTx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+        DMA_CLEAR_FLAG(dmaRx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+
+        DMA_Stream_TypeDef *streamRegsTx = (DMA_Stream_TypeDef *)dmaTx->ref;
+        DMA_Stream_TypeDef *streamRegsRx = (DMA_Stream_TypeDef *)dmaRx->ref;
+
+        LL_DMA_WriteReg(streamRegsTx, CR, 0U);
+        LL_DMA_WriteReg(streamRegsRx, CR, 0U);
+
+        /* Use Rx TC interrupt — fires after SPI operation completes, unlike Tx TC
+         * which fires when Tx FIFO empties while the SPI operation is still in progress.
+         */
+        LL_EX_DMA_EnableIT_TC(streamRegsRx);
+
+        LL_DMA_Init(dmaTx->dma, dmaTx->stream, bus->initTx);
+        LL_DMA_Init(dmaRx->dma, dmaRx->stream, bus->initRx);
+
+        LL_DMA_EnableStream(dmaTx->dma, dmaTx->stream);
+        LL_DMA_EnableStream(dmaRx->dma, dmaRx->stream);
+
+        SET_BIT(dev->bus->busType_u.spi.instance->CR2, SPI_CR2_TXDMAEN | SPI_CR2_RXDMAEN);
+    } else {
+        DMA_Stream_TypeDef *streamRegsTx = (DMA_Stream_TypeDef *)dmaTx->ref;
+
+        dmaTx->userParam = (uint32_t)dev;
+        DMA_CLEAR_FLAG(dmaTx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+        LL_DMA_WriteReg(streamRegsTx, CR, 0U);
+        LL_EX_DMA_EnableIT_TC(streamRegsTx);
+        LL_DMA_Init(dmaTx->dma, dmaTx->stream, bus->initTx);
+        LL_DMA_EnableStream(dmaTx->dma, dmaTx->stream);
+        SET_BIT(dev->bus->busType_u.spi.instance->CR2, SPI_CR2_TXDMAEN);
+    }
+}
+
+void spiInternalStopDMA(const extDevice_t *dev)
+{
+    busDevice_t *bus = dev->bus;
+    dmaChannelDescriptor_t *dmaTx = bus->dmaTx;
+    dmaChannelDescriptor_t *dmaRx = bus->dmaRx;
+    SPI_TypeDef *instance = bus->busType_u.spi.instance;
+
+    if (dmaRx) {
+        LL_DMA_DisableStream(dmaRx->dma, dmaRx->stream);
+        LL_DMA_DisableStream(dmaTx->dma, dmaTx->stream);
+        DMA_CLEAR_FLAG(dmaRx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+        LL_SPI_DisableDMAReq_TX(instance);
+        LL_SPI_DisableDMAReq_RX(instance);
+    } else {
+        while (LL_SPI_IsActiveFlag_BSY(instance));
+        while (LL_SPI_IsActiveFlag_RXNE(instance)) {
+            instance->DR;
+        }
+        LL_DMA_DisableStream(dmaTx->dma, dmaTx->stream);
+        DMA_CLEAR_FLAG(dmaTx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+        LL_SPI_DisableDMAReq_TX(instance);
+    }
+}
 
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor) {
 #if !(defined(STM32F1) || defined(STM32F3))

--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -482,7 +482,7 @@ void spiInternalStopDMA(const extDevice_t *dev)
     } else {
         while (LL_SPI_IsActiveFlag_BSY(instance));
         while (LL_SPI_IsActiveFlag_RXNE(instance)) {
-            instance->DR;
+            (void)instance->DR;
         }
         LL_DMA_DisableStream(dmaTx->dma, dmaTx->stream);
         DMA_CLEAR_FLAG(dmaTx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -269,12 +269,157 @@ FAST_CODE void spiSequenceStart(const extDevice_t *dev)
     }
 }
 
-// Platform-internal DMA functions — stubs until Stage M.3.d (dma_reqmap + spiInitBusDMA).
-void spiInternalInitStream(const extDevice_t *dev, bool preInit) { UNUSED(dev); UNUSED(preInit); }
-void spiInternalStartDMA(const extDevice_t *dev) { UNUSED(dev); }
-void spiInternalStopDMA(const extDevice_t *dev) { UNUSED(dev); }
-void spiInternalResetStream(dmaChannelDescriptor_t *descriptor) { UNUSED(descriptor); }
-void spiInternalResetDescriptors(busDevice_t *bus) { UNUSED(bus); }
+void spiInternalResetDescriptors(busDevice_t *bus)
+{
+    DMA_InitTypeDef *initTx = bus->initTx;
+
+    DMA_StructInit(initTx);
+    initTx->DMA_Channel = bus->dmaTx->channel;
+    initTx->DMA_DIR = DMA_DIR_MemoryToPeripheral;
+    initTx->DMA_Mode = DMA_Mode_Normal;
+    initTx->DMA_PeripheralBaseAddr = (uint32_t)&bus->busType_u.spi.instance->DR;
+    initTx->DMA_Priority = DMA_Priority_Low;
+    initTx->DMA_PeripheralInc = DMA_PeripheralInc_Disable;
+    initTx->DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
+    initTx->DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
+
+    if (bus->dmaRx) {
+        DMA_InitTypeDef *initRx = bus->initRx;
+
+        DMA_StructInit(initRx);
+        initRx->DMA_Channel = bus->dmaRx->channel;
+        initRx->DMA_DIR = DMA_DIR_PeripheralToMemory;
+        initRx->DMA_Mode = DMA_Mode_Normal;
+        initRx->DMA_PeripheralBaseAddr = (uint32_t)&bus->busType_u.spi.instance->DR;
+        initRx->DMA_Priority = DMA_Priority_Low;
+        initRx->DMA_PeripheralInc = DMA_PeripheralInc_Disable;
+        initRx->DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
+    }
+}
+
+void spiInternalResetStream(dmaChannelDescriptor_t *descriptor)
+{
+    DMA_Stream_TypeDef *streamRegs = (DMA_Stream_TypeDef *)descriptor->ref;
+    streamRegs->CR = 0U;
+    DMA_CLEAR_FLAG(descriptor, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+}
+
+void spiInternalInitStream(const extDevice_t *dev, bool preInit)
+{
+    static uint8_t dummyTxByte = 0xff;
+    static uint8_t dummyRxByte;
+    busDevice_t *bus = dev->bus;
+
+    volatile busSegment_t *segment = bus->curSegment;
+
+    if (preInit) {
+        segment++;
+        if (segment->len == 0) {
+            return;
+        }
+    }
+
+    int len = segment->len;
+    uint8_t *txData = segment->u.buffers.txData;
+    DMA_InitTypeDef *initTx = bus->initTx;
+
+    if (txData) {
+        initTx->DMA_Memory0BaseAddr = (uint32_t)txData;
+        initTx->DMA_MemoryInc = DMA_MemoryInc_Enable;
+    } else {
+        dummyTxByte = 0xff;
+        initTx->DMA_Memory0BaseAddr = (uint32_t)&dummyTxByte;
+        initTx->DMA_MemoryInc = DMA_MemoryInc_Disable;
+    }
+    initTx->DMA_BufferSize = len;
+
+    if (bus->dmaRx) {
+        uint8_t *rxData = segment->u.buffers.rxData;
+        DMA_InitTypeDef *initRx = bus->initRx;
+
+        if (rxData) {
+            initRx->DMA_Memory0BaseAddr = (uint32_t)rxData;
+            initRx->DMA_MemoryInc = DMA_MemoryInc_Enable;
+        } else {
+            initRx->DMA_Memory0BaseAddr = (uint32_t)&dummyRxByte;
+            initRx->DMA_MemoryInc = DMA_MemoryInc_Disable;
+        }
+        /* Use 16-bit memory writes where possible to prevent atomic access issues on gyro data */
+        if ((initRx->DMA_Memory0BaseAddr & 0x1) || (len & 0x1)) {
+            initRx->DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
+        } else {
+            initRx->DMA_MemoryDataSize = DMA_MemoryDataSize_HalfWord;
+        }
+        initRx->DMA_BufferSize = len;
+    }
+}
+
+void spiInternalStartDMA(const extDevice_t *dev)
+{
+    dmaChannelDescriptor_t *dmaTx = dev->bus->dmaTx;
+    dmaChannelDescriptor_t *dmaRx = dev->bus->dmaRx;
+    DMA_Stream_TypeDef *streamRegsTx = (DMA_Stream_TypeDef *)dmaTx->ref;
+
+    if (dmaRx) {
+        DMA_Stream_TypeDef *streamRegsRx = (DMA_Stream_TypeDef *)dmaRx->ref;
+
+        dmaRx->userParam = (uint32_t)dev;
+
+        DMA_CLEAR_FLAG(dmaTx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+        DMA_CLEAR_FLAG(dmaRx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+
+        streamRegsTx->CR = 0U;
+        streamRegsRx->CR = 0U;
+
+        /* Use Rx TC interrupt — fires after SPI operation completes, unlike Tx TC
+         * which fires when Tx FIFO empties while the SPI operation is still in progress.
+         */
+        DMA_ITConfig(streamRegsRx, DMA_IT_TC, ENABLE);
+
+        DMA_Init(streamRegsTx, dev->bus->initTx);
+        DMA_Init(streamRegsRx, dev->bus->initRx);
+
+        DMA_Cmd(streamRegsTx, ENABLE);
+        DMA_Cmd(streamRegsRx, ENABLE);
+
+        SPI_I2S_DMACmd(dev->bus->busType_u.spi.instance, SPI_I2S_DMAReq_Tx | SPI_I2S_DMAReq_Rx, ENABLE);
+    } else {
+        dmaTx->userParam = (uint32_t)dev;
+
+        DMA_CLEAR_FLAG(dmaTx, DMA_IT_HTIF | DMA_IT_TEIF | DMA_IT_TCIF);
+
+        streamRegsTx->CR = 0U;
+        DMA_ITConfig(streamRegsTx, DMA_IT_TC, ENABLE);
+        DMA_Init(streamRegsTx, dev->bus->initTx);
+        DMA_Cmd(streamRegsTx, ENABLE);
+
+        SPI_I2S_DMACmd(dev->bus->busType_u.spi.instance, SPI_I2S_DMAReq_Tx, ENABLE);
+    }
+}
+
+void spiInternalStopDMA(const extDevice_t *dev)
+{
+    dmaChannelDescriptor_t *dmaTx = dev->bus->dmaTx;
+    dmaChannelDescriptor_t *dmaRx = dev->bus->dmaRx;
+    SPI_TypeDef *instance = dev->bus->busType_u.spi.instance;
+    DMA_Stream_TypeDef *streamRegsTx = (DMA_Stream_TypeDef *)dmaTx->ref;
+
+    if (dmaRx) {
+        DMA_Stream_TypeDef *streamRegsRx = (DMA_Stream_TypeDef *)dmaRx->ref;
+
+        streamRegsTx->CR = 0U;
+        streamRegsRx->CR = 0U;
+
+        SPI_I2S_DMACmd(instance, SPI_I2S_DMAReq_Tx | SPI_I2S_DMAReq_Rx, DISABLE);
+    } else {
+        while (SPI_I2S_GetFlagStatus(instance, SPI_I2S_FLAG_BSY));
+        while (SPI_I2S_GetFlagStatus(instance, SPI_I2S_FLAG_RXNE)) {
+            instance->DR;
+        }
+        streamRegsTx->CR = 0U;
+        SPI_I2S_DMACmd(instance, SPI_I2S_DMAReq_Tx, DISABLE);
+    }
+}
 
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor) {
 #define BR_BITS ((BIT(5) | BIT(4) | BIT(3)))

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -269,6 +269,7 @@ FAST_CODE void spiSequenceStart(const extDevice_t *dev)
     }
 }
 
+#if defined(STM32F4)
 void spiInternalResetDescriptors(busDevice_t *bus)
 {
     DMA_InitTypeDef *initTx = bus->initTx;
@@ -420,6 +421,7 @@ void spiInternalStopDMA(const extDevice_t *dev)
         SPI_I2S_DMACmd(instance, SPI_I2S_DMAReq_Tx, DISABLE);
     }
 }
+#endif // STM32F4
 
 void spiSetDivisor(SPI_TypeDef *instance, uint16_t divisor) {
 #define BR_BITS ((BIT(5) | BIT(4) | BIT(3)))

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include "resource.h"
 
 // Opaque DMA engine handle used by dma_reqmap (matches BF 4.5-maintenance).
@@ -33,6 +34,7 @@ typedef struct dmaChannelDescriptor_s {
 #if defined(STM32F4) || defined(STM32F7)
     DMA_Stream_TypeDef*         ref;
     uint8_t                     stream;
+    uint32_t                    channel;
 #else
     DMA_Channel_TypeDef*        ref;
 #endif
@@ -114,6 +116,8 @@ dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream);
 dmaChannelDescriptor_t* dmaGetDmaDescriptor(const DMA_Stream_TypeDef* stream);
 DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier);
 uint32_t dmaGetChannel(const uint8_t channel);
+bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex);
+void dmaEnable(dmaIdentifier_e identifier);
 
 #else
 

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -74,6 +74,22 @@ DEFINE_DMA_IRQ_HANDLER(2, 6, DMA2_ST6_HANDLER)
 DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
 #define DMA_RCC(x) ((x) == DMA1 ? RCC_AHB1Periph_DMA1 : RCC_AHB1Periph_DMA2)
+
+bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
+    if (dmaDescriptors[index].owner != OWNER_FREE) {
+        return false;
+    }
+    dmaDescriptors[index].owner = owner;
+    dmaDescriptors[index].resourceIndex = resourceIndex;
+    return true;
+}
+
+void dmaEnable(dmaIdentifier_e identifier) {
+    const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
+    RCC_AHB1PeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);
+}
+
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     RCC_AHB1PeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -76,6 +76,9 @@ DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 #define DMA_RCC(x) ((x) == DMA1 ? RCC_AHB1Periph_DMA1 : RCC_AHB1Periph_DMA2)
 
 bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (identifier == DMA_NONE) {
+        return false;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     if (dmaDescriptors[index].owner != OWNER_FREE) {
         return false;
@@ -86,6 +89,9 @@ bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t reso
 }
 
 void dmaEnable(dmaIdentifier_e identifier) {
+    if (identifier == DMA_NONE) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     RCC_AHB1PeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);
 }

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -85,6 +85,21 @@ static void enableDmaClock(int index) {
     } while (0);
 }
 
+bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
+    if (dmaDescriptors[index].owner != OWNER_FREE) {
+        return false;
+    }
+    dmaDescriptors[index].owner = owner;
+    dmaDescriptors[index].resourceIndex = resourceIndex;
+    return true;
+}
+
+void dmaEnable(dmaIdentifier_e identifier) {
+    const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
+    enableDmaClock(index);
+}
+
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     enableDmaClock(index);

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -86,6 +86,9 @@ static void enableDmaClock(int index) {
 }
 
 bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (identifier == DMA_NONE) {
+        return false;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     if (dmaDescriptors[index].owner != OWNER_FREE) {
         return false;
@@ -96,6 +99,9 @@ bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t reso
 }
 
 void dmaEnable(dmaIdentifier_e identifier) {
+    if (identifier == DMA_NONE) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     enableDmaClock(index);
 }

--- a/src/main/drivers/nvic.h
+++ b/src/main/drivers/nvic.h
@@ -27,6 +27,7 @@
 #define NVIC_PRIO_BARO_EXTI                NVIC_BUILD_PRIORITY(0x0f, 0x0f)
 #define NVIC_PRIO_SONAR_EXTI               NVIC_BUILD_PRIORITY(2, 0)  // maybe increase slightly
 #define NVIC_PRIO_TRANSPONDER_DMA          NVIC_BUILD_PRIORITY(3, 0)
+#define NVIC_PRIO_SPI_DMA                  NVIC_BUILD_PRIORITY(0, 0)
 #ifdef USE_DMA_SPI_DEVICE
 #ifdef STM32F7
 #define NVIC_PRIO_MPU_INT_EXTI             NVIC_BUILD_PRIORITY(0x00, 0x03)

--- a/src/main/drivers/resource.c
+++ b/src/main/drivers/resource.c
@@ -42,6 +42,8 @@ const char * const ownerNames[OWNER_TOTAL_COUNT] = {
     "SPI_SCK",
     "SPI_MISO",
     "SPI_MOSI",
+    "SPI_SDO",
+    "SPI_SDI",
     "I2C_SCL",
     "I2C_SDA",
     "SDCARD",

--- a/src/main/drivers/resource.h
+++ b/src/main/drivers/resource.h
@@ -42,6 +42,8 @@ typedef enum {
     OWNER_SPI_SCK,
     OWNER_SPI_MISO,
     OWNER_SPI_MOSI,
+    OWNER_SPI_SDO,
+    OWNER_SPI_SDI,
     OWNER_I2C_SCL,
     OWNER_I2C_SDA,
     OWNER_SDCARD,


### PR DESCRIPTION
## Summary

Ports the full async DMA SPI implementation from Betaflight 4.5-maintenance, stacked on top of the M.3.c dma_reqmap infrastructure (#1129).

All four sub-stages are bench-verified independently (7 targets each: HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF722V4, FOXEERF405, TMOTORF7).

### M.3.d — `spiInitBusDMA` DMA channel allocation (`f5ed331744`)
- Auto-allocates Tx+Rx DMA channels for each SPI bus via `dma_reqmap`
- Enables DMA clocks, stores descriptors in `busDevice_t`
- Sets `bus->dmaTx->stream/channel` fields needed by LL/stdperiph backends

### M.3.e — DMA stream functions + IRQ handlers (`66f9008bd8`)
- `bus_spi_ll.c` (F7): `spiInternalResetDescriptors`, `spiInternalResetStream`, `spiInternalInitStream`, `spiInternalStartDMA`, `spiInternalStopDMA` using LL DMA API; F7 D-cache flush/invalidate via `__DCACHE_PRESENT` guard
- `bus_spi_stdperiph.c` (F4): same five functions using stdperiph DMA API; 16-bit memory-width optimisation for aligned Rx buffers
- `bus_spi.c`: `spiIrqHandler` (segment-advance + linked-segment chaining), `spiRxIrqHandler`, `spiTxIrqHandler`; IRQ handlers registered via `dmaSetHandler` in `spiInitBusDMA`
- `bus->useDMA` held false pending M.3.f

### M.3.f — `ATOMIC_BLOCK` queuing in `spiSequence` + activate `bus->useDMA` (`4f0e59a652`)
- Replaces blocking `spiWait` in `spiSequence` with `ATOMIC_BLOCK(NVIC_PRIO_MAX)` + linked-segment queue (BF 4.5-m pattern): if bus busy → append to tail; if free → claim and call `spiSequenceStart`
- IMUF9001 blocking path isolated before the atomic block (incompatible with raised BASEPRI)
- Sets `bus->useDMA = true` in `spiInitBusDMA` for both full-duplex and Tx-only buses — DMA path now live

### M.3.g — Gyro reads onto bus DMA abstraction (`09ffd04b01`)
- BMI270 `bmi270GyroReadRegister` / `bmi270GyroReadFifo`: replace raw `IOLo/spiTransfer/IOHi` with `spiSequence`/`spiWait`; rx buffers made static for F7 D-cache cache-line safety
- MPU-6000 `mpuGyroReadSPI`: rx buffer made static (was stack); tx was already `static const`
- ICM-426xx: already uses `STATIC_DMA_DATA_AUTO` for both buffers — no change

## Intentional deviations from BF (carried forward from prior stages)
- DEV-001: `ffs(divisor | 0x100)` vs BF `constrain + ffs` — avoids `maths.h` in `FAST_CODE`
- DEV-002: no `USE_DMA_SPEC` guard in `dma_reqmap_mcu.c` — EF lacks CLI DMA configurator
- DEV-003: `spiInitBusDMA` always auto-assigns opts; no `txDmaopt`/`rxDmaopt` in `spiPinConfig_t`

## Test plan
- [x] `make test` passes (zero new unit test failures)
- [x] All bench + compile + unique targets build with zero new warnings (each sub-stage)
- [x] Hardware bench verified each sub-stage independently (7 targets, unsoldered FCs)
- [ ] Reviewer build + bench on own hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Implemented interrupt-driven SPI DMA sequencing for more efficient, non-blocking transfers
  * Unified DMA start/stop and stream handling for more robust SPI transfers
  * Replaced manual SPI toggling with unified DMA-based transfer sequencing

* **Bug Fixes**
  * Improved sensor read buffering to reduce occasional read corruption and timing issues

* **Chores**
  * Added DMA allocation/enable APIs and SPI DMA priority configuration
  * Extended resource owner identifiers for SPI signal roles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->