### PR TITLE
refactor(gyro): Stage M.4 — EXTI-triggered non-blocking DMA gyro read (BF 4.5-m parity)

### DIFF
--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -75,6 +75,13 @@
 #define GYRO_RATE_16_kHz    64.0f
 #define GYRO_RATE_32_kHz    32.0f
 
+typedef enum {
+    GYRO_EXTI_INIT = 0,
+    GYRO_EXTI_INT_DMA,
+    GYRO_EXTI_INT,
+    GYRO_EXTI_NO_INT
+} gyroModeSPI_e;
+
 typedef struct gyroDev_s {
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_MULTITHREAD)
     pthread_mutex_t lock;
@@ -105,6 +112,13 @@ typedef struct gyroDev_s {
     gyroSensor_e gyroHardware;
     uint8_t accDataReg;
     uint8_t gyroDataReg;
+    gyroModeSPI_e gyroModeSPI;
+    uint32_t detectedEXTI;
+    uint32_t gyroLastEXTI;
+    uint32_t gyroSyncEXTI;
+    int32_t gyroShortPeriod;
+    int32_t gyroDmaMaxDuration;
+    busSegment_t segments[2];
 } gyroDev_t;
 
 typedef struct accDev_s {

--- a/src/main/drivers/accgyro/accgyro.h
+++ b/src/main/drivers/accgyro/accgyro.h
@@ -128,6 +128,7 @@ typedef struct accDev_s {
     sensorAccInitFuncPtr initFn;                              // initialize function
     sensorAccReadFuncPtr readFn;                              // read 3 axis data function
     extDevice_t dev;
+    struct gyroDev_s *gyro;
     uint16_t acc_1G;
     int16_t ADCRaw[XYZ_AXIS_COUNT];
     mpuDetectionResult_t mpuDetectionResult;

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -84,6 +84,8 @@ imufData_t imufData;
 
 #define MPU_INQUIRY_MASK   0x7E
 
+#define GYRO_EXTI_DETECT_THRESHOLD 1000
+
 #if defined(USE_I2C) && !defined(USE_DMA_SPI_DEVICE)
 static void mpu6050FindRevision(gyroDev_t *gyro) {
     // There is a map of revision contained in the android source tree which is quite comprehensive and may help to understand this code
@@ -122,24 +124,35 @@ static void mpu6050FindRevision(gyroDev_t *gyro) {
  * Gyro interrupt service routine
  */
 #if defined(MPU_INT_EXTI)
+// Called in ISR context after DMA transfer completes
+busStatus_e mpuIntCallback(uint32_t arg)
+{
+    gyroDev_t *gyro = (gyroDev_t *)arg;
+    int32_t gyroDmaDuration = cmpTimeCycles(getCycleCounter(), gyro->gyroLastEXTI);
+    if (gyroDmaDuration > gyro->gyroDmaMaxDuration) {
+        gyro->gyroDmaMaxDuration = gyroDmaDuration;
+    }
+    gyro->dataReady = true;
+    return BUS_READY;
+}
+
 FAST_CODE static void mpuIntExtiHandler(extiCallbackRec_t *cb) {
 #ifdef USE_DMA_SPI_DEVICE
     //start dma read
     (void)(cb);
     gyroDmaSpiStartRead();
 #else
-#ifdef DEBUG_MPU_DATA_READY_INTERRUPT
-    static uint32_t lastCalledAtUs = 0;
-    const uint32_t nowUs = micros();
-    debug[0] = (uint16_t)(nowUs - lastCalledAtUs);
-    lastCalledAtUs = nowUs;
-#endif
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
-    gyro->dataReady = true;
-#ifdef DEBUG_MPU_DATA_READY_INTERRUPT
-    const uint32_t now2Us = micros();
-    debug[1] = (uint16_t)(now2Us - nowUs);
-#endif // DEBUG_MPU_DATA_READY_INTERRUPT
+    uint32_t nowCycles = getCycleCounter();
+    int32_t gyroLastPeriod = cmpTimeCycles(nowCycles, gyro->gyroLastEXTI);
+    if ((gyro->gyroShortPeriod == 0) || (gyroLastPeriod < gyro->gyroShortPeriod)) {
+        gyro->gyroSyncEXTI = gyro->gyroLastEXTI + gyro->gyroDmaMaxDuration;
+    }
+    gyro->gyroLastEXTI = nowCycles;
+    if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
+        spiSequence(&gyro->dev, gyro->segments);
+    }
+    gyro->detectedEXTI++;
 #endif // USE_DMA_SPI_DEVICE
 }
 
@@ -258,16 +271,75 @@ FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
     return true;
 }
 
-FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro) {
-    static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    static uint8_t data[7];
-    const bool ack = spiReadWriteBufRB(&gyro->dev, (uint8_t *)dataToSend, data, 7);
-    if (!ack) {
-        return false;
+FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro)
+{
+    int16_t *gyroData = (int16_t *)gyro->dev.rxBuf;
+    switch (gyro->gyroModeSPI) {
+    case GYRO_EXTI_INIT:
+    {
+        memset(gyro->dev.txBuf, 0xff, 16);
+        gyro->gyroDmaMaxDuration = 5;
+#if defined(MPU_INT_EXTI)
+        if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
+            if (spiUseDMA(&gyro->dev)) {
+                gyro->dev.callbackArg = (uint32_t)gyro;
+                gyro->dev.txBuf[0] = gyro->accDataReg | 0x80;
+                gyro->segments[0].len = gyro->gyroDataReg - gyro->accDataReg + sizeof(uint8_t) + 3 * sizeof(int16_t);
+                gyro->segments[0].callback = mpuIntCallback;
+                gyro->segments[0].u.buffers.txData = gyro->dev.txBuf;
+                gyro->segments[0].u.buffers.rxData = &gyro->dev.rxBuf[1];
+                gyro->segments[0].negateCS = true;
+                gyro->segments[1].len = 0;
+                gyro->segments[1].u.link.dev = NULL;
+                gyro->segments[1].u.link.segments = NULL;
+                gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
+            } else {
+                gyro->gyroModeSPI = GYRO_EXTI_INT;
+            }
+        } else {
+            gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+        }
+#else
+        gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+#endif
+        break;
     }
-    gyro->gyroADCRaw[X] = (int16_t)((data[1] << 8) | data[2]);
-    gyro->gyroADCRaw[Y] = (int16_t)((data[3] << 8) | data[4]);
-    gyro->gyroADCRaw[Z] = (int16_t)((data[5] << 8) | data[6]);
+
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+    {
+        gyro->dev.txBuf[0] = gyro->gyroDataReg | 0x80;
+
+        busSegment_t segments[] = {
+            {.u.buffers = {NULL, NULL}, 7, true, NULL},
+            {.u.link = {NULL, NULL}, 0, true, NULL},
+        };
+        segments[0].u.buffers.txData = gyro->dev.txBuf;
+        segments[0].u.buffers.rxData = &gyro->dev.rxBuf[1];
+
+        spiSequence(&gyro->dev, &segments[0]);
+        spiWait(&gyro->dev);
+
+        gyro->gyroADCRaw[X] = __builtin_bswap16(gyroData[1]);
+        gyro->gyroADCRaw[Y] = __builtin_bswap16(gyroData[2]);
+        gyro->gyroADCRaw[Z] = __builtin_bswap16(gyroData[3]);
+        break;
+    }
+
+    case GYRO_EXTI_INT_DMA:
+    {
+        // Data was read by DMA from EXTI interrupt; acc and gyro may not be contiguous
+        const uint8_t gyroDataIndex = ((gyro->gyroDataReg - gyro->accDataReg) >> 1) + 1;
+        gyro->gyroADCRaw[X] = __builtin_bswap16(gyroData[gyroDataIndex]);
+        gyro->gyroADCRaw[Y] = __builtin_bswap16(gyroData[gyroDataIndex + 1]);
+        gyro->gyroADCRaw[Z] = __builtin_bswap16(gyroData[gyroDataIndex + 2]);
+        break;
+    }
+
+    default:
+        break;
+    }
+
     return true;
 }
 

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -149,9 +149,11 @@ FAST_CODE static void mpuIntExtiHandler(extiCallbackRec_t *cb) {
         gyro->gyroSyncEXTI = gyro->gyroLastEXTI + gyro->gyroDmaMaxDuration;
     }
     gyro->gyroLastEXTI = nowCycles;
+#ifdef GYRO_USES_SPI
     if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
         spiSequence(&gyro->dev, gyro->segments);
     }
