### PR TITLE
fix(accgyro): add USE_DUAL_GYRO guard to ICM20649/ICM42605/ICM42688P spiSetBusInstance

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -430,8 +430,10 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_SPI_ICM20649
+#ifndef USE_DUAL_GYRO
 #ifdef ICM20649_SPI_BUS
     spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM20649_SPI_BUS));
+#endif
 #endif
 #ifdef ICM20649_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM20649_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -457,8 +459,10 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_SPI_ICM42605
+#ifndef USE_DUAL_GYRO
 #ifdef ICM42605_SPI_BUS
     spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM42605_SPI_BUS));
+#endif
 #endif
 #ifdef ICM42605_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42605_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;
@@ -470,8 +474,10 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     }
 #endif
 #ifdef USE_GYRO_SPI_ICM42688P
+#ifndef USE_DUAL_GYRO
 #ifdef ICM42688P_SPI_BUS
     spiSetBusInstance(&gyro->dev, SPI_DEV_TO_CFG(ICM42688P_SPI_BUS));
+#endif
 #endif
 #ifdef ICM42688P_CS_PIN
     gyro->dev.busType_u.spi.csnPin = gyro->dev.busType_u.spi.csnPin == IO_NONE ? IOGetByTag(IO_TAG(ICM42688P_CS_PIN)) : gyro->dev.busType_u.spi.csnPin;


### PR DESCRIPTION
## Summary

On dual-gyro targets (`USE_DUAL_GYRO` defined), `gyro->dev` is pre-initialized before `detectSPISensorsAndUpdateDetectionResult` runs. `spiSetBusInstance` must not overwrite it. MPU6000, MPU6500, MPU9250, and ICM20689 all correctly guard their call with `#ifndef USE_DUAL_GYRO`. ICM20649, ICM42605, and ICM42688P were missing this guard.

Affected dual-IMU targets: FOXEERF722V4 (MPU6000 + ICM42688P), TMOTORF7 (MPU6000 + BMI270 + ICM42688P).

`USE_GYRO_IMUF9001` block intentionally unchanged — IMUF9001 is a dual-MCU (F405+F301) design, not a dual-gyro target.

## Classification

Tier 1 — conditional-compilation guard only. No runtime change on single-gyro targets. Correct behavior on dual-gyro targets with ICM426xx/ICM20649.

## Test plan

- [ ] `make test` passes
- [ ] All bench targets clean: HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7
- [ ] All compile-only targets clean: MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 CRAZYFLIE2
- [ ] Zero new warnings

Closes #1120

AI Generated comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI sensor communication handling for multi-gyro configurations on specific sensor models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->