### PR TITLE
fix(config): stop silently zeroing rssi_channel when RSSI_ADC is enabled

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -225,7 +225,6 @@ static void validateAndFixConfig(void) {
 #endif // USE_SOFTSPI
 #if defined(USE_ADC)
     if (featureConfigured(FEATURE_RSSI_ADC)) {
-        rxConfigMutable()->rssi_channel = 0;
         rxConfigMutable()->rssi_src_frame_errors = false;
     } else
 #endif


### PR DESCRIPTION
## Summary
- `validateAndFixConfig()` unconditionally zeroed `rssi_channel` whenever `RSSI_ADC` was enabled, silently destroying user-configured channel assignments on every boot/save cycle.
- Fix: remove the zeroing line. ADC already takes priority at runtime; the channel value does not need to be destroyed to enforce that.
- BF 4.5-m equivalence: BF does not zero `rssi_channel` here — EF-only regression.

## Classification
**Tier 1** — config validation path, no SPI/DMA/device-init change, no flight-critical runtime behavior change.

## Flash delta (vs baseline `b84d4a3d17`)
| Target | Delta |
|--------|-------|
| TMOTORF7 (F722, tightest) | +0 B |
| MATEKF411 (F411) | +584 B |
| HELIOSPRING (F405) | +1,492 B |

*(Cumulative delta from baseline includes prior merged stages, not this fix alone — this fix contributes ~0 B.)*

## Bench test
- Priority target: any bench target with RSSI_ADC support.
- Test: enable `RSSI_ADC`, set `rssi_channel = N`, save + reboot, verify channel is not zeroed in CLI `get rssi_channel`.

## Pre-merge checklist
- [x] Tier 1
- [x] BF-equivalence: BF does not zero `rssi_channel` here
- [x] Zero new warnings — full bench + compile + unique targets: all OK
- [x] Unit tests: PASS

Closes #1135.

AI Generated comment — Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSSI channel configuration no longer gets unexpectedly reset during config validation, preserving your custom settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->