### PR TITLE
fix(brushed): remove pinioSet from pwmWriteStandard, enforce no-3D for brushed protocol

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -26,16 +26,10 @@
 #include "platform.h"
 #include "drivers/time.h"
 
-#include "pg/pinio.h"
-#include "pg/piniobox.h"
-
-#include "interface/msp_box.h"
-
 #include "drivers/io.h"
 #include "pwm_output.h"
 #include "timer.h"
 #include "drivers/pwm_output.h"
-#include "config/feature.h"
 
 static FAST_RAM_ZERO_INIT pwmWriteFn *pwmWrite;
 static FAST_RAM_ZERO_INIT pwmOutputPort_t motors[MAX_SUPPORTED_MOTORS];
@@ -138,15 +132,6 @@ static void pwmWriteUnused(uint8_t index, float value) {
 }
 
 FAST_CODE static void pwmWriteStandard(uint8_t index, float value) {
-    if(feature(FEATURE_3D)) {
-        if (lrintf(value) - 1500 > 0) {
-            pinioSet(0, 0);     // set to forward
-            value = (value - 1500) * 2 + 1000;
-        } else {
-            pinioSet(0, 1);     // set to backward
-            value = (1500 - value) * 2 + 1000;
-        }
-    }
     /* TODO: move value to be a number between 0-1 (i.e. percent throttle from mixer) */
     *motors[index].channel.ccr = lrintf((value * motors[index].pulseScale) + motors[index].pulseOffset);
 }

--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -179,7 +179,7 @@ static void validateAndFixConfig(void) {
         currentPidProfile->auto_profile_cell_count = AUTO_PROFILE_CELL_COUNT_STAY;
     }
     if (motorConfig()->dev.motorPwmProtocol == PWM_TYPE_BRUSHED) {
-        //  featureClear(FEATURE_3D);
+        featureClear(FEATURE_3D);
         if (motorConfig()->mincommand < 1000) {
             motorConfigMutable()->mincommand = 1000;
         }

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -36,9 +36,6 @@
 #include "pg/pg.h"
 #include "pg/pg_ids.h"
 #include "pg/rx.h"
-#include "pg/pinio.h"
-#include "pg/piniobox.h"
-
 #include "interface/msp_box.h"
 
 #include "drivers/pwm_output.h"

--- a/src/main/interface/msp_box.c
+++ b/src/main/interface/msp_box.c
@@ -90,7 +90,7 @@ static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
     { BOXUSER1, "USER1", 40 },
     { BOXUSER2, "USER2", 41 },
     { BOXUSER3, "USER3", 42 },
-    { BOXUSER4, "FLIP OVER AFTER CRASH BRUSHED", 43 },
+    { BOXUSER4, "USER4", 43 },
     { BOXPIDAUDIO, "PID AUDIO", 44 },
     { BOXPARALYZE, "PARALYZE", 45 },
     { BOXGPSRESCUE, "GPS RESCUE", 46 },


### PR DESCRIPTION
AI Generated pull-request

Closes #1165
Closes #357

## Summary

- `pwm_output.c`: remove `pinioSet`/`FEATURE_3D` block from `pwmWriteStandard()` and four unused includes (`pg/pinio.h`, `pg/piniobox.h`, `interface/msp_box.h`, `config/feature.h`)
- `mixer.c`: remove two unused includes (`pg/pinio.h`, `pg/piniobox.h`)
- `msp_box.c`: restore `BOXUSER4` label `"FLIP OVER AFTER CRASH BRUSHED"` → `"USER4"`
- `config.c`: enable `featureClear(FEATURE_3D)` for `PWM_TYPE_BRUSHED` (was commented out)

## Scope and regression analysis

| Scenario | Impact |
|---|---|
| Brushless DSHOT — normal or 3D | None — uses `pwmWriteDshot`; our changes never reached |
| Brushless standard PWM / oneshot / multishot — normal mode | None — removed block was gated on `FEATURE_3D` |
| Brushless standard PWM / oneshot / multishot — 3D mode | Improved — old block corrupted mixer output values and called `pinioSet` on an unrelated pin |
| Brushed — normal mode | None — block was already inactive (`FEATURE_3D` disabled for brushed) |
| Brushed — 3D mode | N/A — `featureClear(FEATURE_3D)` now correctly prevents this; brushed DC motors have a preferred rotation direction and are not suited for 3D |

The existing `BOXUSER4` → `controllerMix3DModeSign = -1` brushed flipover mechanism in `mixer.c` is preserved. Box matching uses permanent ID 43, not the string label, so renaming `USER4` does not affect existing configurations.

## Relation to #357

PR #357 ("Redo brushed flipoveraftercrash", 2020) attempted a full GPIO-based brushed flipover rewrite using `USE_BRUSHED_FLIPOVERAFTERCRASH` and `BRUSHED_REVERSE_PIN`. It was never merged because no target defined `BRUSHED_REVERSE_PIN`, causing armed targets to not fly. This PR implements the valid cleanup portions of that work. The GPIO-based flipover implementation is tracked in a separate issue.

## Build validation

Brushed targets built and tested: `BEEBRAIN_PRO`, `BEEBRAIN_LITE`, `ALIENWHOOPF4`, `ALIENWHOOPF7`, `CRAZYFLIE2`  
Brushless bench targets: `HELIOSPRING`, `TUNERCF405`, `SKYSTARSF405AIO`  
Unit tests: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed 3D mode support from PWM output driver operations; standard PWM value calculations now proceed directly without mode-specific adjustments.
  * Configuration validation now actively disables 3D mode feature flag for brushed motor PWM protocols.
  * Updated USER4 box display label for accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->