### PR TITLE
fix(telemetry): add missing <stdlib.h> in jetiexbus.c for abs() declaration

### DIFF
--- a/src/main/telemetry/jetiexbus.c
+++ b/src/main/telemetry/jetiexbus.c
@@ -20,6 +20,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "platform.h"


### PR DESCRIPTION
AI Generated pull-request

## Problem

`src/main/telemetry/jetiexbus.c` calls `abs(int32_t value)` in `calcGpsDDMMmmm()` without including `<stdlib.h>`, producing two compiler warnings:

```
warning: implicit declaration of function 'abs' [-Wimplicit-function-declaration]
warning: 'abs' argument 1 promotes to 'int32_t' {aka 'long int'} where 'int' is expected
         in a call to built-in function declared without prototype [-Wbuiltin-declaration-mismatch]
```

These warnings were introduced by the GPS/G-Force telemetry additions in #1181.

## Fix

Add `#include <stdlib.h>` — a one-line change that matches Betaflight 4.5-maintenance (`src/main/telemetry/jetiexbus.c` line 23).

## Verification

Built and confirmed warning-free on: `FOXEERF722V4`, `FOXEERF405`, `APEXF7`, `HELIOSPRING`, `SKYSTARSF405AIO`, `TUNERCF405`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal build maintenance update with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->