### PR TITLE
[targets] fix VGOODRCF4 motor map/gyro align and VGOODF722DUAL OSD

### DIFF
--- a/src/main/target/VGOODF722DUAL/target.h
+++ b/src/main/target/VGOODF722DUAL/target.h
@@ -46,6 +46,11 @@
 #define BEEPER_PIN           PC13
 #define BEEPER_INVERTED
 #define USE_USB_DETECT
+#define USB_DETECT_PIN       PC14
+
+#define USE_MAX7456
+#define MAX7456_SPI_CS_PIN   PB2
+#define MAX7456_SPI_INSTANCE SPI1
 
 #define USE_SPI
 #define USE_SPI_DEVICE_1

--- a/src/main/target/VGOODRCF4/target.c
+++ b/src/main/target/VGOODRCF4/target.c
@@ -28,12 +28,12 @@
 #include "drivers/timer_def.h"
 
 const timerHardware_t timerHardware[USABLE_TIMER_CHANNEL_COUNT] = {
-    DEF_TIM(TIM8, CH2, PC7,  TIM_USE_PPM,   0, 0), // PPM
-    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_MOTOR, 0, 0), // S1
-    DEF_TIM(TIM1, CH4, PA10, TIM_USE_MOTOR, 0, 0), // S2
-    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR, 0, 0), // S3
-    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR, 0, 0), // S4
-    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_MOTOR, 0, 0), // S5
-    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_ANY,   0, 0), // S6 | TIM_USE_CAMERA_CONTROL
-    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_LED,   0, 1), //LED_STRIP
+    DEF_TIM(TIM8, CH2, PC7,  TIM_USE_PPM,                0, 0), // PPM
+    DEF_TIM(TIM1, CH1, PA8,  TIM_USE_MOTOR,               0, 0), // M1
+    DEF_TIM(TIM1, CH2, PA9,  TIM_USE_MOTOR,               0, 0), // M2
+    DEF_TIM(TIM1, CH3, PA10, TIM_USE_MOTOR,               0, 0), // M3
+    DEF_TIM(TIM8, CH3, PC8,  TIM_USE_MOTOR,               0, 0), // M4
+    DEF_TIM(TIM8, CH4, PC9,  TIM_USE_MOTOR,               0, 0), // M5
+    DEF_TIM(TIM3, CH3, PB0,  TIM_USE_MOTOR,               0, 0), // M6
+    DEF_TIM(TIM3, CH4, PB1,  TIM_USE_MOTOR | TIM_USE_LED, 0, 0), // M7 / LED_STRIP
 };

--- a/src/main/target/VGOODRCF4/target.h
+++ b/src/main/target/VGOODRCF4/target.h
@@ -27,16 +27,13 @@
 #define LED0_PIN                PC14
 #define LED1_PIN                PC15
 
-//define camera control
-#define CAMERA_CONTROL_PIN      PC9
-
 #define USE_BEEPER
 #define BEEPER_PIN              PC13
 #define BEEPER_INVERTED
 
 //#define ENABLE_DSHOT_DMAR       true//debug for checking
 
-#define GYRO_MPU6000_ALIGN      CW180_DEG
+#define GYRO_MPU6000_ALIGN      CW270_DEG
 
 #define USE_EXTI
 #define MPU_INT_EXTI            PC3
@@ -55,7 +52,7 @@
 #define ENABLE_BLACKBOX_LOGGING_ON_SPIFLASH_BY_DEFAULT
 #define USE_FLASHFS
 #define USE_FLASH_M25P16
-#define USE_FLASH_W25M512
+#define USE_FLASH_W25Q128FV
 #define FLASH_CS_PIN            PB12
 #define FLASH_SPI_INSTANCE      SPI2
 


### PR DESCRIPTION
## Summary

Fixes reported issues in #532 (TYRO79 / VGOODRCF4 gyro orientation and motor resource errors), validated against BF unified-target configs (`VGRC-VGOODRCF4.config`, `VGRC-VGOODF722DUAL.config`).

### VGOODRCF4

- **Gyro alignment `CW180_DEG` → `CW270_DEG`** — resolves the 90° PITCH/ROLL swap; confirmed by BF `gyro_1_sensor_align = CW270`
- **Motor timer order corrected** — PA8 (TIM1_CH1) is now M1, matching BF `resource MOTOR 1 A08`. Previously PA8 was LED-only, causing physical motor pad 1 to be dead and physical motor 2 to appear as Motor 1
- **PA10 timer channel CH4 → CH3** — PA10 is TIM1_CH3 (AF1) per STM32F405 datasheet and BF `timer A10 AF1 → TIM1 CH3`; prior CH4 assignment was incorrect
- **M7/LED_STRIP shared on PB1** — matches BF `resource MOTOR 7 B01` + `resource LED_STRIP 1 B01`
- **`CAMERA_CONTROL_PIN PC9` removed** — PC9 is MOTOR5 per BF; not defined in BF target
- **Flash chip `USE_FLASH_W25M512` → `USE_FLASH_W25Q128FV`** — confirmed by BF `#define USE_FLASH_W25Q128FV`

### VGOODF722DUAL

- **Add `USB_DETECT_PIN PC14`** — `USE_USB_DETECT` was declared but pin undefined; BF `resource USB_DETECT 1 C14`
- **Add `USE_MAX7456` + `MAX7456_SPI_CS_PIN PB2` + `MAX7456_SPI_INSTANCE SPI1`** — OSD chip entirely absent despite `FEATURE_OSD` enabled by default; BF `resource OSD_CS 1 B02`, `max7456_spi_bus = 1`

### VGOODRCF405_DJI

No changes. CodeRabbit's PINIO2 concern was incorrect — file correctly has `PINIO1_PIN PB0` matching BF `resource PINIO 1 B00`.

## Test plan

- [ ] VGOODRCF4: verify gyro shows correct orientation (no PITCH/ROLL swap) in Configurator Setup tab
- [ ] VGOODRCF4: verify all 7 motor pads respond in Configurator Motors tab (motor 1 on physical pad M1 = PA8)
- [ ] VGOODRCF4: verify LED_STRIP functional on PB1 pad
- [ ] VGOODF722DUAL: verify OSD renders on-screen display
- [ ] VGOODF722DUAL: verify USB detect functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)