### PR TITLE
fix(dshot/proshot): explicitly write frame-reset slots in DMA buffers

### DIFF
--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -142,18 +142,24 @@ static FAST_CODE void pwmWriteDshot(uint8_t index, float value) {
 }
 
 static FAST_CODE uint8_t loadDmaBufferDshot(uint32_t *dmaBuffer, int stride, uint16_t packet) {
-    for (int i = 0; i < 16; i++) {
+    int i;
+    for (i = 0; i < 16; i++) {
         dmaBuffer[i * stride] = (packet & 0x8000) ? MOTOR_BIT_1 : MOTOR_BIT_0;  // MSB first
         packet <<= 1;
     }
+    dmaBuffer[i++ * stride] = 0;
+    dmaBuffer[i++ * stride] = 0;
     return DSHOT_DMA_BUFFER_SIZE;
 }
 
 FAST_CODE static uint8_t loadDmaBufferProshot(uint32_t *dmaBuffer, int stride, uint16_t packet) {
-    for (int i = 0; i < 4; i++) {
+    int i;
+    for (i = 0; i < 4; i++) {
         dmaBuffer[i * stride] = PROSHOT_BASE_SYMBOL + ((packet & 0xF000) >> 12) * PROSHOT_BIT_WIDTH;  // Most significant nibble first
         packet <<= 4;   // Shift 4 bits
     }
+    dmaBuffer[i++ * stride] = 0;
+    dmaBuffer[i++ * stride] = 0;
     return PROSHOT_DMA_BUFFER_SIZE;
 }
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary

`loadDmaBufferDshot` and `loadDmaBufferProshot` in `src/main/drivers/pwm_output.c` were not writing the two trailing zero-valued DMA buffer entries used as inter-frame gap / frame-reset markers.

Both `DSHOT_DMA_BUFFER_SIZE` (18) and `PROSHOT_DMA_BUFFER_SIZE` (6) include 2 reset slots beyond the payload (16 bits for DSHOT, 4 nibbles for ProShot). BF's equivalents in `dshot_dpwm.c` explicitly write `dmaBuffer[i++ * stride] = 0` twice after the payload loop on every frame. EmuFlight relied on the buffers being zero from static initialisation.

BF reference: `betaflight/src/main/drivers/dshot_dpwm.c` (`loadDmaBufferDshot`, `loadDmaBufferProshot`).

## Protocol regression analysis

| Protocol | Uses modified functions | Impact |
|---|---|---|
| DSHOT150 / 300 / 600 / 1200 / 2400 / 4800 | `loadDmaBufferDshot` | Slots [16] and [17] explicitly zeroed each frame. Values were already 0 (static init). **No functional change.** |
| ProShot1000 | `loadDmaBufferProshot` | Slots [4] and [5] explicitly zeroed each frame. Values were already 0 (static init). **No functional change.** |
| Standard PWM / OneShot / Multishot / Brushed | Neither | Completely unaffected. |

**Buffer bounds (all modes safe):**
- Non-burst (stride=1): DSHOT max index 17 < 18 ✓; ProShot max index 5 < 6 ✓
- Burst (stride=4): `dmaBurstBuffer[72]`; DSHOT max index `17×4+3 = 71` < 72 ✓; ProShot max `5×4+3 = 23` < 72 ✓

**DMA transfer count:** `dma_init.NbData` uses compile-time constants at init; per-frame `LL_EX_DMA_SetDataLength` uses the `bufferSize` return value (unchanged by this fix). No change in elements transferred.

## Build results — full suite PASS (`51b603b573`)

| Set | Targets | Result |
|---|---|---|
| Unit tests | — | PASS |
| Bench | HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 **APEXF7** TMOTORF7 | OK |
| Compile | MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 | OK |
| Unique | CRAZYFLIE2 ANYFCF7 ELLE0 F4BY STM32F4DISCOVERY NUCLEOF446RE BEEBRAIN_PRO BEEBRAIN_LITE AG3XF4 AG3XF7 COLIBRI | OK |

24 targets, 0 failures. CodeRabbit local review: 0 findings.

## Notes

- Behaviour is unchanged on cold boot (static DMA buffers are zero-initialised). The fix makes each frame self-contained and eliminates any dependency on initial buffer state.
- This does **not** address the APEXF7 ProShot semi-brick reported in #809. That symptom (FC crash on boot after saving ProShot protocol) was not reproducible in static analysis and requires hardware investigation.
- `MOTOR_BITLENGTH` divergence (EF=19, BF=20) is a separate DSHOT timing issue, out of scope here.

## Test plan

- [ ] DSHOT operation unchanged on hardware that previously worked
- [ ] ProShot operation unchanged or improved on hardware that supports it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PWM output signal integrity by enhancing DMA buffer generation for motor control protocols.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1173)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->