### PR TITLE
docs: modernize README, add semver+MSP to CLI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 ## EmuFlight is flight controller software (firmware) used to fly multi-rotor aircraft.
 * This fork differs from Baseflight, Cleanflight and Betaflight in that it focuses on flight performance, innovative filtering, and leading-edge features.
 
-## WARNING
-
-* **DJI components bypass Configurator safety-checks. Do not attempt arming while connected to Configurator with LiPo plugged.  Always remove propellers and use a smoke-stopper for extra safety.**
+> [!WARNING]
+> Always remove propellers and use a smoke-stopper when testing. Never arm with propellers attached while connected to a computer.
 
 ## EmuFlight Releases
 
-* [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5422b54319254b6f9b6d01464ae9380c)](https://www.codacy.com/gh/emuflight/EmuFlight?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=emuflight/EmuFlight&amp;utm_campaign=Badge_Grade)
 * https://github.com/emuflight/EmuConfigurator/releases
 * https://github.com/emuflight/EmuFlight/releases
 
@@ -20,7 +18,7 @@
 
 ## Features
 
-* Support for targets that use the STM32 F7 and F4 processors
+* Support for targets that use the STM32 H7, F7, and F4 processors
 * Support for HelioRC Spring FC's
 * IMUF (Kalman-based) Filtering for all FC's
 * Additional DShot levels: 1200, 2400, 4800
@@ -50,15 +48,20 @@
 ## Installation & Documentation
 
 * See: https://github.com/emuflight/EmuFlight/wiki
+* CLI parameter reference: [docs/CLI/parameters-reference.md](docs/CLI/parameters-reference.md)
 
 ## Configuration Tool
 
 * To configure EmuFlight you should use the EmuFlight-Configurator GUI tool (Windows/OSX/Linux) which can be found here: 
 * https://github.com/emuflight/EmuConfigurator
 
-## DJI OSD [In]Compatibility
+## HD Video System Compatibility
 
-* Setting PIDs and Rates (except for Feed Forward) is supported with the DJI OSD. The filtering menus (MISC PP, FILT PP, FILT GLB) are not currently supported and may result in unintended problems.
+> [!CAUTION]
+> Do not use HD video systems (HDZero, Walksnail, or DJI) to configure EmuFlight. These systems send Betaflight-formatted MSP; EmuFlight's PID, rate, and filter structs differ significantly from Betaflight's, and MSP configuration writes are not source-gated. Sending configuration from any of these devices may silently corrupt your tune. Use **EmuConfigurator**, the **CLI**, or the **EmuFlight OSD** for all configuration.
+
+> [!TIP]
+> Stock DJI goggles do not display OSD. [WTFOS](https://github.com/fpv-wtf/wtfos) enables EmuFlight OSD passthrough on DJI hardware and is the recommended solution for DJI users.
 
 ## Contributing
 
@@ -76,12 +79,34 @@
 
 * Before creating new issues please check to see if there is an existing one.
 
-* If you want to contribute financially on an ongoing basis, please consider becoming a Patreon member (https://www.patreon.com/EmuFlight).
+## Build Environment
+
+| Requirement | Version |
+|-------------|---------|
+| ARM GCC toolchain | 9.x – 13.x (xPack ARM GCC recommended) |
+| Python | 3.12+ |
+| GNU Make | 4.x+ |
+
+Automated builds and unit tests run via **GitHub Actions** on every push and pull request — see [`.github/workflows/`](.github/workflows/) for CI configuration.
+
+To install the ARM toolchain:
+```bash
+make arm_sdk_install   # downloads xPack ARM GCC into tools/
+make test              # run unit tests
+```
+
+## Development Guidelines
+
+EmuFlight development guidance lives in [`.github/instructions/`](.github/instructions/):
+
+- Unit test development best practices
+
+Read these before opening a pull request.
 
 ## Developers
 
 Contribution of bugfixes and new features is encouraged. Please be aware that we have a thorough review process for pull requests. Be prepared to explain what you want to achieve with your pull request.
-Before starting to write code, please read our [development guidelines](docs/development/Development.md ) and [coding style definition](docs/development/CodingStyle.md).
+Before starting to write code, review the [Development Guidelines](#development-guidelines) section above.
 
 ## Open Source / Contributors
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * This fork differs from Baseflight, Cleanflight and Betaflight in that it focuses on flight performance, innovative filtering, and leading-edge features.
 
 > [!WARNING]
-> Always remove propellers and use a smoke-stopper when testing. Never arm with propellers attached while connected to a computer.
+> Always remove propellers and use a smoke-stopper when bench-testing. Never arm with propellers attached while connected to a computer.
 
 ## EmuFlight Releases
 

--- a/docs/CLI/parameters-reference.md
+++ b/docs/CLI/parameters-reference.md
@@ -1,7 +1,7 @@
 # CLI Parameters Reference
 
 > **Auto-generated** — do not edit manually.
-> Source: `src/main/interface/settings.c` | Generated: 2026-05-16 | Commit: `790f6f9f2d`
+> Source: `src/main/interface/settings.c` | Generated: 2026-06-13 | Commit: `47a13a7155` | Firmware: `0.4.3` | MSP: `0.1.54`
 
 ---
 
@@ -74,11 +74,11 @@
 | `gyro_32khz_hardware_lpf` | uint8 | master | `NORMAL`, `EXPERIMENTAL` |
 | `gyro_high_range` | uint8 | master | `OFF`, `ON` |
 | `gyro_sync_denom` | uint8 | master | `1` – `32` |
-| `gyro_lowpass_type` | uint8 | master | `PT1`, `BIQUAD`, `PT2`, `PT3`, `PT4` |
+| `gyro_lowpass_type` | uint8 | master | `PT1`, `SVF`, `PT2`, `PT3`, `PT4` |
 | `gyro_lowpass_hz_roll` | uint16 | master | `0` – `16000` |
 | `gyro_lowpass_hz_pitch` | uint16 | master | `0` – `16000` |
 | `gyro_lowpass_hz_yaw` | uint16 | master | `0` – `16000` |
-| `gyro_lowpass2_type` | uint8 | master | `PT1`, `BIQUAD`, `PT2`, `PT3`, `PT4` |
+| `gyro_lowpass2_type` | uint8 | master | `PT1`, `SVF`, `PT2`, `PT3`, `PT4` |
 | `gyro_lowpass2_hz_roll` | uint16 | master | `0` – `16000` |
 | `gyro_lowpass2_hz_pitch` | uint16 | master | `0` – `16000` |
 | `gyro_lowpass2_hz_yaw` | uint16 | master | `0` – `16000` |
@@ -470,11 +470,11 @@
 | `dterm_abg_alpha` | uint16 | profile | `0` – `1000` |
 | `dterm_abg_boost` | uint16 | profile | `0` – `2000` |
 | `dterm_abg_half_life` | uint8 | profile | `0` – `250` |
-| `dterm_lowpass_type` | uint8 | profile | `PT1`, `BIQUAD`, `PT2`, `PT3`, `PT4` |
+| `dterm_lowpass_type` | uint8 | profile | `PT1`, `SVF`, `PT2`, `PT3`, `PT4` |
 | `dterm_lowpass_hz_roll` | uint16 | profile | `0` – `16000` |
 | `dterm_lowpass_hz_pitch` | uint16 | profile | `0` – `16000` |
 | `dterm_lowpass_hz_yaw` | uint16 | profile | `0` – `16000` |
-| `dterm_lowpass2_type` | uint8 | profile | `PT1`, `BIQUAD`, `PT2`, `PT3`, `PT4` |
+| `dterm_lowpass2_type` | uint8 | profile | `PT1`, `SVF`, `PT2`, `PT3`, `PT4` |
 | `dterm_lowpass2_hz_roll` | uint16 | profile | `0` – `16000` |
 | `dterm_lowpass2_hz_pitch` | uint16 | profile | `0` – `16000` |
 | `dterm_lowpass2_hz_yaw` | uint16 | profile | `0` – `16000` |

--- a/docs/gen_cli_docs.py
+++ b/docs/gen_cli_docs.py
@@ -357,9 +357,12 @@ def _format_requires(ifdef_conds):
     return ', '.join(f'`{c}`' for c in dict.fromkeys(simple))  # deduplicated, ordered
 
 
-def generate_markdown(entries, table_map, settings_c_path, git_hash=None):
+def generate_markdown(entries, table_map, settings_c_path, git_hash=None,
+                      fw_version=None, msp_version=None):
     today = date.today().isoformat()
     ref = git_hash or 'unknown'
+    fw_str  = f' | Firmware: `{fw_version}`'  if fw_version  else ''
+    msp_str = f' | MSP: `{msp_version}`'      if msp_version else ''
 
     # Group by PG, preserving first-seen order
     sections = OrderedDict()
@@ -370,7 +373,7 @@ def generate_markdown(entries, table_map, settings_c_path, git_hash=None):
         '# CLI Parameters Reference',
         '',
         '> **Auto-generated** — do not edit manually.',
-        f'> Source: `{settings_c_path}` | Generated: {today} | Commit: `{ref}`',
+        f'> Source: `{settings_c_path}` | Generated: {today} | Commit: `{ref}`{fw_str}{msp_str}',
         '',
         '---',
         '',
@@ -434,6 +437,41 @@ def _git_hash(path):
         return None
 
 
+def _firmware_version(repo_root: Path):
+    """Return 'MAJOR.MINOR.PATCH' from src/main/build/version.h, or None."""
+    vh = repo_root / 'src' / 'main' / 'build' / 'version.h'
+    if not vh.exists():
+        return None
+    text = vh.read_text()
+    def _def(name):
+        m = re.search(rf'#define\s+{name}\s+(\d+)', text)
+        return m.group(1) if m else None
+    major = _def('FC_VERSION_MAJOR')
+    minor = _def('FC_VERSION_MINOR')
+    patch = _def('FC_VERSION_PATCH_LEVEL')
+    if major and minor and patch:
+        return f'{major}.{minor}.{patch}'
+    return None
+
+
+def _msp_version(repo_root: Path):
+    """Return 'PROTO.MAJOR.MINOR' MSP version from msp_protocol.h, or None."""
+    mh = repo_root / 'src' / 'main' / 'interface' / 'msp_protocol.h'
+    if not mh.exists():
+        return None
+    text = mh.read_text()
+    def _def(name):
+        m = re.search(rf'#define\s+{name}\s+(\d+)', text)
+        return m.group(1) if m else None
+    proto = _def('MSP_PROTOCOL_VERSION')
+    major = _def('API_VERSION_MAJOR')
+    minor = _def('API_VERSION_MINOR')
+    if major and minor:
+        proto = proto or '0'
+        return f'{proto}.{major}.{minor}'
+    return None
+
+
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -491,11 +529,26 @@ def main():
     if not entries:
         sys.exit("ERROR: no entries parsed — check settings.c path and format")
 
-    git_hash = _git_hash(c_path.parent)
+    # Resolve repo root: walk up from settings.c until we find version.h
+    repo_root = c_path.resolve().parent
+    while repo_root != repo_root.parent:
+        if (repo_root / 'src' / 'main' / 'build' / 'version.h').exists():
+            break
+        repo_root = repo_root.parent
+
+    git_hash   = _git_hash(repo_root)
+    fw_version = _firmware_version(repo_root)
+    msp_version = _msp_version(repo_root)
+
+    if fw_version:
+        print(f"Firmware version: {fw_version}")
+    if msp_version:
+        print(f"MSP version:      {msp_version}")
 
     print(f"Generating {out_path}...")
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    md = generate_markdown(entries, table_map, str(c_path), git_hash)
+    md = generate_markdown(entries, table_map, str(c_path), git_hash,
+                           fw_version=fw_version, msp_version=msp_version)
     out_path.write_text(md)
 
     n_sections = len({e['pg'] for e in entries})


### PR DESCRIPTION
AI Generated pull-request

## Summary
- README.md: add Build Environment table, GitHub Actions CI reference,
  Development Guidelines section, H7 support in Features, CLI parameter
  reference link; convert safety block to GitHub alert syntax; add HD
  video system compatibility section ([!CAUTION] + [!TIP] for WTFOS);
  remove stale content (DJI arming bypass warning resolved by #1159,
  dead docs/development/ links, Codacy badge, Patreon link)
- docs/gen_cli_docs.py: parse firmware semver from version.h and MSP
  version from msp_protocol.h; include both in generated doc header
- docs/CLI/parameters-reference.md: regenerated (487 params, 55 sections,
  Firmware 0.4.3, MSP 0.1.54)

Closes #1103, closes #1256

## Test plan
- [ ] `python3 docs/gen_cli_docs.py` runs clean, output header shows firmware + MSP version
- [ ] README renders correctly on GitHub (alert blocks, links)
- [ ] No broken links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated safety guidelines for flight operations and hardware setup
  * Expanded STM32 hardware support documentation to include H7 series
  * Revised HD video system compatibility warnings and guidance
  * Added development environment and contributing guidelines
  * Enhanced CLI parameters reference with firmware and protocol version metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->