### PR TITLE
fix(bus): guard DMA HAL types against SIMULATOR_BUILD for SITL compile

### DIFF
--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -69,8 +69,8 @@ typedef struct busDevice_s {
     } busType_u;
     bool useDMA;
     uint8_t deviceCount;
-#ifndef UNIT_TEST
-    // dmaChannelDescriptor_t requires dma.h which is not available in unit test builds
+#if !defined(UNIT_TEST) && !defined(SIMULATOR_BUILD)
+    // dmaChannelDescriptor_t requires dma.h which is not available in unit test / SITL builds
     dmaChannelDescriptor_t *dmaTx;
     dmaChannelDescriptor_t *dmaRx;
 #if defined(STM32F7)
@@ -80,7 +80,7 @@ typedef struct busDevice_s {
     DMA_InitTypeDef    *initTx;
     DMA_InitTypeDef    *initRx;
 #endif
-#endif // UNIT_TEST
+#endif // !UNIT_TEST && !SIMULATOR_BUILD
     volatile struct busSegment_s *volatile curSegment;
     bool initSegment;
 } busDevice_t;
@@ -108,7 +108,7 @@ typedef struct extDevice_s {
             uint8_t address;
         } mpuSlave;
     } busType_u;
-#ifndef UNIT_TEST
+#if !defined(UNIT_TEST) && !defined(SIMULATOR_BUILD)
     // Per-device DMA init cache — reduces inter-segment setup time (BF 4.5-m pattern).
     // Pointer stored in bus->initTx/initRx so the bus driver always references the
     // current device's cache.
@@ -119,7 +119,7 @@ typedef struct extDevice_s {
     DMA_InitTypeDef    initTx;
     DMA_InitTypeDef    initRx;
 #endif
-#endif // UNIT_TEST
+#endif // !UNIT_TEST && !SIMULATOR_BUILD
     bool useDMA;
     uint8_t *txBuf, *rxBuf;
     uint32_t callbackArg;


### PR DESCRIPTION
AI Generated pull-request

## Summary

- `bus.h` guards around `DMA_InitTypeDef` / `LL_DMA_InitTypeDef` / `dmaChannelDescriptor_t` used `#ifndef UNIT_TEST` alone, which does not exclude SITL builds
- SITL defines `SIMULATOR_BUILD` (injected at `make/source.mk:183`), not `UNIT_TEST` — so the STM32 HAL types were exposed to the host build with no HAL headers available
- Regression introduced in #1121; `make SITL` has been broken on master since 2026-04-25
- Fix extends both guards to `#if !defined(UNIT_TEST) && !defined(SIMULATOR_BUILD)`, matching the existing pattern at `platform.h:25`

## Root cause

`make/source.mk:183` injects `-DSIMULATOR_BUILD` for SITL. `UNIT_TEST` is only defined by the unit-test Makefile path. The two defines are parallel but separate; both must be excluded when guarding against host/stub builds that lack STM32 HAL headers.

## Test plan

- [x] `make SITL` succeeds on this branch (verified locally)
- [x] Pattern matches `platform.h:25`: `#if !defined(UNIT_TEST) && !defined(SIMULATOR_BUILD)`
- [ ] CI ARM builds (targets-group-*) — no change to ARM paths; compile-only verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to exclude DMA-related components from simulator builds in addition to unit test builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1191)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->