+#endif
     gyro->detectedEXTI++;
 #endif // USE_DMA_SPI_DEVICE
 }
@@ -273,6 +275,7 @@ FAST_CODE bool mpuGyroRead(gyroDev_t *gyro) {
 
 FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro)
 {
+#ifdef GYRO_USES_SPI
     int16_t *gyroData = (int16_t *)gyro->dev.rxBuf;
     switch (gyro->gyroModeSPI) {
     case GYRO_EXTI_INIT:
@@ -341,6 +344,19 @@ FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro)
     }
 
     return true;
+#else
+    // I2C gyro path (e.g. CRAZYFLIE2): spiSequence not available
+    static const uint8_t dataToSend[7] = {MPU_RA_GYRO_XOUT_H | 0x80, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    static uint8_t data[7];
+    const bool ack = spiReadWriteBufRB(&gyro->dev, (uint8_t *)dataToSend, data, 7);
+    if (!ack) {
+        return false;
+    }
+    gyro->gyroADCRaw[X] = (int16_t)((data[1] << 8) | data[2]);
+    gyro->gyroADCRaw[Y] = (int16_t)((data[3] << 8) | data[4]);
+    gyro->gyroADCRaw[Z] = (int16_t)((data[5] << 8) | data[6]);
+    return true;
+#endif
 }
 
 #ifdef USE_SPI

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -536,10 +536,10 @@ void mpuDetect(gyroDev_t *gyro) {
 }
 
 void mpuGyroInit(gyroDev_t *gyro) {
+    gyro->accDataReg = MPU_RA_ACCEL_XOUT_H;
+    gyro->gyroDataReg = MPU_RA_GYRO_XOUT_H;
 #ifdef MPU_INT_EXTI
     mpuIntExtiInit(gyro);
-#else
-    UNUSED(gyro);
 #endif
 }
 

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -278,7 +278,7 @@ FAST_CODE bool mpuGyroReadSPI(gyroDev_t *gyro)
     case GYRO_EXTI_INIT:
     {
         memset(gyro->dev.txBuf, 0xff, 16);
-        gyro->gyroDmaMaxDuration = 5;
+        gyro->gyroDmaMaxDuration = 5; // seed estimate in CPU cycles; updated by mpuIntCallback with actual measurements
 #if defined(MPU_INT_EXTI)
         if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
             if (spiUseDMA(&gyro->dev)) {

--- a/src/main/drivers/accgyro/accgyro_mpu.h
+++ b/src/main/drivers/accgyro/accgyro_mpu.h
@@ -236,6 +236,9 @@ struct gyroDev_s;
 void mpuGyroInit(struct gyroDev_s *gyro);
 bool mpuGyroRead(struct gyroDev_s *gyro);
 bool mpuGyroReadSPI(struct gyroDev_s *gyro);
+#if defined(MPU_INT_EXTI)
+busStatus_e mpuIntCallback(uint32_t arg);
+#endif
 void mpuDetect(struct gyroDev_s *gyro);
 uint8_t mpuGyroDLPF(struct gyroDev_s *gyro);
 uint8_t mpuGyroFCHOICE(struct gyroDev_s *gyro);

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -385,6 +385,7 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
         memset(dev->txBuf, 0x00, 14);
 
         gyro->gyroDmaMaxDuration = 5;
+#if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
         if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
             if (spiUseDMA(dev)) {
                 dev->callbackArg = (uint32_t)gyro;
@@ -401,6 +402,9 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
         } else {
             gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
         }
+#else
+        gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+#endif
         break;
     }
 

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -20,10 +20,13 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "platform.h"
 
 #ifdef USE_ACCGYRO_BMI270
+
+#include "common/utils.h"
 
 #include "drivers/accgyro/accgyro.h"
 #include "drivers/accgyro/accgyro_spi_bmi270.h"
@@ -33,6 +36,7 @@
 #include "drivers/io_impl.h"
 #include "drivers/nvic.h"
 #include "drivers/sensor.h"
+#include "drivers/system.h"
 #include "drivers/time.h"
 
 // 10 MHz max SPI frequency
@@ -65,6 +69,8 @@ const uint8_t bmi270_maximum_fifo_config_file[] = {
 };
 
 #define BMI270_CHIP_ID 0x24
+
+#define GYRO_EXTI_DETECT_THRESHOLD 1000
 
 // BMI270 registers (not the complete list)
 typedef enum {
@@ -288,10 +294,29 @@ static void bmi270Config(const gyroDev_t *gyro)
 extiCallbackRec_t bmi270IntCallbackRec;
 
 #if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
+// Called in ISR context after DMA transfer completes
+busStatus_e bmi270Intcallback(uint32_t arg)
+{
+    gyroDev_t *gyro = (gyroDev_t *)arg;
+    int32_t gyroDmaDuration = cmpTimeCycles(getCycleCounter(), gyro->gyroLastEXTI);
+    if (gyroDmaDuration > gyro->gyroDmaMaxDuration) {
+        gyro->gyroDmaMaxDuration = gyroDmaDuration;
+    }
+    gyro->dataReady = true;
+    return BUS_READY;
+}
+
 void bmi270ExtiHandler(extiCallbackRec_t *cb)
 {
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
-    gyro->dataReady = true;
+    extDevice_t *dev = &gyro->dev;
+    uint32_t nowCycles = getCycleCounter();
+    gyro->gyroSyncEXTI = gyro->gyroLastEXTI + gyro->gyroDmaMaxDuration;
+    gyro->gyroLastEXTI = nowCycles;
+    if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
+        spiSequence(dev, gyro->segments);
+    }
+    gyro->detectedEXTI++;
 }
 
 static void bmi270IntExtiInit(gyroDev_t *gyro)
@@ -304,65 +329,113 @@ static void bmi270IntExtiInit(gyroDev_t *gyro)
 
     IOInit(mpuIntIO, OWNER_MPU_EXTI, 0);
     EXTIHandlerInit(&gyro->exti, bmi270ExtiHandler);
-    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING );
+    EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING);
     EXTIEnable(mpuIntIO, true);
 }
 #endif
 
 static bool bmi270AccRead(accDev_t *acc)
 {
-    enum {
-        IDX_REG = 0,
-        IDX_SKIP,
-        IDX_ACCEL_XOUT_L,
-        IDX_ACCEL_XOUT_H,
-        IDX_ACCEL_YOUT_L,
-        IDX_ACCEL_YOUT_H,
-        IDX_ACCEL_ZOUT_L,
-        IDX_ACCEL_ZOUT_H,
-        BUFFER_SIZE,
-    };
+    extDevice_t *dev = &acc->gyro->dev;
 
-    uint8_t bmi270_rx_buf[BUFFER_SIZE];
-    static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_ACC_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
+    switch (acc->gyro->gyroModeSPI) {
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+    {
+        dev->txBuf[0] = BMI270_REG_ACC_DATA_X_LSB | 0x80;
 
-    IOLo(acc->dev.busType_u.spi.csnPin);
-    spiTransfer(acc->dev.bus->busType_u.spi.instance, bmi270_tx_buf, bmi270_rx_buf, BUFFER_SIZE);   // receive response
-    IOHi(acc->dev.busType_u.spi.csnPin);
+        busSegment_t segments[] = {
+            {.u.buffers = {NULL, NULL}, 8, true, NULL},
+            {.u.link = {NULL, NULL}, 0, true, NULL},
+        };
+        segments[0].u.buffers.txData = dev->txBuf;
+        segments[0].u.buffers.rxData = dev->rxBuf;
 
-    acc->ADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_XOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_XOUT_L]);
-    acc->ADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_YOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_YOUT_L]);
-    acc->ADCRaw[Z] = (int16_t)((bmi270_rx_buf[IDX_ACCEL_ZOUT_H] << 8) | bmi270_rx_buf[IDX_ACCEL_ZOUT_L]);
+        spiSequence(dev, &segments[0]);
+        spiWait(dev);
+
+        FALLTHROUGH;
+    }
+
+    case GYRO_EXTI_INT_DMA:
+    {
+        int16_t *accData = (int16_t *)dev->rxBuf;
+        acc->ADCRaw[X] = accData[1];
+        acc->ADCRaw[Y] = accData[2];
+        acc->ADCRaw[Z] = accData[3];
+        break;
+    }
+
+    case GYRO_EXTI_INIT:
+    default:
+        break;
+    }
 
     return true;
 }
 
 static bool bmi270GyroReadRegister(gyroDev_t *gyro)
 {
-    enum {
-        IDX_REG = 0,
-        IDX_SKIP,
-        IDX_GYRO_XOUT_L,
-        IDX_GYRO_XOUT_H,
-        IDX_GYRO_YOUT_L,
-        IDX_GYRO_YOUT_H,
-        IDX_GYRO_ZOUT_L,
-        IDX_GYRO_ZOUT_H,
-        BUFFER_SIZE,
-    };
+    extDevice_t *dev = &gyro->dev;
+    int16_t *gyroData = (int16_t *)dev->rxBuf;
 
-    static const uint8_t bmi270_tx_buf[BUFFER_SIZE] = {BMI270_REG_GYR_DATA_X_LSB | 0x80, 0, 0, 0, 0, 0, 0, 0};
-    static uint8_t bmi270_rx_buf[BUFFER_SIZE];
-    busSegment_t segments[] = {
-        {.u.buffers = {(uint8_t *)bmi270_tx_buf, bmi270_rx_buf}, BUFFER_SIZE, true, NULL},
-        {.u.link = {NULL, NULL}, 0, true, NULL},
-    };
-    spiSequence(&gyro->dev, &segments[0]);
-    spiWait(&gyro->dev);
+    switch (gyro->gyroModeSPI) {
+    case GYRO_EXTI_INIT:
+    {
+        memset(dev->txBuf, 0x00, 14);
 
-    gyro->gyroADCRaw[X] = (int16_t)((bmi270_rx_buf[IDX_GYRO_XOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_XOUT_L]);
-    gyro->gyroADCRaw[Y] = (int16_t)((bmi270_rx_buf[IDX_GYRO_YOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_YOUT_L]);
-    gyro->gyroADCRaw[Z] = (int16_t)((bmi270_rx_buf[IDX_GYRO_ZOUT_H] << 8) | bmi270_rx_buf[IDX_GYRO_ZOUT_L]);
+        gyro->gyroDmaMaxDuration = 5;
+        if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
+            if (spiUseDMA(dev)) {
+                dev->callbackArg = (uint32_t)gyro;
+                dev->txBuf[0] = BMI270_REG_ACC_DATA_X_LSB | 0x80;
+                gyro->segments[0].len = 14;
+                gyro->segments[0].callback = bmi270Intcallback;
+                gyro->segments[0].u.buffers.txData = dev->txBuf;
+                gyro->segments[0].u.buffers.rxData = dev->rxBuf;
+                gyro->segments[0].negateCS = true;
+                gyro->gyroModeSPI = GYRO_EXTI_INT_DMA;
+            } else {
+                gyro->gyroModeSPI = GYRO_EXTI_INT;
+            }
+        } else {
+            gyro->gyroModeSPI = GYRO_EXTI_NO_INT;
+        }
+        break;
+    }
+
+    case GYRO_EXTI_INT:
+    case GYRO_EXTI_NO_INT:
+    {
+        dev->txBuf[0] = BMI270_REG_GYR_DATA_X_LSB | 0x80;
+
+        busSegment_t segments[] = {
+            {.u.buffers = {NULL, NULL}, 8, true, NULL},
+            {.u.link = {NULL, NULL}, 0, true, NULL},
+        };
+        segments[0].u.buffers.txData = dev->txBuf;
+        segments[0].u.buffers.rxData = dev->rxBuf;
+
+        spiSequence(dev, &segments[0]);
+        spiWait(dev);
+
+        gyro->gyroADCRaw[X] = gyroData[1];
+        gyro->gyroADCRaw[Y] = gyroData[2];
+        gyro->gyroADCRaw[Z] = gyroData[3];
+        break;
+    }
+
+    case GYRO_EXTI_INT_DMA:
+    {
+        gyro->gyroADCRaw[X] = gyroData[4];
+        gyro->gyroADCRaw[Y] = gyroData[5];
+        gyro->gyroADCRaw[Z] = gyroData[6];
+        break;
+    }
+
+    default:
+        break;
+    }
 
     return true;
 }

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -384,7 +384,7 @@ static bool bmi270GyroReadRegister(gyroDev_t *gyro)
     {
         memset(dev->txBuf, 0x00, 14);
 
-        gyro->gyroDmaMaxDuration = 5;
+        gyro->gyroDmaMaxDuration = 5; // seed estimate in CPU cycles; updated by bmi270Intcallback with actual measurements
 #if defined(USE_GYRO_EXTI) && defined(USE_MPU_DATA_READY_SIGNAL)
         if (gyro->detectedEXTI > GYRO_EXTI_DETECT_THRESHOLD) {
             if (spiUseDMA(dev)) {

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -47,6 +47,19 @@ void cycleCounterInit(void) {
     RCC_GetClocksFreq(&clocks);
     usTicks = clocks.SYSCLK_Frequency / 1000000;
 #endif
+    // Enable DWT cycle counter (Cortex-M3/M4/M7)
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+#if defined(USE_HAL_DRIVER)
+    // Cortex-M7 requires unlocking DWT write access via LAR
+    *((volatile uint32_t *)(DWT_BASE + 0x0FB0)) = 0xC5ACCE55;
+#endif
+    DWT->CYCCNT = 0;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+}
+
+uint32_t getCycleCounter(void)
+{
+    return DWT->CYCCNT;
 }
 
 // SysTick

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -49,9 +49,8 @@ void cycleCounterInit(void) {
 #endif
     // Enable DWT cycle counter (Cortex-M3/M4/M7)
     CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-#if defined(USE_HAL_DRIVER)
-    // Cortex-M7 requires unlocking DWT write access via LAR
-    *((volatile uint32_t *)(DWT_BASE + 0x0FB0)) = 0xC5ACCE55;
+#if defined(STM32F7)
+    DWT->LAR = 0xC5ACCE55;
 #endif
     DWT->CYCCNT = 0;
     DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -51,6 +51,12 @@ void systemResetToBootloader(void);
 void checkForBootLoaderRequest(void);
 bool isMPUSoftReset(void);
 void cycleCounterInit(void);
+uint32_t getCycleCounter(void);
+
+static inline int32_t cmpTimeCycles(uint32_t a, uint32_t b)
+{
+    return (int32_t)(a - b);
+}
 
 void enableGPIOPowerUsageAndNoiseReductions(void);
 // current crystal frequency - 8 or 12MHz

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -367,6 +367,7 @@ bool accInit(void) {
     memset(&acc, 0, sizeof(acc));
     // copy over the common gyro mpu settings
     acc.dev.dev = *gyroSensorBus();
+    acc.dev.gyro = gyroSensorGetDev();
     acc.dev.mpuDetectionResult = *gyroMpuDetectionResult();
     acc.dev.acc_high_fsr = accelerometerConfig()->acc_high_fsr;
 #ifdef USE_DUAL_GYRO

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -221,6 +221,8 @@ static void gyroInitLowpassFilterLpf(gyroSensor_t *gyroSensor, int slot, int typ
 #define GYRO_OVERFLOW_TRIGGER_THRESHOLD 31980  // 97.5% full scale (1950dps for 2000dps gyro)
 #define GYRO_OVERFLOW_RESET_THRESHOLD 30340    // 92.5% full scale (1850dps for 2000dps gyro)
 
+#define GYRO_BUF_SIZE 32
+
 PG_REGISTER_WITH_RESET_TEMPLATE(gyroConfig_t, gyroConfig, PG_GYRO_CONFIG, 6);
 
 #ifndef GYRO_CONFIG_USE_GYRO_DEFAULT
@@ -702,6 +704,9 @@ bool gyroInit(void) {
 #endif
     spiSetBusInstance(&gyroSensor1.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_1_SPI_BUS));
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_1 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
+        static FAST_RAM_ZERO_INIT uint8_t gyroBuf1[GYRO_BUF_SIZE];
+        gyroSensor1.gyroDev.dev.txBuf = gyroBuf1;
+        gyroSensor1.gyroDev.dev.rxBuf = &gyroBuf1[GYRO_BUF_SIZE / 2];
         ret = gyroInitSensor(&gyroSensor1);
         if (!ret) {
             return false; // TODO handle failure of first gyro detection better. - Perhaps update the config to use second gyro then indicate a new failure mode and reboot.
@@ -709,6 +714,11 @@ bool gyroInit(void) {
         gyroHasOverflowProtection =  gyroHasOverflowProtection && gyroSensor1.gyroDev.gyroHasOverflowProtection;
     }
 #else // USE_DUAL_GYRO
+    {
+        static FAST_RAM_ZERO_INIT uint8_t gyroBuf1[GYRO_BUF_SIZE];
+        gyroSensor1.gyroDev.dev.txBuf = gyroBuf1;
+        gyroSensor1.gyroDev.dev.rxBuf = &gyroBuf1[GYRO_BUF_SIZE / 2];
+    }
     ret = gyroInitSensor(&gyroSensor1);
     gyroHasOverflowProtection =  gyroHasOverflowProtection && gyroSensor1.gyroDev.gyroHasOverflowProtection;
 #endif // USE_DUAL_GYRO
@@ -726,6 +736,9 @@ bool gyroInit(void) {
 #endif
     spiSetBusInstance(&gyroSensor2.gyroDev.dev, SPI_DEV_TO_CFG(GYRO_2_SPI_BUS));
     if (gyroToUse == GYRO_CONFIG_USE_GYRO_2 || gyroToUse == GYRO_CONFIG_USE_GYRO_BOTH) {
+        static FAST_RAM_ZERO_INIT uint8_t gyroBuf2[GYRO_BUF_SIZE];
+        gyroSensor2.gyroDev.dev.txBuf = gyroBuf2;
+        gyroSensor2.gyroDev.dev.rxBuf = &gyroBuf2[GYRO_BUF_SIZE / 2];
         ret = gyroInitSensor(&gyroSensor2);
         if (!ret) {
             return false; // TODO handle failure of second gyro detection better. - Perhaps update the config to use first gyro then indicate a new failure mode and reboot.

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -339,6 +339,18 @@ const extDevice_t *gyroSensorBus(void) {
 #endif
 }
 
+gyroDev_t *gyroSensorGetDev(void) {
+#ifdef USE_DUAL_GYRO
+    if (gyroToUse == GYRO_CONFIG_USE_GYRO_2) {
+        return &gyroSensor2.gyroDev;
+    } else {
+        return &gyroSensor1.gyroDev;
+    }
+#else
+    return &gyroSensor1.gyroDev;
+#endif
+}
+
 #ifdef USE_GYRO_REGISTER_DUMP
 const extDevice_t *gyroSensorBusByDevice(uint8_t whichSensor) {
 #ifdef USE_DUAL_GYRO

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -193,6 +193,7 @@ void gyroDmaSpiStartRead(void);
 void gyroUpdate(timeUs_t currentTimeUs);
 bool gyroGetAverage(quaternion *vAverage);
 const extDevice_t *gyroSensorBus(void);
+struct gyroDev_s *gyroSensorGetDev(void);
 struct mpuConfiguration_s;
 const struct mpuConfiguration_s *gyroMpuConfiguration(void);
 struct mpuDetectionResult_s;


### PR DESCRIPTION
## Summary

Ports Betaflight 4.5-maintenance's `gyroModeSPI` EXTI-triggered non-blocking DMA gyro read state machine to EmuFlight. This is the final stage of the extDevice_t bus-abstraction alignment series.

- **M.4.a** — `gyroModeSPI_e` enum + 7 new `gyroDev_t` fields (`gyroModeSPI`, `detectedEXTI`, `gyroLastEXTI`, `gyroSyncEXTI`, `gyroShortPeriod`, `gyroDmaMaxDuration`, `segments[2]`); DMA-safe `txBuf`/`rxBuf` allocated as `FAST_RAM_ZERO_INIT` in `gyro.c`; DWT cycle counter (`getCycleCounter()`) added to `system.c/h`. Zero behavior change — all fields default to 0 = `GYRO_EXTI_INIT`.

- **M.4.b** — MPU EXTI handler and `mpuGyroReadSPI` 4-state machine (`accgyro_mpu.c`). `mpuIntCallback` (DMA completion ISR) measures transfer duration + sets `dataReady`. `mpuIntExtiHandler` upgraded: cycle timestamps, `spiSequence` trigger in `INT_DMA` mode, `detectedEXTI` counter. `mpuGyroInit` sets `accDataReg`/`gyroDataReg` (BF parity — was missing in EF, caused flatline regression, fixed same session). State machine: `INIT` → arms DMA after 1000 EXTI interrupts if `spiUseDMA()` → `INT_DMA`; else `INT`; no EXTI → `NO_INT`. `INT`/`NO_INT` fall back to blocking `spiSequence`/`spiWait`. `INT_DMA` reads gyro from `rxBuf` without blocking.

- **M.4.c** — BMI270 state machine (`accgyro_spi_bmi270.c`). Same pattern as M.4.b but BMI270-specific: 14-byte combined ACC+GYR DMA read; `bmi270Intcallback`; `bmi270ExtiHandler` upgraded. `bmi270AccRead` replaced with state machine reading `accData[1..3]` from shared buffer in `INT_DMA` mode. `accDev_t` gains `gyroDev_t *gyro` pointer (required to access `gyroModeSPI` from the acc read path — EF had no equivalent of BF's `acc->gyro`); wired via new `gyroSensorGetDev()` accessor (USE_DUAL_GYRO-aware).

## Behavior

- Targets **without** EXTI or without `USE_MPU_DATA_READY_SIGNAL`: fall through to `GYRO_EXTI_NO_INT` — blocking read, identical to pre-M.4 behavior.
- Targets **with** EXTI + DMA: after 1000 EXTI interrupts, transitions to `GYRO_EXTI_INT_DMA` — gyro transfer is triggered from the EXTI ISR, scheduler tick reads the result without waiting.
- Acc path unchanged for non-BMI270 targets. BMI270 acc read now uses the shared DMA buffer in `INT_DMA` mode.

## Test plan

- [x] Build: HELIOSPRING, FOXEERF722V4, APEXF7 (BMI270), PYRODRONEF7, MAMBAF722, TUNERCF405, FOXEERF405, SKYSTARSF405AIO, TMOTORF7 — zero new warnings
- [x] Bench: HELIOSPRING (BMI270/F7), FOXEERF722V4 (BMI270/F7), PYRODRONEF7 (MPU6000/F7), TUNERCF405 (BMI270/F4), SKYSTARSF405AIO (F4), FOXEERF405 (F4), TMOTORF7 (F7) — gyro and acc live, no lockups
- [x] Regression catch: gyro flatline on MPU targets caused by missing `accDataReg`/`gyroDataReg` init — diagnosed and fixed same session
- [x] Regression catch: `bmi270Intcallback` undeclared on targets with `USE_GYRO_EXTI` but not `USE_MPU_DATA_READY_SIGNAL` — guard fixed same session

## Related PRs (extDevice_t series)

#1128 (M.3.a/b), #1129 (M.3.c), #1130 (M.3.d–g)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public gyro device accessor for tighter sensor coordination.

* **Improvements**
  * Enhanced gyro/accelerometer synchronization for more consistent sensor fusion.
  * Smarter interrupt-driven acquisition with DMA-aware handling for lower latency and jitter.
  * Improved high-resolution timing support for more accurate measurement timestamps.
  * More robust sensor initialization and cross-device coordination for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->