### PR TITLE
fix: suppress -Wduplicated-branches warning in accInit dual-gyro align

### DIFF
--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -373,11 +373,14 @@ bool accInit(void) {
     acc.dev.mpuDetectionResult = *gyroMpuDetectionResult();
     acc.dev.acc_high_fsr = accelerometerConfig()->acc_high_fsr;
 #ifdef USE_DUAL_GYRO
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wduplicated-branches"
     if (gyroConfig()->gyro_to_use == GYRO_CONFIG_USE_GYRO_2) {
         acc.dev.accAlign = ACC_2_ALIGN;
     } else {
         acc.dev.accAlign = ACC_1_ALIGN;
     }
+#pragma GCC diagnostic pop
 #else
     acc.dev.accAlign = ALIGN_DEFAULT;
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary
- Wraps the `USE_DUAL_GYRO` acc alignment if/else in `accInit` with `#pragma GCC diagnostic push/ignored "-Wduplicated-branches"/pop`
- Some targets legitimately define `ACC_1_ALIGN == ACC_2_ALIGN` (both IMUs mounted at the same rotation); GCC fires a false-positive `-Wduplicated-branches` warning because both branches expand to identical code after preprocessing. Logic and behavior are unchanged.
- Closes #1200

## Test plan
- [x] All 120 `USE_DUAL_GYRO` targets build clean (zero accel warnings)
- [x] 6 single-gyro targets across F4/F7/H7 build clean
- [ ] Hardware: n/a (no logic change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compiler warning handling to enhance code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->