### PR TITLE
fix(make): clean_all wipes obj/main directly; bare make clean redirects to clean_all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,7 +312,7 @@ CLEAN_ARTIFACTS += $(TARGET_LST)
 # Make sure build date and revision is updated on every incremental build
 $(OBJECT_DIR)/$(TARGET)/build/version.o : FORCE
 
-.PHONY: FORCE
+.PHONY: FORCE clean clean_test clean_all all_clean
 FORCE:
 
 # List of buildable ELF files and their object dependencies.
@@ -402,6 +402,9 @@ TARGETS_CLEAN = $(addsuffix _clean,$(VALID_TARGETS) )
 
 ## clean             : clean one target (TARGET=<name>), or all targets if TARGET is unspecified
 clean:
+# $(origin TARGET) returns "file" when TARGET comes from the ?= default on line 19 (no command-line override)
+# → delegate to clean_all. Returns "command line" or "environment" when the user sets TARGET explicitly
+# → perform the standard per-target clean of $(CLEAN_ARTIFACTS) and $(OBJECT_DIR)/$(TARGET).
 ifeq ($(origin TARGET), file)
 	$(MAKE) clean_all
 else

--- a/Makefile
+++ b/Makefile
@@ -400,12 +400,16 @@ $(NOBUILD_TARGETS):
 CLEAN_TARGETS = $(addprefix clean_,$(VALID_TARGETS) )
 TARGETS_CLEAN = $(addsuffix _clean,$(VALID_TARGETS) )
 
-## clean             : clean up temporary / machine-generated files
+## clean             : clean one target (TARGET=<name>), or all targets if TARGET is unspecified
 clean:
+ifeq ($(origin TARGET), file)
+	$(MAKE) clean_all
+else
 	@echo "Cleaning $(TARGET)"
 	$(V0) rm -f $(CLEAN_ARTIFACTS)
 	$(V0) rm -rf $(OBJECT_DIR)/$(TARGET)
 	@echo "Cleaning $(TARGET) succeeded."
+endif
 
 ## clean_test        : clean up temporary / machine-generated files (tests)
 clean_test:

--- a/Makefile
+++ b/Makefile
@@ -419,11 +419,15 @@ $(CLEAN_TARGETS):
 $(TARGETS_CLEAN):
 	$(V0) $(MAKE) -j TARGET=$(subst _clean,,$@) clean
 
-## clean_all         : clean all valid targets
-clean_all: $(CLEAN_TARGETS)
+## clean_all         : clean all targets (compiled objects only; obj/*.hex and obj/*.bin preserved)
+clean_all:
+	@echo "Cleaning all targets"
+	$(V0) rm -rf $(OBJECT_DIR)
+	$(V0) cd src/test && $(MAKE) clean || true
+	@echo "All targets cleaned."
 
-## all_clean         : clean all valid targets (alias for above)
-all_clean: $(TARGETS_CLEAN)
+## all_clean         : clean all targets (alias for clean_all)
+all_clean: clean_all
 
 
 flash_$(TARGET): $(TARGET_HEX)


### PR DESCRIPTION
AI Generated pull-request

## Problem

`make clean` without an explicit `TARGET=` only cleaned **HELIOSPRING** (the `?=` default). Every other target's compiled objects survived in `obj/main/<TARGET>/`. Stale `.o` files from a previous build with a different toolchain produce LTO/DWARF version mismatches at link time on the next build — silently passing compilation but failing to link.

`make clean_all` and `make all_clean` iterated over every entry in `$(VALID_TARGETS)` via hundreds of recursive `$(MAKE)` sub-invocations — slow, and still missed any target directory that existed in `obj/main/` but was not in `VALID_TARGETS` at that moment.

## Changes

### `clean` — dispatch on `$(origin TARGET)`

`TARGET ?= HELIOSPRING` gives TARGET an origin of `file`. A command-line `TARGET=FOO` gives it `command line`. The new `ifeq` uses that to dispatch:

- `make clean` (no TARGET) → `$(origin TARGET)` == `file` → calls `clean_all`
- `make TARGET=FOXEERF405 clean` → `$(origin TARGET)` == `command line` → existing single-target clean, unchanged

### `clean_all` — replaced iteration with `rm -rf $(OBJECT_DIR)`

`$(OBJECT_DIR)` is `obj/main`. A single `rm -rf obj/main` replaces hundreds of recursive make calls. `cd src/test && make clean` handles `obj/test/`. Firmware outputs (`obj/*.hex`, `obj/*.bin`) live outside `OBJECT_DIR` and are intentionally preserved.

### `all_clean` — now a simple alias for `clean_all`

Was a separate target with its own iteration via `$(TARGETS_CLEAN)`. Now one line: `all_clean: clean_all`.

## Result

`make clean` == `make clean_all` == `make all_clean` — all three wipe `obj/main/` and `obj/test/` and leave `obj/*.hex`/`obj/*.bin` untouched. Per-target aliases `clean_<TARGET>` and `<TARGET>_clean` are unchanged and continue to clean a single target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build system cleanup operations to ensure consistent and more reliable artifact removal across different build scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1182)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->