### PR TITLE
fix(rx): JETI ExBus unconditionally use SERIAL_BIDIR

### DIFF
--- a/src/main/rx/jetiexbus.c
+++ b/src/main/rx/jetiexbus.c
@@ -33,9 +33,7 @@
  * Number of channels: 16
  *
  * Connect as follows:
- * Jeti EX Bus -> Serial RX (connect directly)
- * Serial TX -> Resistor(2k4) ->Serial RX
- * In jeti pdf it is different, but if the resistor breaks, the receiver continues to operate.
+ * Jeti EX Bus -> Serial TX (connect directly)
  *
  */
 
@@ -51,6 +49,7 @@
 
 #include "pg/rx.h"
 
+#include "common/time.h"
 #include "common/utils.h"
 
 #include "drivers/time.h"
@@ -148,34 +147,45 @@ void jetiExBusFrameReset(void) {
 // Receive ISR callback
 static void jetiExBusDataReceive(uint16_t c, void *data) {
     UNUSED(data);
-    uint32_t now;
-    static uint32_t jetiExBusTimeLast = 0;
-    static int32_t jetiExBusTimeInterval;
+    static timeUs_t jetiExBusTimeLast = 0;
     static uint8_t *jetiExBusFrame;
+    static uint8_t jetiExBusFrameMaxSize;
+    const timeUs_t now = microsISR();
+
     // Check if we shall reset frame position due to time
-    now = micros();
-    jetiExBusTimeInterval = now - jetiExBusTimeLast;
-    jetiExBusTimeLast = now;
-    if (jetiExBusTimeInterval > JETIEXBUS_MIN_FRAME_GAP) {
+    if (cmpTimeUs(now, jetiExBusTimeLast) > JETIEXBUS_MIN_FRAME_GAP) {
         jetiExBusFrameReset();
         jetiExBusFrameState = EXBUS_STATE_ZERO;
         jetiExBusRequestState = EXBUS_STATE_ZERO;
     }
+    jetiExBusTimeLast = now;
+
     // Check if we shall start a frame?
     if (jetiExBusFramePosition == 0) {
         switch (c) {
         case EXBUS_START_CHANNEL_FRAME:
             jetiExBusFrameState = EXBUS_STATE_IN_PROGRESS;
             jetiExBusFrame = jetiExBusChannelFrame;
+            jetiExBusFrameMaxSize = EXBUS_MAX_CHANNEL_FRAME_SIZE;
             break;
         case EXBUS_START_REQUEST_FRAME:
             jetiExBusRequestState = EXBUS_STATE_IN_PROGRESS;
             jetiExBusFrame = jetiExBusRequestFrame;
+            jetiExBusFrameMaxSize = EXBUS_MAX_REQUEST_FRAME_SIZE;
             break;
         default:
             return;
         }
     }
+
+    if (jetiExBusFramePosition == jetiExBusFrameMaxSize) {
+        // frame overrun
+        jetiExBusFrameReset();
+        jetiExBusFrameState = EXBUS_STATE_ZERO;
+        jetiExBusRequestState = EXBUS_STATE_ZERO;
+        return;
+    }
+
     // Store in frame copy
     jetiExBusFrame[jetiExBusFramePosition] = (uint8_t)c;
     jetiExBusFramePosition++;
@@ -200,7 +210,7 @@ static void jetiExBusDataReceive(uint16_t c, void *data) {
             jetiExBusFrameState = EXBUS_STATE_RECEIVED;
         if (jetiExBusRequestState == EXBUS_STATE_IN_PROGRESS) {
             jetiExBusRequestState = EXBUS_STATE_RECEIVED;
-            jetiTimeStampRequest = micros();
+            jetiTimeStampRequest = now;
         }
         jetiExBusFrameReset();
     }
@@ -244,9 +254,8 @@ bool jetiExBusInit(const rxConfig_t *rxConfig, rxRuntimeConfig_t *rxRuntimeConfi
                                    NULL,
                                    JETIEXBUS_BAUDRATE,
                                    MODE_RXTX,
-                                   JETIEXBUS_OPTIONS | (rxConfig->serialrx_inverted ? SERIAL_INVERTED : 0) | (rxConfig->halfDuplex ? SERIAL_BIDIR : 0)
+                                   JETIEXBUS_OPTIONS | (rxConfig->serialrx_inverted ? SERIAL_INVERTED : 0) | SERIAL_BIDIR
                                   );
-    serialSetMode(jetiExBusPort, MODE_RX);
     return jetiExBusPort != NULL;
 }
 #endif // SERIAL_RX

--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -320,9 +320,7 @@ void handleJetiExBusTelemetry(void) {
             return;
         }
         if ((jetiExBusRequestFrame[EXBUS_HEADER_DATA_ID] == EXBUS_EX_REQUEST) && (jetiExBusCalcCRC16(jetiExBusRequestFrame, jetiExBusRequestFrame[EXBUS_HEADER_MSG_LEN]) == 0)) {
-            // switch to TX mode
             if (serialRxBytesWaiting(jetiExBusPort) == 0) {
-                serialSetMode(jetiExBusPort, MODE_TX);
                 jetiExBusTransceiveState = EXBUS_TRANS_TX;
                 item = sendJetiExBusTelemetry(jetiExBusRequestFrame[EXBUS_HEADER_PACKET_ID], item);
                 jetiExBusRequestState = EXBUS_STATE_PROCESSED;
@@ -336,7 +334,6 @@ void handleJetiExBusTelemetry(void) {
     // check the state if transmit is ready
     if (jetiExBusTransceiveState == EXBUS_TRANS_IS_TX_COMPLETED) {
         if (isSerialTransmitBufferEmpty(jetiExBusPort)) {
-            serialSetMode(jetiExBusPort, MODE_RX);
             jetiExBusTransceiveState = EXBUS_TRANS_RX;
             jetiExBusRequestState = EXBUS_STATE_ZERO;
         }


### PR DESCRIPTION
AI Generated pull-request

Fixes #704

## Root Cause

JETI ExBus is an inherently half-duplex protocol. The serial port was opened with `SERIAL_BIDIR` only when `rxConfig->halfDuplex` was set by the user. Without it, the UART remained in full-duplex mode and the FC could not drive the TX line for telemetry responses.

## Changes (BF 4.5-maintenance parity)

**`src/main/rx/jetiexbus.c`**
- Always pass `SERIAL_BIDIR` to `openSerialPort` — removes the `rxConfig->halfDuplex` conditional (root-cause fix; matches BF `rx/jetiexbus.c`)
- Remove `serialSetMode(jetiExBusPort, MODE_RX)` after init — direction is hardware-managed with `SERIAL_BIDIR`
- Add per-frame `jetiExBusFrameMaxSize` tracking and overrun detection in the ISR to prevent buffer overwrite on noisy lines
- Use `microsISR()` / `cmpTimeUs()` for overflow-safe ISR timing
- Move `jetiExBusTimeLast = now` to after the gap-reset block (BF parity)
- Reuse already-captured `now` for `jetiTimeStampRequest` (removes second `micros()` call)
- Correct wiring comment: EX Bus connects to Serial TX, not RX

**`src/main/telemetry/jetiexbus.c`**
- Remove `serialSetMode(jetiExBusPort, MODE_TX)` and `serialSetMode(jetiExBusPort, MODE_RX)` from `handleJetiExBusTelemetry` — direction switching is not needed when the port is opened with `SERIAL_BIDIR`

## BF Equivalence

Diff verified against `betaflight/src/main/{rx,telemetry}/jetiexbus.c` on `4.5-maintenance`. The `SERIAL_BIDIR` change and removal of `serialSetMode` calls are direct backports.

## Coverage gaps

F446 and F7X5XG not exercised by CI (no targets in build set).

## Tier Classification

**Tier 2 — behavioral change** (device-init path, serial port options).  
Bench verification required on at least one F4 and one F7 target before merge.  
Build gate: zero warnings across all bench + compile targets — confirmed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jeti EX Bus receiver frame assembly timing accuracy for more reliable serial communication.
  * Simplified telemetry transmission flow by removing unnecessary serial port mode switching operations.
  * Enhanced serial port initialization for bidirectional communication support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1168)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->