### PR TITLE
fix(mixer): add 'f' suffix to double literals in twoPassMix

### DIFF
--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -1034,8 +1034,8 @@ static void twoPassMix(float *motorMix, const float *yawMix, const float *rollPi
     float throttlePostYaw = postYawThrottle - yawThrottleCorrection;
     float thrustPostYaw = motorToThrust(throttlePostYaw, true);
 
-    float maxMotor = -1000.0;
-    float minMotor = 1000.0;
+    float maxMotor = -1000.0f;
+    float minMotor = 1000.0f;
 
     // correct for the extra thrust yaw adds, then fill up motorMix with pitch and roll
     for (int i = 0; i < motorCount; i++) {
@@ -1058,7 +1058,7 @@ static void twoPassMix(float *motorMix, const float *yawMix, const float *rollPi
     }
 
     // if the range is outside the normal bounds, correct it here
-    float motorCorrection = 0.0;
+    float motorCorrection = 0.0f;
     if (maxMotor > 1.0f) {
         motorCorrection = 1.0f - maxMotor;
     } else if (minMotor < 0.0f) {


### PR DESCRIPTION
## Summary

- Add `f` suffix to three double literals in `twoPassMix()`: `maxMotor` (`-1000.0f`), `minMotor` (`1000.0f`), `motorCorrection` (`0.0f`)
- No runtime behavior change — pure type consistency with surrounding code

## Classification

Tier 1 — structural/style only. Zero warnings across all 8 bench targets (HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7).

Closes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)