### PR TITLE
fix(codacy): replace invalid extraOptions with documented language key

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,5 +1,4 @@
 ---
 engines:
   cppcheck:
-    enabled: true
-    extraOptions: "--suppress=missingIncludeSystem"
+    language: c


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Replaces the invalid `extraOptions` and `enabled` keys in `.codacy.yml` with the documented `language: c` key
- `extraOptions` is not a valid key in the Codacy configuration schema — it is silently ignored by the GitHub App; the `--suppress=missingIncludeSystem` suppression in #1156 was therefore never applied
- `language: c` is the correct documented key for cppcheck; tells Codacy to analyse in C mode rather than C++ mode

## Root cause of #1156 not resolving missingIncludeSystem

The Codacy GitHub App honours only three keys under `engines.<tool>`: `language`, `exclude_paths`, and `base_sub_dir`. There is no config-file mechanism to disable individual cppcheck patterns. The `--suppress` flag is a cppcheck CLI argument and has no corresponding `.codacy.yml` key.

To suppress `missingIncludeSystem` entirely, the pattern must be disabled in the Codacy UI: **Repository Settings → Code Patterns → cppcheck → uncheck `missingIncludeSystem`** (Info / CodeStyle). This is a server-side pattern toggle and cannot be driven by the config file.

## Test plan

- [x] `make test` passes (unit tests)
- [x] All 23 build targets pass (Bench ×8, Compile ×4, Unique ×11) — config-only change, no source impact
- [ ] Verify Codacy GitHub App no longer reports `missingIncludeSystem` after pattern is disabled in Codacy UI (out-of-band; requires maintainer action in Codacy dashboard)

Refs #1155. Supersedes the suppression attempt in #1156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality tool configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1187)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->