### PR TITLE
fix: make bus_spi_impl.h self-sufficient (closes #1122)

### DIFF
--- a/src/main/drivers/bus_spi_impl.h
+++ b/src/main/drivers/bus_spi_impl.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include "bus.h"
+#include "dma.h"
+
 // Sentinel value stored in bus->curSegment when no DMA transfer is in progress.
 #define BUS_SPI_FREE 0x0
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Add `#include "bus.h"` and `#include "dma.h"` to `bus_spi_impl.h`
- The header declared function prototypes referencing `extDevice_t` / `busDevice_t` (defined in `bus.h`) and `dmaChannelDescriptor_t` (defined in `dma.h`) without including those headers
- Compiled only because every includer happened to pull them in first — fragile include-order dependency, same class of issue as #1115

## Notes

- BF 4.5-m has the identical gap; this is an EmuFlight-side cleanup
- Tier 1 — structural, no runtime behavior change

## Build

All bench + compile + unique targets pass, zero warnings.

Closes #1122

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal header dependencies to improve code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->