### PR TITLE
fix(bus_spi): clamp DMA SPI transfer length to dmaTxBuffer size

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -442,6 +442,9 @@ void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
             uint8_t *txData = segments[0].u.buffers.txData;
             uint8_t *rxData = segments[0].u.buffers.rxData;
             int len = segments[0].len;
+            if ((size_t)len > sizeof(dmaTxBuffer)) {
+                len = sizeof(dmaTxBuffer);
+            }
             uint32_t timeoutCheck = millis();
             if (txData) {
                 memcpy(dmaTxBuffer, txData, len);


### PR DESCRIPTION
## Summary

- Resolves Codacy CWE-120 (buffer copy without checking size of input) warnings in the `USE_DMA_SPI_DEVICE` IMUF9001 DMA path of `bus_spi.c`.
- `dmaTxBuffer` / `dmaRxBuffer` are 58 bytes. The `memcpy`/`memset` calls used `segments[0].len` directly with no upper-bound check.
- Clamps `len` to `sizeof(dmaTxBuffer)` immediately after extraction, bounding all subsequent buffer operations and the DMA transfer.
- IMUF9001 transactions are always 58 bytes; this guard is purely defensive.

Pre-existing issue tracked in #1124.

Closes #1124

## Test plan
- [x] Build any target with `USE_DMA_SPI_DEVICE` (IMUF9001); verify compiles clean
- [x] Confirm Codacy no longer flags CWE-120 on these lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential buffer overflow issue in DMA SPI transfers during TX-only operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->