### PR TITLE
fix(spi): add SPIDEV_6 support for STM32H7 (SPI6 peripheral)

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -94,6 +94,10 @@ SPIDevice spiDeviceByInstance(SPI_TypeDef *instance) {
     if (instance == SPI5)
         return SPIDEV_5;
 #endif
+#ifdef USE_SPI_DEVICE_6
+    if (instance == SPI6)
+        return SPIDEV_6;
+#endif
     return SPIINVALID;
 }
 
@@ -135,6 +139,12 @@ bool spiInit(SPIDevice device) {
         break;
     case SPIDEV_5:
 #if defined(USE_SPI_DEVICE_5)
+        spiInitDevice(device);
+        ok = true;
+#endif
+        break;
+    case SPIDEV_6:
+#if defined(USE_SPI_DEVICE_6)
         spiInitDevice(device);
         ok = true;
 #endif

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -74,7 +74,8 @@ typedef enum SPIDevice {
     SPIDEV_2,
     SPIDEV_3,
     SPIDEV_4,
-    SPIDEV_5
+    SPIDEV_5,
+    SPIDEV_6
 } SPIDevice;
 
 #if defined(STM32F1)
@@ -85,7 +86,7 @@ typedef enum SPIDevice {
 #define SPIDEV_COUNT 4
 #elif defined(STM32H7)
 #if defined(STM32H743xx) || defined(STM32H750xx) || defined(STM32H723xx) || defined(STM32H725xx) || defined(STM32H730xx) || defined(STM32H735xx)
-#define SPIDEV_COUNT 5
+#define SPIDEV_COUNT 6
 #else
 #define SPIDEV_COUNT 4
 #endif

--- a/src/main/drivers/bus_spi_pinconfig.c
+++ b/src/main/drivers/bus_spi_pinconfig.c
@@ -379,6 +379,23 @@ const spiHardware_t spiHardware[] = {
         .rcc = RCC_APB2(SPI5),
         .dmaIrqHandler = DMA2_ST2_HANDLER,
     },
+    {
+        .device = SPIDEV_6,
+        .reg = SPI6,
+        .sckPins = {
+            { DEFIO_TAG_E(PA5), GPIO_AF8_SPI6 },
+            { DEFIO_TAG_E(PB3), GPIO_AF8_SPI6 },
+        },
+        .misoPins = {
+            { DEFIO_TAG_E(PA6), GPIO_AF8_SPI6 },
+            { DEFIO_TAG_E(PB4), GPIO_AF8_SPI6 },
+        },
+        .mosiPins = {
+            { DEFIO_TAG_E(PA7), GPIO_AF8_SPI6 },
+            { DEFIO_TAG_E(PB5), GPIO_AF8_SPI6 },
+        },
+        .rcc = RCC_APB4(SPI6),
+    },
 #endif
 #endif
 };


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Add `SPIDEV_6` to `SPIDevice` enum in `bus_spi.h`
- Bump `SPIDEV_COUNT` from 5 → 6 for STM32H743/H750/H723/H725/H730/H735 (these expose SPI6 on APB4; smaller H7 variants keep SPIDEV_COUNT 4)
- Wire `#ifdef USE_SPI_DEVICE_6` in `spiDeviceByInstance()` and `spiInit()` in `bus_spi.c`
- Add SPI6 pin-config entry in `bus_spi_pinconfig.c` (PA5/PB3 SCK, PA6/PB4 MISO, PA7/PB5 MOSI, RCC_APB4) scoped to the H7 sub-variants that carry SPI6

Without this, any target routing a peripheral to SPI6 emits `-Wint-conversion` (raw `SPI_TypeDef *` treated as `uint32_t`). BF 4.5-m parity.

Closes #1239

## Test plan
- [ ] Build passes: LUXH743NDAA (requires feat/target-updates), SPRACINGH7EF
- [ ] Hardware verified: n/a (driver plumbing; hardware test deferred to feat/target-updates merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional compilation issues in the SPI driver to ensure proper device initialization.

* **New Features**
  * Added support for SPI6 device with complete hardware pin configuration and clock source mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->