### PR TITLE
fix(msp): per-client arming disable to prevent DJI MSP bypass

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -169,6 +169,7 @@ extern uint8_t __config_end;
 
 
 static serialPort_t *cliPort;
+static mspDescriptor_t cliMspDescriptor;
 
 #ifdef STM32F1
 #define CLI_IN_BUFFER_SIZE 128
@@ -2621,7 +2622,7 @@ void cliMsp(char *cmdline) {
         //TODO need to fill inPtr with the rest of the bytes from the command line
         buft.ptr = buft.end = bufPtr;
         if (mspCommonProcessOutCommand(mspCommand, &buft, NULL) || mspProcessOutCommand(mspCommand, &buft)
-                || mspCommonProcessInCommand(mspCommand, &inBuf, NULL) > -1 || mspProcessInCommand(mspCommand, &inBuf) > -1) {
+                || mspCommonProcessInCommand(cliMspDescriptor, mspCommand, &inBuf, NULL) > -1 || mspProcessInCommand(cliMspDescriptor, mspCommand, &inBuf) > -1) {
             bufWriterAppend(cliWriter, '.');                 //"." is success
             bufWriterAppend(cliWriter, mspCommand);          //msp command sent
             bufWriterAppend(cliWriter, inBuf.ptr - inBuf.end);                  //msp command sent
@@ -4587,5 +4588,6 @@ void cliEnter(serialPort_t *serialPort) {
 
 void cliInit(const serialConfig_t *serialConfig) {
     UNUSED(serialConfig);
+    cliMspDescriptor = mspDescriptorAlloc();
 }
 #endif // USE_CLI

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -145,6 +145,30 @@ enum {
 
 static uint8_t rebootMode;
 
+static int mspDescriptorCounter = 0;
+
+mspDescriptor_t mspDescriptorAlloc(void)
+{
+    return (mspDescriptor_t)mspDescriptorCounter++;
+}
+
+static uint32_t mspArmingDisableFlags = 0;
+
+static void mspArmingDisableByDescriptor(mspDescriptor_t desc)
+{
+    mspArmingDisableFlags |= (1 << desc);
+}
+
+static void mspArmingEnableByDescriptor(mspDescriptor_t desc)
+{
+    mspArmingDisableFlags &= ~(1 << desc);
+}
+
+static bool mspIsMspArmingEnabled(void)
+{
+    return mspArmingDisableFlags == 0;
+}
+
 #ifndef USE_OSD_SLAVE
 
 typedef enum {
@@ -1409,7 +1433,8 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
         }
 #endif // USE_OSD_SLAVE
 
-static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn) {
+static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn) {
+    UNUSED(srcDesc);
 #if defined(USE_OSD_SLAVE)
     UNUSED(dst);
 #endif
@@ -1482,7 +1507,8 @@ static void mspFcDataFlashReadCommand(sbuf_t *dst, sbuf_t *src) {
 #endif
 
 #ifdef USE_OSD_SLAVE
-static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
+static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src) {
+    UNUSED(srcDesc);
     UNUSED(cmdMSP);
     UNUSED(src);
     switch(cmdMSP) {
@@ -1503,7 +1529,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
 
 #else
 
-mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
+mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src) {
     uint32_t i;
     uint8_t value;
     const unsigned int dataSize = sbufBytesRemaining(src);
@@ -2084,6 +2110,7 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
     disableRunawayTakeoff = sbufReadU8(src);
     }
     if (command) {
+    mspArmingDisableByDescriptor(srcDesc);
     setArmingDisabled(ARMING_DISABLED_MSP);
     if (ARMING_FLAG(ARMED)) {
     disarm();
@@ -2092,10 +2119,13 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
     runawayTakeoffTemporaryDisable(false);
 #endif
     } else {
+    mspArmingEnableByDescriptor(srcDesc);
+    if (mspIsMspArmingEnabled()) {
     unsetArmingDisabled(ARMING_DISABLED_MSP);
 #ifdef USE_RUNAWAY_TAKEOFF
     runawayTakeoffTemporaryDisable(disableRunawayTakeoff);
 #endif
+    }
     }
     }
     break;
@@ -2354,7 +2384,7 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
         }
 #endif // USE_OSD_SLAVE
 
-mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPostProcessFnPtr *mspPostProcessFn) {
+mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src, mspPostProcessFnPtr *mspPostProcessFn) {
     UNUSED(mspPostProcessFn);
     const unsigned int dataSize = sbufBytesRemaining(src);
     UNUSED(dataSize); // maybe unused due to compiler options
@@ -2507,7 +2537,7 @@ mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPostProces
 #endif
 #endif // OSD || USE_OSD_SLAVE
     default:
-        return mspProcessInCommand(cmdMSP, src);
+        return mspProcessInCommand(srcDesc, cmdMSP, src);
     }
     return MSP_RESULT_ACK;
 }
@@ -2515,7 +2545,7 @@ mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPostProces
 /*
  * Returns MSP_RESULT_ACK, MSP_RESULT_ERROR or MSP_RESULT_NO_REPLY
  */
-mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
     int ret = MSP_RESULT_ACK;
     sbuf_t *dst = &reply->buf;
     sbuf_t *src = &cmd->buf;
@@ -2526,7 +2556,7 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
         ret = MSP_RESULT_ACK;
     } else if (mspProcessOutCommand(cmdMSP, dst)) {
         ret = MSP_RESULT_ACK;
-    } else if ((ret = mspFcProcessOutCommandWithArg(cmdMSP, src, dst, mspPostProcessFn)) != MSP_RESULT_CMD_UNKNOWN) {
+    } else if ((ret = mspFcProcessOutCommandWithArg(srcDesc, cmdMSP, src, dst, mspPostProcessFn)) != MSP_RESULT_CMD_UNKNOWN) {
         /* ret */;
 #ifdef USE_SERIAL_4WAY_BLHELI_INTERFACE
     } else if (cmdMSP == MSP_SET_4WAY_IF) {
@@ -2544,7 +2574,7 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
         ret = MSP_RESULT_ACK;
 #endif
     } else {
-        ret = mspCommonProcessInCommand(cmdMSP, src, mspPostProcessFn);
+        ret = mspCommonProcessInCommand(srcDesc, cmdMSP, src, mspPostProcessFn);
     }
     reply->result = ret;
     return ret;

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -156,12 +156,12 @@ static uint32_t mspArmingDisableFlags = 0;
 
 static void mspArmingDisableByDescriptor(mspDescriptor_t desc)
 {
-    mspArmingDisableFlags |= (1 << desc);
+    mspArmingDisableFlags |= ((uint32_t)1 << desc);
 }
 
 static void mspArmingEnableByDescriptor(mspDescriptor_t desc)
 {
-    mspArmingDisableFlags &= ~(1 << desc);
+    mspArmingDisableFlags &= ~((uint32_t)1 << desc);
 }
 
 static bool mspIsMspArmingEnabled(void)

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -149,6 +149,9 @@ static int mspDescriptorCounter = 0;
 
 mspDescriptor_t mspDescriptorAlloc(void)
 {
+    if (mspDescriptorCounter >= (int)(sizeof(uint32_t) * 8)) {
+        return (mspDescriptor_t)0;
+    }
     return (mspDescriptor_t)mspDescriptorCounter++;
 }
 

--- a/src/main/interface/msp.h
+++ b/src/main/interface/msp.h
@@ -54,16 +54,19 @@ typedef struct mspPacket_s {
     uint8_t direction;
 } mspPacket_t;
 
+typedef int mspDescriptor_t;
+
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.
-typedef mspResult_e (*mspProcessCommandFnPtr)(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
+typedef mspResult_e (*mspProcessCommandFnPtr)(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
 typedef void (*mspProcessReplyFnPtr)(mspPacket_t *cmd);
 
 
 void mspInit(void);
-mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
+mspDescriptor_t mspDescriptorAlloc(void);
+mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
 void mspFcProcessReply(mspPacket_t *reply);
 bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn);
-mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn);
+mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn);
 bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst);
-mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *dst);
+mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *dst);

--- a/src/main/io/displayport_hdzero_osd.c
+++ b/src/main/io/displayport_hdzero_osd.c
@@ -377,7 +377,7 @@ displayPort_t* hdzeroOsdDisplayPortInit(void)
  * VTX sends an MSP command every 125ms or so.
  * VTX will have be marked as not ready if no commands received within VTX_TIMEOUT.
  */
-static mspResult_e hdZeroProcessMspCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn)
+static mspResult_e hdZeroProcessMspCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn)
 {
     if (vtxSeen && !vtxActive) {
         vtxReset = true;
@@ -409,7 +409,7 @@ static mspResult_e hdZeroProcessMspCommand(mspPacket_t *cmd, mspPacket_t *reply,
     }
 
     // Process MSP command
-    return mspProcessCommand(cmd, reply, mspPostProcessFn);
+    return mspProcessCommand(srcDesc, cmd, reply, mspPostProcessFn);
 }
 
 void hdzeroOsdSerialProcess(mspProcessCommandFnPtr mspProcessCommandFn)

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -44,6 +44,7 @@ static mspPort_t mspPorts[MAX_MSP_PORT_COUNT];
 void resetMspPort(mspPort_t *mspPortToReset, serialPort_t *serialPort) {
     memset(mspPortToReset, 0, sizeof(mspPort_t));
     mspPortToReset->port = serialPort;
+    mspPortToReset->descriptor = mspDescriptorAlloc();
 }
 
 void mspSerialAllocatePorts(void) {
@@ -344,7 +345,7 @@ static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspPr
         .direction = MSP_DIRECTION_REQUEST,
     };
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    const mspResult_e status = mspProcessCommandFn(&command, &reply, &mspPostProcessFn);
+    const mspResult_e status = mspProcessCommandFn(msp->descriptor, &command, &reply, &mspPostProcessFn);
     if (status != MSP_RESULT_NO_REPLY) {
         sbufSwitchToReader(&reply.buf, outBufHead); // change streambuf direction
         mspSerialEncode(msp, &reply, msp->mspVersion);

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -113,6 +113,7 @@ typedef struct mspPort_s {
     uint8_t checksum1;
     uint8_t checksum2;
     bool sharedWithTelemetry;
+    mspDescriptor_t descriptor;
 } mspPort_t;
 
 void mspSerialInit(void);

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -60,9 +60,13 @@ static mspTxBuffer_t mspTxBuffer;
 static mspPacket_t mspRxPacket;
 static mspPacket_t mspTxPacket;
 static mspDescriptor_t mspSharedDescriptor;
+static bool mspSharedDescriptorInitialized;
 
 void initSharedMsp(void) {
-    mspSharedDescriptor = mspDescriptorAlloc();
+    if (!mspSharedDescriptorInitialized) {
+        mspSharedDescriptor = mspDescriptorAlloc();
+        mspSharedDescriptorInitialized = true;
+    }
     mspPackage.requestBuffer = (uint8_t *)&mspRxBuffer;
     mspPackage.requestPacket = &mspRxPacket;
     mspPackage.requestPacket->buf.ptr = mspPackage.requestBuffer;

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -59,8 +59,10 @@ static mspRxBuffer_t mspRxBuffer;
 static mspTxBuffer_t mspTxBuffer;
 static mspPacket_t mspRxPacket;
 static mspPacket_t mspTxPacket;
+static mspDescriptor_t mspSharedDescriptor;
 
 void initSharedMsp(void) {
+    mspSharedDescriptor = mspDescriptorAlloc();
     mspPackage.requestBuffer = (uint8_t *)&mspRxBuffer;
     mspPackage.requestPacket = &mspRxPacket;
     mspPackage.requestPacket->buf.ptr = mspPackage.requestBuffer;
@@ -76,7 +78,7 @@ static void processMspPacket(void) {
     mspPackage.responsePacket->result = 0;
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    if (mspFcProcessCommand(mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
+    if (mspFcProcessCommand(mspSharedDescriptor, mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
         sbufWriteU8(&mspPackage.responsePacket->buf, TELEMETRY_MSP_ERROR);
     }
     if (mspPostProcessFn) {

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -386,4 +386,6 @@ bool boardInformationIsSet(void) { return true; };
 bool setBoardName(char *newBoardName) { UNUSED(newBoardName); return true; };
 bool setManufacturerId(char *newManufacturerId) { UNUSED(newManufacturerId); return true; };
 bool persistBoardInformation(void) { return true; };
+
+mspDescriptor_t mspDescriptorAlloc(void) { return 0; }
 }

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -273,7 +273,8 @@ extern "C" {
 
     bool isAirmodeActive(void) {return true;}
 
-    mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+    mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+        UNUSED(srcDesc);
 
         UNUSED(mspPostProcessFn);
 
@@ -307,4 +308,6 @@ extern "C" {
     
     // Battery stub (missing from original test)
     uint8_t getBatteryCellCount(void) { return 3; }
+
+    mspDescriptor_t mspDescriptorAlloc(void) { return 0; }
 }


### PR DESCRIPTION
## Summary

- Backport of betaflight/betaflight#9040 (BF 4.1, 2019-10-14)
- Resolves #211 — DJI OSD/system could send `MSP_SET_ARMING_DISABLED(0)` and unconditionally clear `ARMING_DISABLED_MSP`, bypassing safety arming locks set by the configurator or other MSP clients

## What changed

Adds `mspDescriptor_t`: an integer ID allocated once per MSP client at init time. A `uint32_t` bitmask tracks which clients have requested arming disable. `ARMING_DISABLED_MSP` is only cleared when **all** clients that set it have explicitly released it.

Each client gets a descriptor:
- Each serial MSP port (via `resetMspPort`)
- HDZero OSD port (via `resetMspPort`)
- Telemetry MSP shared path (CRSF/SmartPort pass-through)
- CLI MSP pass-through (EmuFlight-specific, not in BF)

The one intentional divergence from BF: `mspFcProcessOutCommandWithArg` uses `UNUSED(srcDesc)` because EmuFlight has no batch-MSP (`MSP_MSP`) command — confirmed absent.

## Test

- `make test` passes
- Bench targets build clean: HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7
- Hardware tested on HELIOSPRING and FOXEERF722V4 at commit b3f755416f, arming via ELRS RC (non-DJI):
  - USB disconnected: arm/disarm via RC permitted — correct
  - USB connected (Configurator): arm/disarm blocked — correct; Configurator's MSP client holds the disable
  - Lifecycle: USB disconnected → arm/disarm via RC → remain powered → connect USB Configurator → arm/disarm blocked → disconnect USB → arm/disarm remains blocked until power-cycle — correct; per-descriptor bitmask preserves the Configurator's disable after disconnect (no explicit release sent); DJI or any other MSP client cannot bypass it
- DJI-specific path not hardware-verified; backport logic is mechanically equivalent to the verified BF fix (betaflight/betaflight#9040); expected to comply with code goals

## References

- Resolves #211
- BF fix: betaflight/betaflight#9040
- BF issue: betaflight/betaflight#8909

AI Generated pull-request — Claude Sonnet 4.6 via Claude Code