### PR TITLE
fix(osd): cast intentional SPI DR-drain read to (void) in max7456 DMA IRQ handler

### DIFF
--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -307,7 +307,7 @@ void max7456_dma_irq_handler(dmaChannelDescriptor_t* descriptor) {
         // Empty RX buffer. RX DMA takes care of it if enabled.
         // This should be done after transmission finish!!!
         while (SPI_I2S_GetFlagStatus(dev->bus->busType_u.spi.instance, SPI_I2S_FLAG_RXNE) == SET) {
-            dev->bus->busType_u.spi.instance->DR;
+            (void)dev->bus->busType_u.spi.instance->DR;
         }
         DMA_Cmd(MAX7456_DMA_CHANNEL_TX, DISABLE);
         DMA_CLEAR_FLAG(descriptor, DMA_IT_TCIF);


### PR DESCRIPTION
## Summary
- In `max7456_dma_irq_handler()`, a bare read of `dev->bus->busType_u.spi.instance->DR` is used to drain the SPI RX register as an intentional side effect. Static analyzers flag this as an unused return value (CWE-562 / unused result).
- Fix: cast to `(void)` to make the intentional side effect explicit and silence the warning.
- No runtime behavior change — identical codegen.
- BF 4.5-m equivalence: BF uses the same `(void)` cast pattern for DR-drain reads.

## Classification
**Tier 1** — compile-time annotation only, zero runtime behavior change.

## Flash delta
0 B (cast produces identical assembly).

## Bench test
- Priority target: any target with max7456 OSD — **FOXEERF722V4** or **FOXEERF405**.
- Test: OSD visible and not corrupted on boot. USB enumerate sufficient for Tier 1.

## Pre-merge checklist
- [x] Tier 1
- [x] BF-equivalence: BF uses `(void)` cast for DR-drain reads
- [x] Zero new warnings — full bench + compile + unique targets: all OK
- [x] Unit tests: PASS

Closes #1110.

AI Generated comment — Claude Sonnet 4.6