### PR TITLE
fix(gyro): backport clockMicrosToCycles + gyroShortPeriod init for MPU6000 (BF 4.5-m parity)

### DIFF
--- a/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6000.c
@@ -98,6 +98,7 @@ static bool mpuSpi6000InitDone = false;
 #define MPU6000_REV_D8 0x58
 #define MPU6000_REV_D9 0x59
 #define MPU6000_REV_D10 0x5A
+#define MPU6000_SHORT_THRESHOLD         82  // Any interrupt interval less than this will be recognised as the short interval of ~79us
 
 void mpu6000SpiGyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
@@ -213,6 +214,7 @@ bool mpu6000SpiGyroDetect(gyroDev_t *gyro) {
     gyro->readFn = mpuGyroReadSPI;
     // 16.4 dps/lsb scalefactor
     gyro->scale = 1.0f / 16.4f;
+    gyro->gyroShortPeriod = clockMicrosToCycles(MPU6000_SHORT_THRESHOLD);
     return true;
 }
 

--- a/src/main/drivers/system.c
+++ b/src/main/drivers/system.c
@@ -61,6 +61,11 @@ uint32_t getCycleCounter(void)
     return DWT->CYCCNT;
 }
 
+uint32_t clockMicrosToCycles(uint32_t micros)
+{
+    return micros * usTicks;
+}
+
 // SysTick
 
 static volatile int sysTickPending = 0;

--- a/src/main/drivers/system.h
+++ b/src/main/drivers/system.h
@@ -52,6 +52,7 @@ void checkForBootLoaderRequest(void);
 bool isMPUSoftReset(void);
 void cycleCounterInit(void);
 uint32_t getCycleCounter(void);
+uint32_t clockMicrosToCycles(uint32_t micros);
 
 static inline int32_t cmpTimeCycles(uint32_t a, uint32_t b)
 {


### PR DESCRIPTION
## Summary

- **`system.c` / `system.h`**: backport `clockMicrosToCycles(micros)` from BF 4.5-maintenance — the function was absent from EF entirely, causing linker failures on targets that include the MPU6000 driver via LTO (SKYSTARSF405AIO, MATEKF411, ANYFCF7).
- **`accgyro_spi_mpu6000.c`**: add `MPU6000_SHORT_THRESHOLD` define (82 µs, BF parity) and set `gyro->gyroShortPeriod` in `mpu6000SpiGyroDetect` — the field was introduced in M.4 but never initialised for MPU6000, leaving the short-period EXTI double-pulse filter permanently disabled (`gyroShortPeriod == 0` makes the first condition in `mpuIntExtiHandler` always true, bypassing the filter unconditionally).

Fixes #1132

## BF reference

- `src/main/drivers/system.c:184` — `clockMicrosToCycles` definition
- `src/main/drivers/system.h:72` — declaration
- `src/main/drivers/accgyro/accgyro_spi_mpu6000.c:53,227` — `MPU6000_SHORT_THRESHOLD` + `gyroShortPeriod` assignment

## Test plan

- [x] `make test` — unit tests pass
- [x] Full build sweep — all bench, compile, and unique targets pass (zero new warnings)
- [x] Bench gyro verified on 6 targets: PYRODRONEF7 (MPU6000/F7), FOXEERF722V4 (MPU6000/F7), FOXEERF405 (MPU6000/F4), TMOTORF7 (BMI270 variant/F7), HELIOSPRING (IMUF9001/F4), SKYSTARSF405AIO (MPU6000+BMI270/F4)
- [x] Classification: **Tier 1** — structural init fix; no new code paths; gyro live on all tested targets

**Coverage gaps (unchanged):** F446, F7X5XG not in bench set.

AI Generated comment — Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved gyro detection capabilities with enhanced timing threshold logic for better recognition of short interrupt intervals during sensor calibration.
  * Expanded system clock utilities with a new microseconds-to-clock-cycles conversion function for improved timing precision in driver operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->