### PR TITLE
build: add targets-h7 convenience target for STM32H7 MCU group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -571,6 +571,10 @@ targets-f4:
 targets-f7:
 	$(V1) $(MAKE) -s targets-by-mcu MCU_TYPE=STM32F7
 
+## targets-h7        : make all H7 targets
+targets-h7:
+	$(V1) $(MAKE) -s targets-by-mcu MCU_TYPE=STM32H7
+
 ## test              : run the cleanflight test suite
 ## junittest         : run the cleanflight test suite, producing Junit XML result files.
 test junittest:


### PR DESCRIPTION
AI Generated [pull-request]

## Summary

Adds `targets-h7` to the Makefile, mirroring the existing `targets-f4` and `targets-f7` convenience targets.

```makefile
## targets-h7        : make all H7 targets
targets-h7:
	$(V1) $(MAKE) -s targets-by-mcu MCU_TYPE=STM32H7
```

- Delegates to the existing `targets-by-mcu` mechanism — no new logic
- Net change: 4 lines in `Makefile` only; CI workflow is untouched

Closes #1230.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new build target enabling STM32H7 microcontroller support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->