### PR TITLE
feat: enable OSD and Telemetry by default on all capable targets

### DIFF
--- a/src/main/config/feature.h
+++ b/src/main/config/feature.h
@@ -23,7 +23,7 @@
 #include "pg/pg.h"
 
 #ifndef DEFAULT_FEATURES
-#define DEFAULT_FEATURES 0
+#define DEFAULT_FEATURES (FEATURE_OSD | FEATURE_TELEMETRY)
 #endif
 
 #ifndef DEFAULT_RX_FEATURE


### PR DESCRIPTION
AI Generated pull-request

Closes #1271

## Summary

- Change the global `DEFAULT_FEATURES` fallback in `src/main/config/feature.h` from `0` to `(FEATURE_OSD | FEATURE_TELEMETRY)`
- Targets with an explicit `DEFAULT_FEATURES` in `target.h` are **unaffected** — the fallback lives inside a `#ifndef DEFAULT_FEATURES` guard
- Targets without OSD or telemetry hardware are safe: `validateAndFixConfig()` in `fc/config.c` unconditionally clears `FEATURE_OSD` (line ~305) when `USE_OSD` is not compiled in and clears `FEATURE_TELEMETRY` (line ~290) when `USE_TELEMETRY` is not compiled in
- `USE_TELEMETRY` is defined in `common_fc_pre.h` — present on all real FC targets; no target loses telemetry capability
- Does not gate on `MAX7456` only — the `USE_OSD` guard covers all OSD backends (analog MAX7456, HDZero, Walksnail, MSP OSD)

## Proof of correctness (simulated)

| Path | Result |
|------|--------|
| Target WITHOUT `DEFAULT_FEATURES` | gets `0x00040400` = `FEATURE_OSD \| FEATURE_TELEMETRY` ✅ |
| Target WITH explicit `DEFAULT_FEATURES` | override wins unchanged ✅ |
| Target WITH fallback but no `USE_OSD` | `validateAndFixConfig()` strips `FEATURE_OSD` at runtime ✅ |

## Files changed

`src/main/config/feature.h` — 1 line changed

## Test plan

- [x] `make test` — all unit tests passed
- [x] Bench targets: `HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7` — all linked, zero warnings
- [x] Compile-only targets: `MATEKF411 NBDHMBF4PRO WORMFC ALIENWHOOPF7 CRAZYFLIE2` — all linked, zero warnings
- [ ] Hardware verification: not required — no driver/hardware path changed; incapable targets stripped at runtime by `validateAndFixConfig()`

## MSP note

No MSP changes. No PG version bump required — `DEFAULT_FEATURES` only affects flash-erased/first-boot defaults; stored `featureConfig` is preserved for existing users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Default configuration updated to enable On-Screen Display (OSD) and Telemetry features by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->