### PR TITLE
fix(gyro): BMI270 DLPF_EXPERIMENTAL rate-select reads lpf param, not gyro->hardware_lpf

### DIFF
--- a/src/main/drivers/accgyro/gyro_sync.c
+++ b/src/main/drivers/accgyro/gyro_sync.c
@@ -66,7 +66,7 @@ uint32_t gyroSetSampleRate(gyroDev_t *gyro, uint8_t lpf, uint8_t gyroSyncDenomin
             break;
         case BMI_270_SPI:    //bmi270
 #ifdef USE_GYRO_DLPF_EXPERIMENTAL
-            if (gyro->hardware_lpf == GYRO_HARDWARE_LPF_EXPERIMENTAL) {
+            if (lpf == GYRO_HARDWARE_LPF_EXPERIMENTAL) {
                 // 6.4KHz sampling, but data is unfiltered (no hardware DLPF)
                 gyro->gyroRateKHz = GYRO_RATE_6400_Hz;
                 gyroConfigMutable()->gyroSampleRateHz = 6400;


### PR DESCRIPTION
## Summary

In `gyroSetSampleRate()` (`gyro_sync.c`), the `BMI_270_SPI` branch under `USE_GYRO_DLPF_EXPERIMENTAL` was checking `gyro->hardware_lpf` (the previously-stored struct value) instead of the `lpf` function parameter (the incoming request). Every other case in the function uses `lpf`; this branch was the only outlier.

At boot the two values are coincidentally equal — `gyro.c` stores `hardware_lpf` at line 620, then calls `gyroSetSampleRate` with the same config value at line 622 — so there is no init regression. But the inconsistency violates the function contract and means BMI270 experimental-rate selection does not respond to the incoming parameter value.

**Fix:** one-line change: `gyro->hardware_lpf` → `lpf`.

## BF equivalence note

BF 4.5-m uses `gyro->hardware_lpf` in the same branch, but BF's `gyroSetSampleRate` signature carries **no** `lpf` parameter — so the struct read is the only option there. EF's signature has the parameter; using it is correct here.

## Test plan

- [x] Unit tests pass (`make test`)
- [x] All bench targets compile clean: HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7
- [x] All compile targets clean: MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 CRAZYFLIE2
- [x] Unique targets clean (NUCLEOF446RE, COLIBRI, STM32F4DISCOVERY, etc.)
- [ ] BMI270 bench verification pending (user will set `gyro_hardware_lpf = EXPERIMENTAL` via CLI and confirm 6.4 kHz loop rate in Configurator sensors tab)

## Classification

Tier 1 — no default-config behavior change. The `EXPERIMENTAL` path activates only when the user explicitly sets `gyro_hardware_lpf = EXPERIMENTAL` via CLI. No device-init ordering, CS timing, or DMA path changes.

Closes #1127

AI Generated comment — Claude AI (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gyroscope sampling rate configuration to properly respect hardware filter settings, ensuring accurate sensor behavior in all filtering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->