### PR TITLE
fix(make): arm_sdk download/install progress reporting and CI compatibility

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -39,7 +39,8 @@ ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
 
 # Use silent+stderr in CI (CI env var set by GitHub Actions); progress bar otherwise.
 # --progress-bar emits ANSI escape codes that pollute CI logs.
-CURL_PROGRESS := $(if $(CI),-sS,--progress-bar)
+# Match explicit truthy values only to avoid false positives (e.g., CI=false).
+CURL_PROGRESS := $(if $(filter true 1 yes,$(CI)),-sS,--progress-bar)
 
 # add toolchain binaries to PATH
 export PATH := $(ARM_SDK_DIR)/bin:$(PATH)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -51,16 +51,21 @@ arm_sdk_install: arm_sdk_download $(SDK_INSTALL_MARKER)
 
 $(SDK_INSTALL_MARKER):
 ifneq ($(OSFAMILY), windows)
+	@echo "[arm_sdk] Extracting: $(ARM_SDK_FILE) → $(TOOLS_DIR)"
 	-$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
 else
+	@echo "[arm_sdk] Extracting: $(ARM_SDK_FILE) → $(ARM_SDK_DIR)"
 	-$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
 endif
+	@echo "[arm_sdk] Installed: $(SDK_INSTALL_MARKER)"
 
 .NOTPARALLEL .PHONY: arm_sdk_download
 arm_sdk_download: | $(DL_DIR)
 arm_sdk_download: $(DL_DIR)/$(ARM_SDK_FILE)
 $(DL_DIR)/$(ARM_SDK_FILE):
-	$(V1) curl -L -sS -o "$(DL_DIR)/$(ARM_SDK_FILE)" -z "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
+	@echo "[arm_sdk] Downloading: $(ARM_SDK_FILE)"
+	$(V1) curl -L --progress-bar -o "$(DL_DIR)/$(ARM_SDK_FILE)" -z "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
+	@echo "[arm_sdk] Download complete: $(DL_DIR)/$(ARM_SDK_FILE)"
 
 ## arm_sdk_clean     : Uninstall Arm SDK
 .PHONY: arm_sdk_clean
@@ -266,7 +271,7 @@ zip_clean:
 
 ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
   ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
-else ifeq (,$(findstring _install,$(MAKECMDGOALS)))
+else ifeq (,$(findstring arm_sdk,$(MAKECMDGOALS)))
   GCC_VERSION = $(shell arm-none-eabi-gcc -dumpversion)
   ifeq ($(GCC_VERSION),)
     $(error **ERROR** arm-none-eabi-gcc not in the PATH. Run 'make arm_sdk_install' to install automatically in the tools folder of this repo)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -57,12 +57,12 @@ arm_sdk_install: arm_sdk_download $(SDK_INSTALL_MARKER)
 $(SDK_INSTALL_MARKER):
 ifneq ($(OSFAMILY), windows)
 	@echo "[arm_sdk] Extracting: $(ARM_SDK_FILE) → $(TOOLS_DIR)"
-	-$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) tar -C $(TOOLS_DIR) -xjf "$(DL_DIR)/$(ARM_SDK_FILE)"
 else
 	@echo "[arm_sdk] Extracting: $(ARM_SDK_FILE) → $(ARM_SDK_DIR)"
-	-$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
+	$(V1) unzip -q -d $(ARM_SDK_DIR) "$(DL_DIR)/$(ARM_SDK_FILE)"
 endif
-	@echo "[arm_sdk] Installed: $(SDK_INSTALL_MARKER)"
+	@[ -f "$(SDK_INSTALL_MARKER)" ] && echo "[arm_sdk] Installed: $(SDK_INSTALL_MARKER)" || (echo "[arm_sdk] ERROR: extraction failed, marker not found"; exit 1)
 
 .NOTPARALLEL .PHONY: arm_sdk_download
 arm_sdk_download: | $(DL_DIR)
@@ -276,7 +276,7 @@ zip_clean:
 
 ifeq ($(shell [ -d "$(ARM_SDK_DIR)" ] && echo "exists"), exists)
   ARM_SDK_PREFIX := $(ARM_SDK_DIR)/bin/arm-none-eabi-
-else ifeq (,$(findstring arm_sdk,$(MAKECMDGOALS)))
+else ifeq (,$(filter arm_sdk_install arm_sdk_download arm_sdk_clean,$(MAKECMDGOALS)))
   GCC_VERSION = $(shell arm-none-eabi-gcc -dumpversion)
   ifeq ($(GCC_VERSION),)
     $(error **ERROR** arm-none-eabi-gcc not in the PATH. Run 'make arm_sdk_install' to install automatically in the tools folder of this repo)

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -37,6 +37,10 @@ endif
 
 ARM_SDK_FILE := $(notdir $(ARM_SDK_URL))
 
+# Use silent+stderr in CI (CI env var set by GitHub Actions); progress bar otherwise.
+# --progress-bar emits ANSI escape codes that pollute CI logs.
+CURL_PROGRESS := $(if $(CI),-sS,--progress-bar)
+
 # add toolchain binaries to PATH
 export PATH := $(ARM_SDK_DIR)/bin:$(PATH)
 
@@ -64,7 +68,7 @@ arm_sdk_download: | $(DL_DIR)
 arm_sdk_download: $(DL_DIR)/$(ARM_SDK_FILE)
 $(DL_DIR)/$(ARM_SDK_FILE):
 	@echo "[arm_sdk] Downloading: $(ARM_SDK_FILE)"
-	$(V1) curl -L --progress-bar -o "$(DL_DIR)/$(ARM_SDK_FILE)" -z "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
+	$(V1) curl -L $(CURL_PROGRESS) -o "$(DL_DIR)/$(ARM_SDK_FILE)" "$(ARM_SDK_URL)"
 	@echo "[arm_sdk] Download complete: $(DL_DIR)/$(ARM_SDK_FILE)"
 
 ## arm_sdk_clean     : Uninstall Arm SDK


### PR DESCRIPTION
## Changes

### Commit 1: Progress and PATH guard fixes
- **curl**: Replace `-sS` (silent) with `--progress-bar` for visible download progress in local builds
- **Progress feedback**: Add `[arm_sdk]` echo messages before/after download and extraction steps
- **PATH guard fix**: Extend `findstring _install` → `findstring arm_sdk` so `arm_sdk_download` and `arm_sdk_clean` no longer trigger missing-SDK errors before SDK is installed

### Commit 2: Remove `-z` flag, add CI-aware progress
- **Remove `-z` warnings**: Delete spurious `-z "path"` time-condition flag. This is a make file-target rule that only runs when the file doesn't exist, so curl always received a non-existent path and attempted date-parsing → warnings.
- **CI compatibility**: Add `CURL_PROGRESS` variable (`--progress-bar` for local, `-sS` for CI). GitHub Actions exports `CI=true`, preventing ANSI escape codes in CI logs.

## Testing
- Dry-run verified for both `arm_sdk_download` and `arm_sdk_install`
- CI mode (`CI=true`) correctly suppresses progress bar
- Local mode shows live progress bar
- No warnings from curl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved ARM SDK download experience with enhanced progress feedback (silent mode in CI, progress bar in local builds) and additional installation logging.
  * Updated toolchain setup validation logic for more consistent build environment configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->