### PR TITLE
chore: suppress cppcheck missingIncludeSystem false positive (Codacy)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+engines:
+  cppcheck:
+    enabled: true
+    extraOptions: "--suppress=missingIncludeSystem"


### PR DESCRIPTION
Closes #1155

Codacy runs Cppcheck without system include paths, causing a false-positive `missingIncludeSystem` warning on `#include <stdint.h>` in every `target.c` file (351+ files).

Adds `.codacy.yml` to suppress this check via `--suppress=missingIncludeSystem`, eliminating the noise without affecting any real lint coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality tooling configuration to enable additional static analysis checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->