### PR TITLE
fix(drivers): bus_i2c_busdev.h self-contained; dmaTransactionInProgress static

### DIFF
--- a/src/main/drivers/bus_i2c_busdev.h
+++ b/src/main/drivers/bus_i2c_busdev.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "drivers/bus.h"
+
 bool i2cBusWriteRegister(const extDevice_t *dev, uint8_t reg, uint8_t data);
 bool i2cBusReadRegisterBuffer(const extDevice_t *dev, uint8_t reg, uint8_t *data, uint8_t length);
 uint8_t i2cBusReadRegister(const extDevice_t *dev, uint8_t reg);

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -190,8 +190,8 @@
 #define MAX7456_SPI_CLK           (SPI_CLOCK_STANDARD)
 #endif
 
-extDevice_t max7456BusDevice;
-extDevice_t *dev = &max7456BusDevice;
+static extDevice_t max7456BusDevice;
+static extDevice_t *dev = &max7456BusDevice;
 
 static uint16_t max7456SpiClock = MAX7456_SPI_CLK;
 

--- a/src/main/drivers/max7456.c
+++ b/src/main/drivers/max7456.c
@@ -208,7 +208,7 @@ static uint8_t shadowBuffer[VIDEO_BUFFER_CHARS_PAL];
 
 #define MAX_CHARS2UPDATE    100
 #ifdef MAX7456_DMA_CHANNEL_TX
-volatile bool dmaTransactionInProgress = false;
+static volatile bool dmaTransactionInProgress = false;
 #endif
 
 static uint8_t spiBuff[MAX_CHARS2UPDATE * 6];

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -190,8 +190,8 @@
 #define MAX7456_SPI_CLK           (SPI_CLOCK_STANDARD)
 #endif
 
-extDevice_t max7456BusDevice;
-extDevice_t *dev = &max7456BusDevice;
+static extDevice_t max7456BusDevice;
+static extDevice_t *dev = &max7456BusDevice;
 
 static uint16_t max7456SpiClock = MAX7456_SPI_CLK;
 

--- a/src/main/drivers/nbd7456.c
+++ b/src/main/drivers/nbd7456.c
@@ -208,7 +208,7 @@ static uint8_t shadowBuffer[VIDEO_BUFFER_CHARS_PAL];
 
 #define MAX_CHARS2UPDATE    100
 #ifdef MAX7456_DMA_CHANNEL_TX
-volatile bool dmaTransactionInProgress = false;
+static volatile bool dmaTransactionInProgress = false;
 #endif
 
 static uint8_t spiBuff[MAX_CHARS2UPDATE * 6];


### PR DESCRIPTION
## Summary

- **#1115** — \`bus_i2c_busdev.h\` declares functions using \`extDevice_t\` without including the header that defines it; adds \`#include "drivers/bus.h"\`.
- **#1112** — \`dmaTransactionInProgress\`, \`max7456BusDevice\`, and \`extDevice_t *dev\` in \`max7456.c\` and \`nbd7456.c\` had unintended external linkage; all changed to \`static\`. All uses are file-local — no external references exist. (\`maxScreenSize\` intentionally left non-static; extern-declared in \`max7456.h\`.)

## Classification

Tier 1 — compile-time only. Zero runtime behavior change.

## Test plan

- [x] \`make test\` passes
- [x] All bench targets clean: HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7
- [x] All compile-only targets clean: MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 CRAZYFLIE2
- [x] All NBD targets clean (14 targets including NBDHMBF4PRO which directly compiles nbd7456.c): NBDHMBF41S NBDCRICKETF7 NBDBBBLV3 NBDBBBLV2 NBD_INFINITYAIOV2 NBD_INFINITYAIO255 NBD_INFINITYAIO NBD_INFINITY200RS NBD_CRICKETF7V2 NBD_CRICKETF7 NBDINFINITYF4 NBDHMBF4PRO NBD_INFINITYF4 NBD_INFINITYAIOV2PRO
- [x] Zero new warnings across all targets

Closes #1115
Closes #1112

AI Generated comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)