### PR TITLE
fix(config): unconditionally clamp failsafe_procedure to valid range

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -256,6 +256,9 @@ static void validateAndFixConfig(void) {
             failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
         }
 #endif
+        if (failsafeConfig()->failsafe_procedure >= FAILSAFE_PROCEDURE_COUNT) {
+            failsafeConfigMutable()->failsafe_procedure = FAILSAFE_PROCEDURE_DROP_IT;
+        }
         if (isModeActivationConditionPresent(BOXGPSRESCUE)) {
             removeModeActivationCondition(BOXGPSRESCUE);
         }


### PR DESCRIPTION
## Summary

- Without `USE_GPS_RESCUE`, `FAILSAFE_PROCEDURE_COUNT == 2` and the GPS-rescue enum value doesn't exist. A stale numeric value from a GPS-rescue-enabled EEPROM is now out of range and was silently skipped by the `#if defined(USE_GPS_RESCUE)`-gated check.
- Adds an unconditional `>= FAILSAFE_PROCEDURE_COUNT` check immediately after the existing guarded block, resetting any out-of-range procedure to `FAILSAFE_PROCEDURE_DROP_IT`.
- The existing GPS-rescue-specific check is preserved for the case where GPS rescue is compiled in but GPS is unavailable.

Closes #1148

## Test plan
- [ ] Build target without `USE_GPS_RESCUE`; verify compiles clean
- [ ] Build target with `USE_GPS_RESCUE`; verify behavior unchanged
- [ ] Confirm `validateAndFixConfig()` resets an out-of-range procedure value on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)