### PR TITLE
fix(dshot): align MOTOR_BITLENGTH=20 and ARR=n-1 with Betaflight

### DIFF
--- a/src/main/drivers/pwm_output.h
+++ b/src/main/drivers/pwm_output.h
@@ -109,7 +109,7 @@ typedef enum {
 
 #define MOTOR_BIT_0           7
 #define MOTOR_BIT_1           14
-#define MOTOR_BITLENGTH       19
+#define MOTOR_BITLENGTH       20
 
 #define MOTOR_PROSHOT1000_HZ         MHZ_TO_HZ(24)
 #define PROSHOT_BASE_SYMBOL          24 // 1uS

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -167,7 +167,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         RCC_ClockCmd(timerRCC(timer), ENABLE);
         TIM_Cmd(timer, DISABLE);
         TIM_TimeBaseStructure.TIM_Prescaler = (uint16_t)(lrintf((float) timerClock(timer) / getDshotHz(pwmProtocolType) + 0.01f) - 1);
-        TIM_TimeBaseStructure.TIM_Period = pwmProtocolType == PWM_TYPE_PROSHOT1000 ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH;
+        TIM_TimeBaseStructure.TIM_Period = (pwmProtocolType == PWM_TYPE_PROSHOT1000 ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH) - 1;
         TIM_TimeBaseStructure.TIM_ClockDivision = TIM_CKD_DIV1;
         TIM_TimeBaseStructure.TIM_RepetitionCounter = 0;
         TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -155,7 +155,7 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
         RCC_ClockCmd(timerRCC(timer), ENABLE);
         LL_TIM_DisableCounter(timer);
         init.Prescaler = (uint16_t)(lrintf((float) timerClock(timer) / getDshotHz(pwmProtocolType) + 0.01f) - 1);
-        init.Autoreload = pwmProtocolType == PWM_TYPE_PROSHOT1000 ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH;
+        init.Autoreload = (pwmProtocolType == PWM_TYPE_PROSHOT1000 ? MOTOR_NIBBLE_LENGTH_PROSHOT : MOTOR_BITLENGTH) - 1;
         init.ClockDivision = LL_TIM_CLOCKDIVISION_DIV1;
         init.RepetitionCounter = 0;
         init.CounterMode = LL_TIM_COUNTERMODE_UP;


### PR DESCRIPTION
AI Generated pull-request

Closes #1174

## Summary

- `MOTOR_BITLENGTH` 19 → 20 in `pwm_output.h` — constant now reads as full ticks-per-bit (12 MHz / 600 kHz = 20), matching BF and INAV
- ARR assignment changed to `(... MOTOR_BITLENGTH) - 1` in both `pwm_output_dshot_hal.c` and `pwm_output_dshot.c` — matching BF's `n-1` pattern
- **Net effect on DSHOT wire timing: zero.** Pre-fix EmuFlight used `MOTOR_BITLENGTH=19` with no `- 1`; BF uses `MOTOR_BITLENGTH=20` with `- 1`. Both yield ARR=19 (20 ticks = 1.667 µs for DSHOT600). The value difference and missing `- 1` cancelled each other out — DSHOT timing was always correct.
- **PROSHOT side-effect fix:** adding `- 1` to the shared ternary corrects PROSHOT nibble period from 97 ticks (~4.042 µs) to 96 ticks (exactly 4.000 µs). Complements #1173's DMA buffer zero-fill fix at the timer-config layer.

## BF reference

`src/main/drivers/dshot_dpwm.h`: `MOTOR_BITLENGTH=20`
`src/main/drivers/stm32/pwm_output_dshot_hal.c:301`: `init.Autoreload = (... MOTOR_BITLENGTH) - 1`

## Test plan

- [x] Unit tests: PASS
- [x] Bench targets (HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7): all PASS
- [x] Compile targets (MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 CRAZYFLIE2): all PASS
- [x] CodeRabbit local review: 0 findings
- [x] **Hardware verified: HELIOSPRING DSHOT operational @ 337d56e886**