### PR TITLE
fix(usb): cap CDC_Send_DATA blocking spin to prevent WWDG reset under TX backpressure

### DIFF
--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -346,12 +346,18 @@ uint32_t CDC_Send_FreeBytes(void) {
  *         this function.
  * @param  ptrBuffer: Buffer of data to be sent
  * @param  sendLength: Number of data to be sent (in bytes)
- * @retval Bytes sent
+ * @retval Bytes actually written; may be less than sendLength on TX backpressure
+ *         (host slow or disconnected). Callers must not assume a full write.
  */
 uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength) {
     for (uint32_t i = 0; i < sendLength; i++) {
+        // Wait up to 2 ms per byte for space; return partial count on timeout
+        // to prevent an indefinite spin that would trigger WWDG reset.
+        uint32_t deadline = millis() + 2;
         while (CDC_Send_FreeBytes() == 0) {
-            // block until there is free space in the ring buffer
+            if (millis() >= deadline) {
+                return i;
+            }
             delay(1);
         }
         ATOMIC_BLOCK(NVIC_BUILD_PRIORITY(6, 0)) { // Paranoia

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -156,10 +156,29 @@ static uint16_t VCP_Ctrl(uint32_t Cmd, uint8_t* Buf, uint32_t Len) {
  * Description    : send the data received from the STM32 to the PC through USB
  * Input          : buffer to send, and the length of the buffer.
  * Output         : None.
- * Return         : None.
+ * Return         : Bytes actually written; may be less than sendLength on TX
+ *                  backpressure (host slow or disconnected).
  *******************************************************************************/
 uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength) {
-    VCP_DataTx(ptrBuffer, sendLength);
+    // Wait up to 2 ms for any in-flight USB packet to finish; bail early on timeout.
+    uint32_t txStateDeadline = millis() + 2;
+    while (USB_Tx_State != 0) {
+        if (millis() >= txStateDeadline) {
+            return 0;
+        }
+    }
+    for (uint32_t i = 0; i < sendLength; i++) {
+        // Wait up to 2 ms per byte for ring-buffer space; return partial count on timeout.
+        uint32_t deadline = millis() + 2;
+        while (CDC_Send_FreeBytes() == 0) {
+            if (millis() >= deadline) {
+                return i;
+            }
+            delay(1);
+        }
+        APP_Rx_Buffer[APP_Rx_ptr_in] = ptrBuffer[i];
+        APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
+    }
     return sendLength;
 }
 

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -27,7 +27,9 @@
 #include "usbd_cdc_vcp.h"
 #include "stm32f4xx_conf.h"
 #include "stdbool.h"
+#include "drivers/nvic.h"
 #include "drivers/time.h"
+#include "build/atomic.h"
 
 LINE_CODING g_lc;
 
@@ -176,8 +178,10 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength) {
             }
             delay(1);
         }
-        APP_Rx_Buffer[APP_Rx_ptr_in] = ptrBuffer[i];
-        APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
+        ATOMIC_BLOCK(NVIC_BUILD_PRIORITY(6, 0)) {
+            APP_Rx_Buffer[APP_Rx_ptr_in] = ptrBuffer[i];
+            APP_Rx_ptr_in = (APP_Rx_ptr_in + 1) % APP_RX_DATA_SIZE;
+        }
     }
     return sendLength;
 }


### PR DESCRIPTION
## Summary

`CDC_Send_DATA()` contains an unbounded per-byte spin waiting for USB TX buffer space:

- **F7 path** (`vcp_hal/usbd_cdc_interface.c`): `while (CDC_Send_FreeBytes() == 0) { delay(1); }`
- **F4 path** (`vcpf4/usbd_cdc_vcp.c` / `VCP_DataTx`): two unbounded spins — one on `USB_Tx_State` and one per-byte buffer-full

When the USB host is slow to drain (large CLI output, tab-complete spam) or disconnects while the FC is actively sending, the SERIAL task can stall for the duration of the spin.

**Observed:** SERIAL task max = **377 ms** on HELIOSPRING under normal bench CLI use (captured in `tasks` output). Average is near zero — the event is rare but the worst case is severe.

**Primary symptom:** Configurator disconnect / MSP timeout during large `dump` output; intermittent fast-connect CLI stall (~30% failure rate on aggressive connect timing).

**Note:** This is a task-scheduler stall, not a crash. GYRO/PID and other interrupt-driven tasks are unaffected. A watchdog reset is a theoretical edge case (requires watchdog kicks in the main loop path), not the primary observed failure mode.

**Fix:** Add a 2 ms per-byte deadline to each spin. Return bytes written so far on timeout (partial write). Both call sites in `serial_usb_vcp.c` (`usbVcpWriteBuf`, `usbVcpFlush`) already loop with `USB_TIMEOUT` — partial-write return is handled correctly with no data loss regression.

BF 4.5-m and current BF master have the identical unbounded spins (confirmed as of 2025-12-13). This fix diverges intentionally.

## Classification
**Tier 1** — USB serial path only. Not flight-critical. Not SPI/DMA/gyro/device-init.

## Flash delta (vs baseline `b84d4a3d17`)
| Target | Delta |
|--------|-------|
| TMOTORF7 (F722, 512KB — tightest) | +64 B |
| HELIOSPRING (F405) | +248 B |

All 512KB targets remain well within FLASH1 limit.

## Bench verification
| Target | MCU | USB path | Result |
|--------|-----|----------|--------|
| HELIOSPRING | STM32F405 | `vcpf4/usbd_cdc_vcp.c` | PASS |
| FOXEERF722V4 | STM32F722 | `vcp_hal/usbd_cdc_interface.c` | PASS |

Test: CLI spam (`dump`, `get *`, tab-complete), unplug mid-output, reconnect. No unrecoverable stall on either target. Fast-connect failure rate reduced from ~30% to ~14% (n=7; improvement noted, small sample).

## Pre-merge checklist
- [x] Tier 1
- [x] BF-equivalence: BF has same unbounded spin (unfixed); intentional divergence documented
- [x] Zero new warnings — full bench + compile + unique targets: all OK
- [x] Unit tests: PASS

Closes #1107.

AI Generated comment — Claude Sonnet 4.6