### PR TITLE
fix(sitl): resolve make SITL warnings

### DIFF
--- a/lib/main/dyad/dyad.c
+++ b/lib/main/dyad/dyad.c
@@ -1091,8 +1091,10 @@ void dyad_vwritef(dyad_Stream *stream, const char *fmt, va_list args) {
         default:
           f[1] = *fmt;
           switch (*fmt) {
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
             case 'f':
             case 'g': sprintf(buf, f, va_arg(args, double));    break;
             case 'd':
@@ -1100,7 +1102,9 @@ void dyad_vwritef(dyad_Stream *stream, const char *fmt, va_list args) {
             case 'x':
             case 'X': sprintf(buf, f, va_arg(args, unsigned));  break;
             case 'p': sprintf(buf, f, va_arg(args, void*));     break;
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
             default : buf[0] = *fmt; buf[1] = '\0';
           }
           str = buf;

--- a/lib/main/dyad/dyad.c
+++ b/lib/main/dyad/dyad.c
@@ -5,6 +5,12 @@
  * under the terms of the MIT license. See LICENSE for details.
  */
 
+#if __GNUC__ > 6
+#define FALLTHROUGH __attribute__ ((fallthrough))
+#else
+#define FALLTHROUGH do {} while(0)
+#endif
+
 #ifdef _WIN32
   #define _WIN32_WINNT 0x501
   #ifndef _CRT_SECURE_NO_WARNINGS
@@ -741,8 +747,7 @@ void dyad_update(void) {
             break;
           }
         }
-        /* Fall through */
-
+        FALLTHROUGH;
       case DYAD_STATE_CLOSING:
         if (select_has(&dyad_selectSet, SELECT_WRITE, stream->sockfd)) {
           stream_flushWriteBuffer(stream);
@@ -1086,6 +1091,8 @@ void dyad_vwritef(dyad_Stream *stream, const char *fmt, va_list args) {
         default:
           f[1] = *fmt;
           switch (*fmt) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
             case 'f':
             case 'g': sprintf(buf, f, va_arg(args, double));    break;
             case 'd':
@@ -1093,6 +1100,7 @@ void dyad_vwritef(dyad_Stream *stream, const char *fmt, va_list args) {
             case 'x':
             case 'X': sprintf(buf, f, va_arg(args, unsigned));  break;
             case 'p': sprintf(buf, f, va_arg(args, void*));     break;
+#pragma GCC diagnostic pop
             default : buf[0] = *fmt; buf[1] = '\0';
           }
           str = buf;

--- a/make/mcu/SITL.mk
+++ b/make/mcu/SITL.mk
@@ -51,6 +51,7 @@ LD_FLAGS    := \
               -Wl,-gc-sections,-Map,$(TARGET_MAP) \
               -Wl,-L$(LINKER_DIR) \
               -Wl,--cref \
+              -Wl,--no-warn-rwx-segments \
               -T$(LD_SCRIPT)
 
 ifneq ($(filter SITL_STATIC,$(OPTIONS)),)

--- a/make/mcu/SITL.mk
+++ b/make/mcu/SITL.mk
@@ -40,6 +40,8 @@ MCU_EXCLUDES = \
 
 TARGET_MAP  = $(OBJECT_DIR)/$(FORKNAME)_$(TARGET).map
 
+# TODO: --no-warn-rwx-segments suppresses a host-ELF linker warning; remove once
+#       the SITL linker script assigns proper section permissions (no RWX segments).
 LD_FLAGS    := \
               -lm \
               -lpthread \

--- a/src/main/build/atomic.h
+++ b/src/main/build/atomic.h
@@ -127,11 +127,7 @@ static inline uint8_t __basepriSetRetVal(uint8_t prio) {
 // this macro can be used only ONCE PER LINE, but multiple uses per block are fine
 
 #if (__GNUC__ > 9)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcpp"
-# warning "Please verify that ATOMIC_BARRIER works as intended"
-#pragma GCC diagnostic pop
-// increment version number if BARRIER works
+#pragma message "ATOMIC_BARRIER: please verify that cleanup-based barrier works as intended on this GCC version"
 // TODO - use flag to disable ATOMIC_BARRIER and use full barrier instead
 // you should check that local variable scope with cleanup spans entire block
 #endif


### PR DESCRIPTION
AI Generated pull-request

Resolves all compiler and linker warnings produced by `make SITL` on GCC 13 (Ubuntu 24.04 host).

## Changes

**`lib/main/dyad/dyad.c`**
- Add `FALLTHROUGH` macro (`__attribute__((fallthrough))` on GCC > 6, `do{}while(0)` otherwise) to fix `-Wimplicit-fallthrough`: the existing `/* Fall through */` comment was separated from the next `case` by a blank line, which GCC does not recognize as an intentional fallthrough annotation.
- Add `#pragma GCC diagnostic push/ignored "-Wformat-nonliteral"/pop` around the four `sprintf(buf, f, …)` calls in `dyad_vwritef` where `f` is an intentional non-literal format string.

**`make/mcu/SITL.mk`**
- Add `-Wl,--no-warn-rwx-segments` to `LD_FLAGS` to suppress the linker warning about the host ELF having a LOAD segment with RWX permissions.

**`src/main/build/atomic.h`**
- Replace the `# warning` + `-Wcpp` suppress pragma with `#pragma message`. The prior form triggered `-Wgnu-#warning` / `-pedantic` on GCC 13 (used for SITL host builds); the `-Wcpp` diagnostic pragma did not cover the "extension before C2X" pedantic diagnostic, so the warning leaked through.

## Before / After

```
# Before
lib/main/dyad/dyad.c:1090: warning: format not a string literal [-Wformat-nonliteral]
lib/main/dyad/dyad.c:1092: warning: format not a string literal [-Wformat-nonliteral]
lib/main/dyad/dyad.c:1094: warning: format not a string literal [-Wformat-nonliteral]
lib/main/dyad/dyad.c:1095: warning: format not a string literal [-Wformat-nonliteral]
lib/main/dyad/dyad.c:738:  warning: this statement may fall through [-Wimplicit-fallthrough=]
src/main/build/atomic.h:132: warning: #warning before C2X is a GCC extension
/usr/bin/ld: warning: EmuFlight_SITL.elf has a LOAD segment with RWX permissions

# After
Building SITL succeeded.   ← zero warnings
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced compiler and toolchain compatibility to improve overall build system stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emuflight/EmuFlight/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->