### PR TITLE
fix(jeti): correct EXTEL_MAX_LEN, sensor data types, and GPS frame guard

### DIFF
--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -57,7 +57,7 @@
 #define EXTEL_SYNC_LEN      1
 #define EXTEL_CRC_LEN       1
 #define EXTEL_HEADER_LEN    6
-#define EXTEL_MAX_LEN       28
+#define EXTEL_MAX_LEN       26
 #define EXTEL_OVERHEAD      (EXTEL_SYNC_LEN + EXTEL_HEADER_LEN + EXTEL_CRC_LEN)
 #define EXTEL_MAX_PAYLOAD   (EXTEL_MAX_LEN - EXTEL_OVERHEAD)
 #define EXBUS_MAX_REQUEST_BUFFER_SIZE   (EXBUS_OVERHEAD + EXTEL_MAX_LEN)
@@ -114,14 +114,14 @@ typedef struct exBusSensor_s {
 // after every 15 sensors a new header has to be inserted (e.g. "BF D2")
 const exBusSensor_t jetiExSensors[] = {
     {"BF D1",       "",      EX_TYPE_DES,   0              },     // device descripton
-    {"Voltage",     "V",     EX_TYPE_14b,   DECIMAL_MASK(1)},
-    {"Current",     "A",     EX_TYPE_14b,   DECIMAL_MASK(2)},
-    {"Altitude",    "m",     EX_TYPE_14b,   DECIMAL_MASK(2)},
+    {"Voltage",     "V",     EX_TYPE_22b,   DECIMAL_MASK(1)},
+    {"Current",     "A",     EX_TYPE_22b,   DECIMAL_MASK(2)},
+    {"Altitude",    "m",     EX_TYPE_22b,   DECIMAL_MASK(2)},
     {"Capacity",    "mAh",   EX_TYPE_22b,   DECIMAL_MASK(0)},
     {"Power",       "W",     EX_TYPE_22b,   DECIMAL_MASK(1)},
-    {"Roll angle",  "\xB0",  EX_TYPE_14b,   DECIMAL_MASK(1)},
-    {"Pitch angle", "\xB0",  EX_TYPE_14b,   DECIMAL_MASK(1)},
-    {"Heading",     "\xB0",  EX_TYPE_14b,   DECIMAL_MASK(1)},
+    {"Roll angle",  "\xB0",  EX_TYPE_22b,   DECIMAL_MASK(1)},
+    {"Pitch angle", "\xB0",  EX_TYPE_22b,   DECIMAL_MASK(1)},
+    {"Heading",     "\xB0",  EX_TYPE_22b,   DECIMAL_MASK(1)},
     {"Vario",       "m/s",   EX_TYPE_22b,   DECIMAL_MASK(2)}
 };
 
@@ -277,7 +277,11 @@ uint8_t createExTelemetryValueMessage(uint8_t *exMessage, uint8_t item) {
             sensorValue = sensorValue >> 8;
             iCount--;
         }
-        *p++ = (sensorValue & 0x9F) | jetiExSensors[item].decimals;
+        if (jetiExSensors[item].exDataType != EX_TYPE_GPS) {
+            *p++ = (sensorValue & 0x9F) | jetiExSensors[item].decimals;
+        } else {
+            *p++ = sensorValue;
+        }
         item = getNextActiveSensor(item);
         if (startItem >= item) {
             break;


### PR DESCRIPTION
AI Generated pull-request

## Summary

Three protocol-correctness fixes to `telemetry/jetiexbus.c`, aligned with Betaflight 4.5-maintenance (`src/main/telemetry/jetiexbus.c`).

- **`EXTEL_MAX_LEN` 28 → 26** — the JETI ExTel specification defines a maximum frame length of 26 bytes. The previous value of 28 produced oversized frames that receivers may silently reject.
- **Six sensors upgraded `EX_TYPE_14b` → `EX_TYPE_22b`** (Voltage, Current, Altitude, Roll angle, Pitch angle, Heading) — `EX_TYPE_14b` clips at ±8,191. Altitude is returned in centimetres; any flight above ~82 m would clip to 82 m on the JETI display. `EX_TYPE_22b` (±2,097,151) covers all realistic sensor ranges. The frame-assembly loop in `createExTelemetryValueMessage()` is already generic over data-type width via `exDataTypeLen[]` — no other code needed changing.
- **GPS data guard in `createExTelemetryValueMessage()`** — `EX_TYPE_GPS` values encode coordinates in the final byte directly; applying the sign/decimal mask `(sensorValue & 0x9F) | decimals` would corrupt them. The guard matches BF 4.5-m exactly and is defensive for any future GPS sensor additions.

## BF 4.5-maintenance equivalence

All three changes match `betaflight/src/main/telemetry/jetiexbus.c` (4.5-maintenance). No EmuFlight-specific divergence introduced.

## Tier classification

**Tier 1** — telemetry-only change; no flight path, motor, or gyro paths touched.

## Build verification

Zero warnings on all 13 bench + compile targets:

| Tier | Targets |
|------|---------|
| Bench | HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7 |
| Compile | MATEKF411, NBDHMBF4PRO, WORMFC, ALIENWHOOPF7, CRAZYFLIE2 |

CRAZYFLIE2 included (I2C gyro + `MPU_INT_EXTI`, no SPI — GYRO_USES_SPI guard gate).

CodeRabbit local review (`coderabbit review --agent`): **0 findings**.

## Coverage gaps

F446 and F7X5XG families not exercised by CI (no targets in set) — unaffected as this is a telemetry-only change with no MCU-family-specific code paths.

## Test plan

- [ ] Flash a JETI ExBus-equipped board and verify sensor values display correctly on a JETI receiver (Voltage, Current, Altitude, Roll, Pitch, Heading, Vario)
- [ ] Confirm altitude reads correctly above 82 m (previously clipped)
- [ ] Confirm no regression on non-JETI RX/TX protocols (all changed symbols are file-private to `jetiexbus.c`)

Closes #1169

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified telemetry payload sizing and sensor data type definitions
  * Updated GPS telemetry value message encoding

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1176)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->