### PR TITLE
fix: DShot beacon fires even when battery alarm owns beeper

### DIFF
--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -270,17 +270,19 @@ void beeper(beeperMode_e mode) {
         }
         break;
     }
+    // Capture beacon request before the priority-loss early-return so the DShot motor tone
+    // fires even when a higher-priority alarm (e.g. BAT_CRIT_LOW) owns the physical buzzer.
+#ifdef USE_DSHOT
+    if (mode == BEEPER_RX_SET || mode == BEEPER_RX_LOST) {
+        dshotBeaconPendingMode = mode;
+    }
+#endif
     if (!selectedCandidate) {
         return;
     }
     currentBeeperEntry = selectedCandidate;
     beeperPos = 0;
     beeperNextToggleTime = 0;
-#ifdef USE_DSHOT
-    if (mode == BEEPER_RX_SET || mode == BEEPER_RX_LOST) {
-        dshotBeaconPendingMode = mode;
-    }
-#endif
 }
 
 void beeperSilence(void) {

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -293,6 +293,9 @@ void beeperSilence(void) {
     beeperNextToggleTime = 0;
     beeperPos = 0;
     currentBeeperEntry = NULL;
+#ifdef USE_DSHOT
+    dshotBeaconPendingMode = BEEPER_SILENCE;
+#endif
 }
 
 /*

--- a/src/main/io/beeper.c
+++ b/src/main/io/beeper.c
@@ -180,6 +180,12 @@ static uint8_t beep_multiBeeps[MAX_MULTI_BEEPS + 1];
 // Beeper off = 0 Beeper on = 1
 static uint8_t beeperIsOn = 0;
 
+#ifdef USE_DSHOT
+// Tracks whether BEEPER_RX_SET or BEEPER_RX_LOST was requested this cycle so the DShot
+// motor beacon fires even when a higher-priority alarm (e.g. BAT_CRIT_LOW) owns the buzzer.
+static beeperMode_e dshotBeaconPendingMode = BEEPER_SILENCE;
+#endif
+
 // Place in current sequence
 static uint16_t beeperPos = 0;
 // Time when beeper routine must act next time
@@ -270,6 +276,11 @@ void beeper(beeperMode_e mode) {
     currentBeeperEntry = selectedCandidate;
     beeperPos = 0;
     beeperNextToggleTime = 0;
+#ifdef USE_DSHOT
+    if (mode == BEEPER_RX_SET || mode == BEEPER_RX_LOST) {
+        dshotBeaconPendingMode = mode;
+    }
+#endif
 }
 
 void beeperSilence(void) {
@@ -372,9 +383,13 @@ void beeperUpdate(timeUs_t currentTimeUs) {
     if (!beeperIsOn) {
         beeperIsOn = 1;
 #ifdef USE_DSHOT
+        // Use dshotBeaconPendingMode rather than currentBeeperEntry->mode so the motor beacon
+        // fires even when a higher-priority buzzer alarm (e.g. BAT_CRIT_LOW) owns the beeper.
+        const beeperMode_e beaconMode = dshotBeaconPendingMode;
+        dshotBeaconPendingMode = BEEPER_SILENCE;
         if (!areMotorsRunning()
-                && ((currentBeeperEntry->mode == BEEPER_RX_SET && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_SET)))
-                    || (currentBeeperEntry->mode == BEEPER_RX_LOST && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_LOST))))) {
+                && ((beaconMode == BEEPER_RX_SET && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_SET)))
+                    || (beaconMode == BEEPER_RX_LOST && !(beeperConfig()->dshotBeaconOffFlags & BEEPER_GET_FLAG(BEEPER_RX_LOST))))) {
             if ((currentTimeUs - getLastDisarmTimeUs() > DSHOT_BEACON_GUARD_DELAY_US) && !isTryingToArm()) {
                 lastDshotBeaconCommandTimeUs = currentTimeUs;
                 pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), beeperConfig()->dshotBeaconTone, false);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -93,6 +93,14 @@ cli_unittest_DEFINES := \
 		USE_CLI \
 		SystemCoreClock=1000000
 
+beeper_dshot_beacon_unittest_SRC := \
+		$(USER_DIR)/io/beeper.c \
+		$(USER_DIR)/pg/beeper.c \
+		$(USER_DIR)/pg/pg.c
+
+beeper_dshot_beacon_unittest_DEFINES := \
+		USE_DSHOT
+
 cms_unittest_SRC := \
 		$(USER_DIR)/cms/cms.c \
 		$(USER_DIR)/common/typeconversion.c \

--- a/src/test/unit/beeper_dshot_beacon_unittest.cc
+++ b/src/test/unit/beeper_dshot_beacon_unittest.cc
@@ -1,0 +1,215 @@
+/*
+ * This file is part of EmuFlight.
+ *
+ * EmuFlight is free software. You can redistribute this software and/or
+ * modify this software under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
+ *
+ * EmuFlight is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this software. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Tests that the DShot motor beacon fires via beeper(BEEPER_RX_SET) even when
+ * a higher-priority battery alarm (BEEPER_BAT_CRIT_LOW) currently owns the
+ * physical buzzer and would otherwise block the beacon via priority arbitration.
+ *
+ * Regression guard for: dshotBeaconPendingMode must be set before the
+ * selectedCandidate==NULL early-return in beeper(), not after.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "io/beeper.h"
+    #include "pg/beeper.h"
+    #include "pg/pg.h"
+    #include "pg/pg_ids.h"
+    #include "sensors/battery.h"
+    #include "drivers/pwm_output.h"
+    #include "fc/rc_modes.h"
+    #include "io/gps.h"
+
+    // beeperConfig PG is defined in io/beeper.c itself (linked via _SRC)
+
+    // --- controllable stub state ---
+    static bool stubMotorsRunning = false;
+    static timeUs_t stubLastDisarmTime = 0;
+    static bool stubTryingToArm = false;
+    static batteryState_e stubBatteryState = BATTERY_OK;
+    static bool stubRcModeBeeper = false;
+    static int dshotBeaconCallCount = 0;
+    static uint8_t dshotBeaconToneRecorded = 0;
+
+    // --- stubs ---
+    bool areMotorsRunning(void) { return stubMotorsRunning; }
+    timeUs_t getLastDisarmTimeUs(void) { return stubLastDisarmTime; }
+    bool isTryingToArm(void) { return stubTryingToArm; }
+    batteryState_e getBatteryState(void) { return stubBatteryState; }
+
+    bool IS_RC_MODE_ACTIVE(boxId_e modeId) {
+        if (modeId == BOXBEEPERON) return stubRcModeBeeper;
+        return false;
+    }
+
+    void pwmWriteDshotCommand(uint8_t index, uint8_t motorCount, uint8_t command, bool blocking) {
+        UNUSED(index); UNUSED(motorCount); UNUSED(blocking);
+        dshotBeaconCallCount++;
+        dshotBeaconToneRecorded = command;
+    }
+
+    // minimal stubs for beeper.c dependencies
+    void BEEP_ON_stub(void) {}
+    void BEEP_OFF_stub(void) {}
+    void warningLedEnable(void) {}
+    void warningLedDisable(void) {}
+    void warningLedRefresh(void) {}
+    void warningLedFlash(void) {}
+    void warningLedUpdate(void) {}
+
+    uint32_t micros(void) { return 0; }
+    uint32_t millis(void) { return 0; }
+}
+
+#include "gtest/gtest.h"
+
+// Helper: run beeperUpdate() enough times to advance through a full beep sequence
+// starting from beeperIsOn==0 so the DShot block fires.
+static void runBeeperUpdate(timeUs_t timeUs) {
+    beeperUpdate(timeUs);
+}
+
+class DshotBeaconPriorityTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        pgResetAll();
+        // Enable both beacon modes (default has them masked off)
+        beeperConfigMutable()->dshotBeaconOffFlags = 0;
+        beeperSilence();
+        stubMotorsRunning = false;
+        stubLastDisarmTime = 0;
+        stubTryingToArm = false;
+        stubBatteryState = BATTERY_OK;
+        stubRcModeBeeper = false;
+        dshotBeaconCallCount = 0;
+        dshotBeaconToneRecorded = 0;
+    }
+};
+
+// Normal case: beeper switch on, no competing alarm → beacon fires.
+TEST_F(DshotBeaconPriorityTest, BeaconFiresWhenRxSetActiveNoBatteryAlarm)
+{
+    // given: beeper switch active, well past disarm guard, motors idle
+    stubRcModeBeeper = true;
+    const timeUs_t t = 1200000U + 1000;
+
+    // when
+    runBeeperUpdate(t);
+
+    // then: DShot beacon was sent
+    EXPECT_GE(dshotBeaconCallCount, 1);
+}
+
+// Key regression: battery critical alarm active (priority 6 > RX_SET priority 9).
+// Before the fix, beeper(BEEPER_RX_SET) returned early and never set
+// dshotBeaconPendingMode, so the beacon was silenced.
+TEST_F(DshotBeaconPriorityTest, BeaconFiresWhenBatteryCritLowOwnsBeeper)
+{
+    // given: battery critical alarm is active (it calls beeper(BEEPER_BAT_CRIT_LOW) externally)
+    beeper(BEEPER_BAT_CRIT_LOW);
+
+    // and: beeper switch is also active → beeperUpdate() calls beeper(BEEPER_RX_SET)
+    stubRcModeBeeper = true;
+    const timeUs_t t = 1200000U + 1000;
+
+    // when
+    runBeeperUpdate(t);
+
+    // then: DShot motor beacon MUST still fire despite battery alarm owning the buzzer
+    EXPECT_GE(dshotBeaconCallCount, 1)
+        << "DShot beacon was silenced by battery alarm priority — regression in dshotBeaconPendingMode placement";
+}
+
+// Mirror: battery low (priority 7) should also not block the beacon.
+TEST_F(DshotBeaconPriorityTest, BeaconFiresWhenBatteryLowOwnsBeeper)
+{
+    beeper(BEEPER_BAT_LOW);
+    stubRcModeBeeper = true;
+    const timeUs_t t = 1200000U + 1000;
+
+    runBeeperUpdate(t);
+
+    EXPECT_GE(dshotBeaconCallCount, 1)
+        << "DShot beacon was silenced by BAT_LOW alarm priority";
+}
+
+// Beacon must NOT fire when motors are running (safety guard).
+TEST_F(DshotBeaconPriorityTest, BeaconDoesNotFireWhenMotorsRunning)
+{
+    stubRcModeBeeper = true;
+    stubMotorsRunning = true;
+    const timeUs_t t = 1200000U + 1000;
+
+    runBeeperUpdate(t);
+
+    EXPECT_EQ(0, dshotBeaconCallCount);
+}
+
+// Beacon must NOT fire within the disarm guard window.
+TEST_F(DshotBeaconPriorityTest, BeaconDoesNotFireInsideDisarmGuard)
+{
+    stubRcModeBeeper = true;
+    stubLastDisarmTime = 0;
+    const timeUs_t t = 1200000U / 2; // inside guard window
+
+    runBeeperUpdate(t);
+
+    EXPECT_EQ(0, dshotBeaconCallCount);
+}
+
+// Beacon must NOT fire when dshotBeaconOffFlags masks BEEPER_RX_SET.
+TEST_F(DshotBeaconPriorityTest, BeaconDoesNotFireWhenMaskedByOffFlags)
+{
+    beeperConfigMutable()->dshotBeaconOffFlags = BEEPER_GET_FLAG(BEEPER_RX_SET);
+    stubRcModeBeeper = true;
+    const timeUs_t t = 1200000U + 1000;
+
+    runBeeperUpdate(t);
+
+    EXPECT_EQ(0, dshotBeaconCallCount);
+}
+
+// RX_LOST (priority 1) was already immune pre-fix; confirm it still fires.
+TEST_F(DshotBeaconPriorityTest, BeaconFiresOnRxLost)
+{
+    beeper(BEEPER_BAT_CRIT_LOW); // lower-priority alarm present
+    beeper(BEEPER_RX_LOST);      // RX_LOST priority 1 wins buzzer too
+    const timeUs_t t = 1200000U + 1000;
+
+    runBeeperUpdate(t);
+
+    EXPECT_GE(dshotBeaconCallCount, 1);
+}
+
+// STUBS — satisfy link dependencies not covered above
+
+extern "C" {
+    uint8_t armingFlags = 0;
+    int16_t debug[4] = {};
+    uint32_t stateFlags = 0;
+    gpsSolutionData_t gpsSol = {};
+    void delay(uint32_t ms) { UNUSED(ms); }
+    bool isMotorProtocolDshot(void) { return true; }
+    uint8_t getMotorCount(void) { return 4; }
+    void systemBeep(bool onoff) { UNUSED(onoff); }
+    bool feature(uint32_t mask) { UNUSED(mask); return false; }
+}

--- a/src/test/unit/beeper_dshot_beacon_unittest.cc
+++ b/src/test/unit/beeper_dshot_beacon_unittest.cc
@@ -201,6 +201,25 @@ TEST_F(DshotBeaconPriorityTest, BeaconFiresOnRxLost)
     EXPECT_GE(dshotBeaconCallCount, 1);
 }
 
+// beeperSilence() must clear dshotBeaconPendingMode so a silenced beeper
+// cannot fire a motor beacon on the next tick.
+TEST_F(DshotBeaconPriorityTest, BeeperSilenceClearsPendingMode)
+{
+    // given: pending mode is primed directly (RC mode is OFF so beeperUpdate()
+    // cannot re-arm it after the silence)
+    stubRcModeBeeper = false;
+    beeper(BEEPER_RX_SET);
+    const timeUs_t t = 1200000U + 1000;
+
+    // when: beeperSilence() is called before beeperUpdate() consumes the pending mode
+    beeperSilence();
+
+    // then: beeperUpdate() must NOT fire the motor beacon
+    runBeeperUpdate(t);
+    EXPECT_EQ(0, dshotBeaconCallCount)
+        << "beeperSilence() failed to clear dshotBeaconPendingMode";
+}
+
 // STUBS — satisfy link dependencies not covered above
 
 extern "C" {

--- a/src/test/unit/beeper_dshot_beacon_unittest.cc
+++ b/src/test/unit/beeper_dshot_beacon_unittest.cc
@@ -82,10 +82,11 @@ extern "C" {
 
 #include "gtest/gtest.h"
 
-// Helper: run beeperUpdate() enough times to advance through a full beep sequence
-// starting from beeperIsOn==0 so the DShot block fires.
-static void runBeeperUpdate(timeUs_t timeUs) {
-    beeperUpdate(timeUs);
+// Helper: run beeperUpdate() several times to advance through a full beep sequence.
+// Multiple iterations guard against future changes to beeperSilence() that might
+// leave beeperIsOn in an unexpected state on the first tick.
+static void runBeeperUpdate(timeUs_t timeUs, int iterations = 3) {
+    for (int i = 0; i < iterations; ++i) beeperUpdate(timeUs);
 }
 
 class DshotBeaconPriorityTest : public ::testing::Test {


### PR DESCRIPTION
AI Generated pull-request

## Summary

\`BEEPER_RX_SET\` (manual beeper AUX switch, priority 9) is lower priority
than \`BEEPER_BAT_CRIT_LOW\` (6) and \`BEEPER_BAT_LOW\` (7) in the beeper
priority table. When a low-battery alarm is active it wins arbitration and
\`currentBeeperEntry->mode\` is never \`BEEPER_RX_SET\`, so the DShot motor
beacon never fires — a downed model with a dead battery cannot be found by
its motors even with the beeper switch held on.

\`BEEPER_RX_LOST\` (priority 1) was already immune to this. Only \`RX_SET\`
was affected.

**Fix**: add \`dshotBeaconPendingMode\` — a static set in \`beeper()\` whenever
\`BEEPER_RX_SET\` or \`BEEPER_RX_LOST\` is called, **before** the priority
arbitration early-return, independently of which entry wins buzzer priority.
\`beeperUpdate()\` reads and clears this each cycle; the DShot motor-tone block
uses it instead of \`currentBeeperEntry->mode\`. \`beeperSilence()\` also clears
it so an explicit silence cannot leave a stale beacon pending.

The physical buzzer still plays the highest-priority alarm (battery warning
continues to sound). Only the motor beacon output is decoupled from buzzer
priority. All existing guards are unchanged: \`!areMotorsRunning()\`, 1.2 s
disarm guard, \`!isTryingToArm()\`, \`dshotBeaconOffFlags\`.

BF 4.5-maintenance has the same priority-crowding behaviour (RX_SET=10,
BAT_CRIT_LOW=7, BAT_LOW=8) with no equivalent fix.

## Test plan
- [x] Build passes: \`HELIOSPRING\` (F4, DShot)
- [x] Unit tests pass: \`make test\` — 8 cases in \`beeper_dshot_beacon_unittest\`
  covering the key regression, both alarm variants, all three safety guards,
  and \`beeperSilence()\` clearing the pending mode
- [ ] Hardware verified on HELIOSPRING: DShot motor beacon fires while
      battery alarm is active and beeper AUX switch is on

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Motor beacon coordination: DShot motor beacon tones now emit independently from the buzzer system, ensuring motor feedback remains available even when high-priority alarms override the buzzer during critical alerts and alarm conditions.

* **Tests**
  * Added unit tests validating motor beacon behavior under alarm arbitration, including safety guards and edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->