### PR TITLE
fix: crashflip/turtle broken when 3D feature enabled but disabled via switch

### DIFF
--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -287,7 +287,8 @@ void disarm(void) {
 #endif
         BEEP_OFF;
 #ifdef USE_DSHOT
-        if (isMotorProtocolDshot() && flipOverAfterCrashMode && !feature(FEATURE_3D)) {
+        if (isMotorProtocolDshot() && flipOverAfterCrashMode &&
+            (!feature(FEATURE_3D) || IS_RC_MODE_ACTIVE(BOX3D) || flight3DConfig()->switched_mode3d)) {
             pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, false);
         }
 #endif
@@ -323,7 +324,7 @@ void tryArm(void) {
         if (isMotorProtocolDshot() && isModeActivationConditionPresent(BOXFLIPOVERAFTERCRASH)) {
             if (!(IS_RC_MODE_ACTIVE(BOXFLIPOVERAFTERCRASH) || (tryingToArm == ARMING_DELAYED_CRASHFLIP))) {
                 flipOverAfterCrashMode = false;
-                if (!feature(FEATURE_3D)) {
+                if (!feature(FEATURE_3D) || IS_RC_MODE_ACTIVE(BOX3D) || flight3DConfig()->switched_mode3d) {
                     pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_NORMAL, false);
                 }
             } else {
@@ -331,7 +332,7 @@ void tryArm(void) {
 #ifdef USE_RUNAWAY_TAKEOFF
                 runawayTakeoffCheckDisabled = false;
 #endif
-                if (!feature(FEATURE_3D)) {
+                if (!feature(FEATURE_3D) || IS_RC_MODE_ACTIVE(BOX3D) || flight3DConfig()->switched_mode3d) {
                     pwmWriteDshotCommand(ALL_MOTORS, getMotorCount(), DSHOT_CMD_SPIN_DIRECTION_REVERSED, false);
                 }
             }


### PR DESCRIPTION
AI Generated pull-request

Closes #1279

## Summary
- \`disarm()\` and \`tryArm()\` guarded DSHOT \`SPIN_DIRECTION_REVERSED\` / \`SPIN_DIRECTION_NORMAL\`
  commands with \`!feature(FEATURE_3D)\`, which is \`false\` whenever 3D is enabled in config —
  even if the user has switched 3D off via the \`BOX3D\` box or \`switched_mode3d\`.
- Result: turtle/crashflip silently fails to reverse motor direction on any craft with 3D
  enabled but currently running unidirectional.
- Fix replaces the guard with the De Morgan complement of the codebase-standard
  "3D is truly bidirectional" check already used in \`calculateThrottlePercent()\` and elsewhere:
  \`!feature(FEATURE_3D) || IS_RC_MODE_ACTIVE(BOX3D) || flight3DConfig()->switched_mode3d\`
- Three guards patched in \`fc_core.c\`: one in \`disarm()\`, two in \`tryArm()\`.

## Test plan
- [x] Build passes: HELIOSPRING
- [ ] Hardware verified: pending (HELIOSPRING / FOXEERF722V4 — requires 3D+turtle test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved "flip over after crash" motor control behavior for 3D flight mode scenarios, ensuring proper spin-direction handling during both arming and disarming when 3D mode is active or engaged via the mode switch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->