### PR TITLE
fix(msp): drain TX and clear pendingRequest before CLI entry

### DIFF
--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -383,6 +383,8 @@ static void mspProcessPendingRequest(mspPort_t * mspPort) {
         break;
 #ifdef USE_CLI
     case MSP_PENDING_CLI:
+        mspPort->pendingRequest = MSP_PENDING_NONE;
+        waitForSerialPortToFinishTransmitting(mspPort->port);
         cliEnter(mspPort->port);
         break;
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary

- In \`mspProcessPendingRequest\`, when \`MSP_PENDING_CLI\` fires after the 100 ms guard, the port's \`pendingRequest\` was not cleared before calling \`cliEnter()\`. Added \`mspPort->pendingRequest = MSP_PENDING_NONE\` first (matches BF 4.5-m).
- Added \`waitForSerialPortToFinishTransmitting(mspPort->port)\` before \`cliEnter()\` so all queued MSP response bytes in the TX buffer drain completely before the CLI welcome message is enqueued. This eliminates interleaving of MSP frames with the "Entering CLI Mode" string in the serial stream.
- Observable effect: reduces MSP binary noise visible in the CLI tab on initial connection from several full BOXNAMES frames down to at most one small residual frame. Full elimination of display garbage requires the companion EmuConfigurator fix (PR emuflight/EmuConfigurator#613).

## Test plan

- [x] Build passes: HELIOSPRING (F405)
- [ ] Build passes: FOXEERF722V4, STELLARH7DEV
- [x] Hardware verified: HELIOSPRING — reduced CLI init noise confirmed
- [ ] Hardware verified: FOXEERF722V4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with CLI mode entry via serial port to ensure proper state management and transmission completion before entering command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->