### PR TITLE
ci(coderabbit): disable Infer; adopt BF config baseline

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,5 +17,7 @@ reviews:
   tools:
     infer:
       enabled: false
+    cppcheck:
+      enabled: false
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: true
+  high_level_summary: true
+  high_level_summary_placeholder: ""
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - ".*"
+  tools:
+    infer:
+      enabled: false
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds `.coderabbit.yaml` to disable two static-analysis tools that produce unusable results on cross-compiled embedded firmware.

## Problem

**Infer (1.2.0):** Fatal error on every firmware file — fires unconditionally on every PR touching a driver or IO file:

\`\`\`
src/main/drivers/flash.c:25:10: fatal error: 'platform.h' file not found
\`\`\`

Infer invokes stock \`clang-18\` on \`x86_64-linux-gnu\`. \`platform.h\` is generated at build time by the Makefile from the target's define cascade; it only exists inside the ARM toolchain build output directory. Without the ARM GCC toolchain, STM32 HAL headers, and generated \`platform.h\`, Infer cannot proceed on any firmware source file.

**cppcheck:** Produces false positives on embedded MCU C idioms — HAL macros, DMA buffer patterns, pointer arithmetic patterns normal to firmware but flagged as errors without MCU context. Already disabled in Codacy for this reason; the same false-positive profile applies here.

## Fix

Disable both tools explicitly. Authentic code-quality analysis comes from CodeRabbit's AI-based review, which does not require a compilation toolchain and correctly understands code logic in context.

Config modelled on betaflight/betaflight `.coderabbit.yaml`.

## Change

One new file: `.coderabbit.yaml` — config only, no source changes.

\`\`\`yaml
tools:
  infer:
    enabled: false
  cppcheck:
    enabled: false
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings for code review workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->