### PR TITLE
fix(APEXF7): add PINIO2 config and UART4 MSP default for DJI Vista

### DIFF
--- a/src/main/target/APEXF7/config.c
+++ b/src/main/target/APEXF7/config.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include "platform.h"
 #ifdef USE_TARGET_CONFIG
+#include "io/serial.h"
 #include "pg/pinio.h"
 #include "pg/piniobox.h"
 
@@ -31,5 +32,12 @@ void targetConfiguration(void) {
     pinioBoxConfigMutable()->permanentId[2] = 255;
     pinioBoxConfigMutable()->permanentId[3] = 255;
     pinioConfigMutable()->config[0] = 129;
+    pinioConfigMutable()->config[1] = 129;
+
+    // UART4 default: MSP DisplayPort for DJI Vista/O3 (matches BF: serial 3 1)
+    serialPortConfig_t *uart4Port = serialFindPortConfiguration(SERIAL_PORT_UART4);
+    if (uart4Port) {
+        uart4Port->functionMask = FUNCTION_MSP;
+    }
 }
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary

- `pinioConfigMutable()->config[1] = 129` was missing; PINIO2 mode was left at default (1) instead of matching PINIO1 (129). BF reference: `PINIO2_CONFIG 129` in `betaflight/config/configs/APEXF7/config.h`.
- UART4 had no serial function default. DJI Vista / O3 DisplayPort OSD requires MSP on UART4 as a factory default. BF reference: `serial 3 1` in the BF unified target config (`APEX-APEXF7.config`).

Fixes #662 (DJI Vista not powering/communicating under EmuFlight on APEXF7).

## Behavioural note — UART4 MSP default

`targetConfiguration()` is called by `resetConfigs()`, which runs on every `defaults` or `defaults nosave` CLI command. This means UART4 will be re-assigned to MSP each time defaults are reset — matching BF factory behaviour.

**For users without DJI:** MSP on an unconnected UART is passive (responds only when polled; sends nothing). It will not break non-DJI setups. If UART4 is needed for another function (GPS, serial RX, etc.), clear the MSP assignment in the Ports tab after flashing or after running `defaults`.

## Notes

- Flash chip define (`USE_FLASH_M25P16`) is intentionally left unchanged. EmuFlight's M25P16 driver already detects the on-board W25Q128FV via JEDEC ID `0xEF4018`. BF's `USE_FLASH_W25Q128FV` driver is QuadSPI/OctoSPI-only and does not apply to this target's standard SPI connection.
- No changes to `target.h` or `target.c`; timer/motor pin assignments are correct.

## Test plan

- [x] Build: `make APEXF7` succeeds with no warnings
- [ ] Flash APEXF7 and confirm UART4 defaults to MSP in Ports tab on first flash
- [ ] Confirm PINIO2 behaviour matches PINIO1 (both mode 129)
- [ ] Confirm DJI Vista / O3 powers and establishes DisplayPort OSD
- [ ] Confirm `defaults` re-applies UART4 MSP assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)