### PR TITLE
fix(position): implement getEstimatedVario() — closes #1183

### DIFF
--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -43,6 +43,8 @@ static int16_t estimatedVario = 0;                   // in cm/s
 static int32_t prevAltitude = INT32_MIN;             // INT32_MIN = uninitialized sentinel
 
 #define BARO_UPDATE_FREQUENCY_40HZ (1000 * 25)
+#define VARIO_DEADBAND_CM_S        10          // deadband applied to vario output (cm/s); matches BF 4.5-m value
+#define USEC_PER_SEC               1000000     // µs per second; used to scale altitude delta to cm/s
 
 
 #if defined(USE_BARO) || defined(USE_GPS)
@@ -102,7 +104,7 @@ void calculateEstimatedAltitude(timeUs_t currentTimeUs) {
     if (prevAltitude == INT32_MIN) {
         prevAltitude = estimatedAltitude;
     } else {
-        estimatedVario = applyDeadband(constrain((estimatedAltitude - prevAltitude) * 1000000 / (int32_t)dTime, INT16_MIN, INT16_MAX), 10);
+        estimatedVario = applyDeadband(constrain((estimatedAltitude - prevAltitude) * USEC_PER_SEC / (int32_t)dTime, INT16_MIN, INT16_MAX), VARIO_DEADBAND_CM_S);
     }
     prevAltitude = estimatedAltitude;
 

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -39,6 +39,7 @@
 #include "sensors/barometer.h"
 
 static int32_t estimatedAltitude = 0;                // in cm
+static int16_t estimatedVario = 0;                   // in cm/s
 
 #define BARO_UPDATE_FREQUENCY_40HZ (1000 * 25)
 
@@ -97,9 +98,14 @@ void calculateEstimatedAltitude(timeUs_t currentTimeUs) {
     } else if (haveBaroAlt) {
         estimatedAltitude = baroAlt;
     }
+    static int32_t prevAltitude = 0;
+    estimatedVario = applyDeadband(constrain((estimatedAltitude - prevAltitude) * 1000000 / (int32_t)dTime, INT16_MIN, INT16_MAX), 10);
+    prevAltitude = estimatedAltitude;
+
     DEBUG_SET(DEBUG_ALTITUDE, 0, (int32_t)(100 * gpsTrust));
     DEBUG_SET(DEBUG_ALTITUDE, 1, baroAlt);
     DEBUG_SET(DEBUG_ALTITUDE, 2, gpsAlt);
+    DEBUG_SET(DEBUG_ALTITUDE, 3, estimatedVario);
 }
 
 bool isAltitudeOffset(void) {
@@ -111,7 +117,6 @@ int32_t getEstimatedAltitude(void) {
     return estimatedAltitude;
 }
 
-// This should be removed or fixed, but it would require changing a lot of other things to get rid of.
 int16_t getEstimatedVario(void) {
-    return 0;
+    return estimatedVario;
 }

--- a/src/main/flight/position.c
+++ b/src/main/flight/position.c
@@ -40,6 +40,7 @@
 
 static int32_t estimatedAltitude = 0;                // in cm
 static int16_t estimatedVario = 0;                   // in cm/s
+static int32_t prevAltitude = INT32_MIN;             // INT32_MIN = uninitialized sentinel
 
 #define BARO_UPDATE_FREQUENCY_40HZ (1000 * 25)
 
@@ -98,8 +99,11 @@ void calculateEstimatedAltitude(timeUs_t currentTimeUs) {
     } else if (haveBaroAlt) {
         estimatedAltitude = baroAlt;
     }
-    static int32_t prevAltitude = 0;
-    estimatedVario = applyDeadband(constrain((estimatedAltitude - prevAltitude) * 1000000 / (int32_t)dTime, INT16_MIN, INT16_MAX), 10);
+    if (prevAltitude == INT32_MIN) {
+        prevAltitude = estimatedAltitude;
+    } else {
+        estimatedVario = applyDeadband(constrain((estimatedAltitude - prevAltitude) * 1000000 / (int32_t)dTime, INT16_MIN, INT16_MAX), 10);
+    }
     prevAltitude = estimatedAltitude;
 
     DEBUG_SET(DEBUG_ALTITUDE, 0, (int32_t)(100 * gpsTrust));


### PR DESCRIPTION
AI Generated [pull-request]

## Summary

Replaces the `getEstimatedVario()` stub that always returned `0` (acknowledged in a code comment: *"This should be removed or fixed, but it would require changing a lot of other things to get rid of."*). The fix is 7 lines in a single file.

**What vario is:** vertical speed (climb/sink rate) in cm/s. Positive = climbing, negative = descending. Used by telemetry protocols to show altitude rate on a receiver display or ground station.

## Implementation

Finite-difference derivative of `estimatedAltitude` (already computed at 40 Hz from baro + GPS fusion), with a 10 cm/s deadband to suppress sensor noise — the same threshold used in BF 4.5-maintenance.

```c
static int32_t prevAltitude = 0;
estimatedVario = applyDeadband(constrain((estimatedAltitude - prevAltitude) * 1000000 / (int32_t)dTime, INT16_MIN, INT16_MAX), 10);
prevAltitude = estimatedAltitude;
```

Also adds `DEBUG_ALTITUDE` slot 3 for the vario value (BF parity).

## Consumers fixed

All 8 callers of `getEstimatedVario()` now receive a live value instead of 0:

| Consumer | File |
|----------|------|
| MSP | `interface/msp.c` |
| OSD | `io/osd.c` |
| iBUS | `telemetry/ibus_shared.c` |
| SmartPort | `telemetry/smartport.c` |
| GHST | `telemetry/ghst.c` |
| FrSky Hub | `telemetry/frsky_hub.c` |
| HoTT | `telemetry/hott.c` |
| JETI ExBus | `telemetry/jetiexbus.c` |

## Test plan

- [x] All 23 targets build clean (unit tests + bench + compile + unique sets)
- [x] Single file changed: `src/main/flight/position.c`
- [ ] Live vario readout visible on telemetry display with baro or GPS enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Estimated vertical speed now calculates the rate of altitude change in real time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1185)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->