### PR TITLE
build: pass/fail summary after multi-target make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ CLEAN_ARTIFACTS += $(TARGET_LST)
 # Rebuild version.o whenever any source changes so the embedded timestamp stays current
 $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
-.PHONY: clean clean_test clean_all all_clean binary_hex build_summary_init build_summary
+.PHONY: clean clean_test clean_all all_clean binary_hex
 
 BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
@@ -371,9 +371,17 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S | $$(dir $$@)
 ## all               : Build all targets (excluding unsupported); prints pass/fail summary
 ##                     pass -k to continue on failure; summary always printed
 all supported:
-	@$(MAKE) build_summary_init
+	@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
 	-@$(MAKE) $(SUPPORTED_TARGETS)
-	@$(MAKE) build_summary
+	@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
+	failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
+	echo ""; \
+	echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
+	if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; then \
+		echo "Failed targets:"; \
+		cat $(BUILD_SUMMARY_FAILED); \
+	fi; \
+	[ "$$failed" -eq 0 ]
 
 ## all_with_unsupported : Build all targets (including unsupported)
 all_with_unsupported: $(VALID_TARGETS)
@@ -428,19 +436,6 @@ $(VALID_TARGETS):
 		exit 1; \
 	fi
 
-build_summary_init:
-	@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
-
-build_summary:
-	@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
-	failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
-	echo ""; \
-	echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
-	if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; then \
-		echo "Failed targets:"; \
-		cat $(BUILD_SUMMARY_FAILED); \
-	fi; \
-	[ "$$failed" -eq 0 ]
 
 $(NOBUILD_TARGETS):
 	$(MAKE) TARGET=$@

--- a/Makefile
+++ b/Makefile
@@ -499,7 +499,7 @@ $(firstword $(MAKECMDGOALS)):
 else
 # Normal invocation (single target, named group, or inner sub-make).
 $(VALID_TARGETS):
-	$(V0) echo "Building $@"; \
+	@echo "Building $@"; \
 	if $(MAKE) binary_hex TARGET=$@; then \
 		echo "Building $@ succeeded."; \
 		echo "$@" >> $(BUILD_SUMMARY_PASSED); \

--- a/Makefile
+++ b/Makefile
@@ -310,8 +310,9 @@ $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
 .PHONY: clean clean_test clean_all all_clean binary_hex build_summary_init build_summary
 
-BUILD_SUMMARY_PASSED := $(BIN_DIR)/.build_passed
-BUILD_SUMMARY_FAILED := $(BIN_DIR)/.build_failed
+BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
+BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
+BUILD_SUMMARY_FAIL_LIST_MAX ?= 10
 
 # Build each output directory once, not once-per-file, for parallel-safe compilation
 $(TARGET_DIRS):
@@ -368,7 +369,11 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S | $$(dir $$@)
 
 
 ## all               : Build all targets (excluding unsupported); prints pass/fail summary
-all supported: build_summary
+##                     pass -k to continue on failure; summary always printed
+all supported:
+	@$(MAKE) build_summary_init
+	-@$(MAKE) $(SUPPORTED_TARGETS)
+	@$(MAKE) build_summary
 
 ## all_with_unsupported : Build all targets (including unsupported)
 all_with_unsupported: $(VALID_TARGETS)
@@ -412,8 +417,6 @@ targets-group-11: $(GROUP_11_TARGETS)
 ## targets-group-rest: build the rest of the targets (not listed in groups 1-11)
 targets-group-rest: $(GROUP_OTHER_TARGETS)
 
-$(SUPPORTED_TARGETS): | build_summary_init
-
 $(VALID_TARGETS):
 	$(V0) @echo "Building $@"; \
 	if $(MAKE) binary_hex TARGET=$@; then \
@@ -422,17 +425,18 @@ $(VALID_TARGETS):
 	else \
 		echo "Building $@ FAILED."; \
 		echo "$@" >> $(BUILD_SUMMARY_FAILED); \
+		exit 1; \
 	fi
 
 build_summary_init:
 	@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
 
-build_summary: $(SUPPORTED_TARGETS)
+build_summary:
 	@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
 	failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
 	echo ""; \
 	echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
-	if [ "$$failed" -gt 0 ] && [ "$$failed" -le 10 ]; then \
+	if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; then \
 		echo "Failed targets:"; \
 		cat $(BUILD_SUMMARY_FAILED); \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -312,14 +312,15 @@ $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
 BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
-BUILD_SUMMARY_FAIL_LIST_MAX ?= 10
 
 # Detect direct multi-target invocations: `make T1 T2 T3`.
-# When 2+ of the MAKECMDGOALS are VALID_TARGETS, set IN_SUMMARY_OUTER so the
-# build graph is restructured (_auto_summary does the real work; individual
-# targets become no-ops).  Unknown goals are silenced in the outer make and
-# reported via the inner make's exit code so the overall exit is still non-zero.
-# IN_SUMMARY_BUILD is the recursion guard passed to sub-makes.
+# When 2+ goals are on the command line and at least 1 is a valid target,
+# set IN_SUMMARY_OUTER to restructure the build graph: all goals become
+# no-ops that depend on _auto_summary, which does the real work via a
+# sub-make.  Unknown goals (e.g. typos) are passed through to the sub-make
+# where "no rule to make target" is reported; _exit captures that non-zero
+# code so the outer make exits non-zero too.
+# IN_SUMMARY_BUILD=1 is the recursion guard passed to sub-makes.
 ifndef IN_SUMMARY_BUILD
 _DIRECT_VALID := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
 ifneq ($(words $(MAKECMDGOALS)), 0)
@@ -335,8 +336,9 @@ endif
 # Run TARGET_LIST through make (inheriting -k/-j from MAKEFLAGS), then print
 # a pass/fail summary.  Always runs the report even when targets fail.
 # IN_SUMMARY_BUILD=1 guards the sub-make from triggering IN_SUMMARY_OUTER.
-# _exit captures the inner make exit code (non-zero for recipe failures AND
-# for "no rule to make target" errors from unknown goals).
+# _exit captures the inner make exit code — non-zero for both recipe
+# failures (tracked via markers) and "no rule to make target" errors from
+# unknown goals (not written to any marker but still cause exit != 0).
 define summary_build
 @rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
 @_exit=0; \
@@ -345,7 +347,7 @@ passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
 failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
 echo ""; \
 echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
-if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; then \
+if [ "$$failed" -gt 0 ]; then \
 	echo "Failed targets:"; \
 	cat $(BUILD_SUMMARY_FAILED); \
 fi; \
@@ -469,24 +471,16 @@ targets-group-rest:
 
 ifdef IN_SUMMARY_OUTER
 # Outer intercepted invocation: real work happens inside _auto_summary's
-# sub-make; individual target recipes are no-ops to avoid double-building.
-# Unknown goals are also made no-ops here so make doesn't emit a second
-# "no rule" error — the inner make already reported it and _exit captures it.
-_INVALID_GOALS := $(filter-out $(VALID_TARGETS), $(MAKECMDGOALS))
-
+# sub-make.  Every command-line goal (valid or not) becomes a no-op that
+# depends on _auto_summary, so if _auto_summary exits non-zero ALL goals
+# fail and make exits non-zero.  Unknown goals are silenced here; the inner
+# make reports the "no rule" error and _exit propagates it.
 .PHONY: _auto_summary
 _auto_summary:
 	$(call summary_build,$(MAKECMDGOALS))
 
-$(firstword $(MAKECMDGOALS)): _auto_summary
-
-$(VALID_TARGETS):
+$(MAKECMDGOALS): _auto_summary
 	@:
-
-ifneq ($(_INVALID_GOALS),)
-$(_INVALID_GOALS):
-	@:
-endif
 
 else
 # Normal invocation (single target, named group, or inner sub-make).

--- a/Makefile
+++ b/Makefile
@@ -430,6 +430,9 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S | $$(dir $$@)
 	$(V1) $(CROSS_CC) -c -o $@ $(ASFLAGS) $<
 
 
+# Note: invoking multiple group targets in one command (e.g. make all targets-group-1)
+# is not detected and may result in overlapping parallel builds and failures.
+
 ## all               : Build all targets (excluding unsupported); prints pass/fail summary
 ##                     pass -k to continue on failure; summary always printed
 all supported:

--- a/Makefile
+++ b/Makefile
@@ -314,16 +314,17 @@ BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 BUILD_SUMMARY_FAIL_LIST_MAX ?= 10
 
-# Detect direct multi-valid-target invocations: `make T1 T2 T3`.
-# When all MAKECMDGOALS are VALID_TARGETS and there are 2+, set IN_SUMMARY_OUTER
-# so the build graph can be restructured (targets become no-ops; _auto_summary
-# does the real work).  IN_SUMMARY_BUILD is the recursion guard passed to the
-# sub-make so that inner invocations skip this block and run real recipes.
+# Detect direct multi-target invocations: `make T1 T2 T3`.
+# When 2+ of the MAKECMDGOALS are VALID_TARGETS, set IN_SUMMARY_OUTER so the
+# build graph is restructured (_auto_summary does the real work; individual
+# targets become no-ops).  Unknown goals are silenced in the outer make and
+# reported via the inner make's exit code so the overall exit is still non-zero.
+# IN_SUMMARY_BUILD is the recursion guard passed to sub-makes.
 ifndef IN_SUMMARY_BUILD
 _DIRECT_VALID := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
-ifeq ($(words $(_DIRECT_VALID)), $(words $(MAKECMDGOALS)))
-ifneq ($(words $(MAKECMDGOALS)), 1)
 ifneq ($(words $(MAKECMDGOALS)), 0)
+ifneq ($(words $(MAKECMDGOALS)), 1)
+ifneq ($(words $(_DIRECT_VALID)), 0)
 IN_SUMMARY_OUTER := 1
 endif
 endif
@@ -334,10 +335,13 @@ endif
 # Run TARGET_LIST through make (inheriting -k/-j from MAKEFLAGS), then print
 # a pass/fail summary.  Always runs the report even when targets fail.
 # IN_SUMMARY_BUILD=1 guards the sub-make from triggering IN_SUMMARY_OUTER.
+# _exit captures the inner make exit code (non-zero for recipe failures AND
+# for "no rule to make target" errors from unknown goals).
 define summary_build
 @rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
--@$(MAKE) IN_SUMMARY_BUILD=1 $(1)
-@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
+@_exit=0; \
+$(MAKE) IN_SUMMARY_BUILD=1 $(1) || _exit=$$?; \
+passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
 failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
 echo ""; \
 echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
@@ -345,7 +349,7 @@ if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; th
 	echo "Failed targets:"; \
 	cat $(BUILD_SUMMARY_FAILED); \
 fi; \
-[ "$$failed" -eq 0 ]
+[ "$$_exit" -eq 0 ] && [ "$$failed" -eq 0 ]
 endef
 
 # Build each output directory once, not once-per-file, for parallel-safe compilation
@@ -466,14 +470,23 @@ targets-group-rest:
 ifdef IN_SUMMARY_OUTER
 # Outer intercepted invocation: real work happens inside _auto_summary's
 # sub-make; individual target recipes are no-ops to avoid double-building.
+# Unknown goals are also made no-ops here so make doesn't emit a second
+# "no rule" error — the inner make already reported it and _exit captures it.
+_INVALID_GOALS := $(filter-out $(VALID_TARGETS), $(MAKECMDGOALS))
+
 .PHONY: _auto_summary
 _auto_summary:
-	$(call summary_build,$(_DIRECT_VALID))
+	$(call summary_build,$(MAKECMDGOALS))
 
 $(firstword $(MAKECMDGOALS)): _auto_summary
 
 $(VALID_TARGETS):
 	@:
+
+ifneq ($(_INVALID_GOALS),)
+$(_INVALID_GOALS):
+	@:
+endif
 
 else
 # Normal invocation (single target, named group, or inner sub-make).

--- a/Makefile
+++ b/Makefile
@@ -470,18 +470,18 @@ targets-group-rest:
 	$(call summary_build,$(GROUP_OTHER_TARGETS))
 
 ifdef IN_SUMMARY_OUTER
-# Outer intercepted invocation: real work happens inside _auto_summary's
-# sub-make.  Every command-line goal (valid or not) becomes a no-op that
-# depends on _auto_summary.  Goals must be declared .PHONY so that GNU Make
-# propagates _auto_summary's failure through to the outer make's exit code;
-# non-phony targets with @: recipes are silently considered "up to date" and
-# do not cause a non-zero exit even when a prerequisite failed (Make 4.4+).
-.PHONY: _auto_summary $(MAKECMDGOALS)
-_auto_summary:
-	$(call summary_build,$(MAKECMDGOALS))
+# Outer intercepted invocation: real work happens in the first goal's recipe.
+# Remaining goals are @: no-ops so make doesn't error on unknown targets.
+# summary_build exits non-zero on any failure, which causes the first goal's
+# recipe to fail — make reliably propagates a goal's own recipe failure to
+# the outer exit code (unlike prerequisite failure propagation in Make 4.4+).
+.PHONY: $(MAKECMDGOALS)
 
-$(MAKECMDGOALS): _auto_summary
+$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)):
 	@:
+
+$(firstword $(MAKECMDGOALS)):
+	$(call summary_build,$(MAKECMDGOALS))
 
 else
 # Normal invocation (single target, named group, or inner sub-make).

--- a/Makefile
+++ b/Makefile
@@ -314,42 +314,52 @@ BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 
 # Detect direct multi-target invocations: `make T1 T2 T3`.
-# When 2+ goals are on the command line and at least 1 is a valid target,
+# When 2+ goals are on the command line, at least 1 is a valid target,
+# AND no goal is a known non-build target (clean, test, etc.),
 # set IN_SUMMARY_OUTER to restructure the build graph: all goals become
-# no-ops that depend on _auto_summary, which does the real work via a
-# sub-make.  Unknown goals (e.g. typos) are passed through to the sub-make
-# where "no rule to make target" is reported; _exit captures that non-zero
-# code so the outer make exits non-zero too.
+# no-ops, the first goal's recipe runs summary_build (which does the real
+# work via a sub-make).  Unknown goals (e.g. typos) are passed through to
+# the sub-make where "no rule to make target" is reported; they are also
+# pre-populated into the failed marker so they appear in the summary count.
 # IN_SUMMARY_BUILD=1 is the recursion guard passed to sub-makes.
 ifndef IN_SUMMARY_BUILD
-_DIRECT_VALID := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
+_DIRECT_VALID       := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
+_SUMMARY_SKIP_GOALS := clean clean_test clean_all all_clean binary_hex test $(NOBUILD_TARGETS)
+_DIRECT_NON_BUILD   := $(filter $(_SUMMARY_SKIP_GOALS), $(MAKECMDGOALS))
 ifneq ($(words $(MAKECMDGOALS)), 0)
 ifneq ($(words $(MAKECMDGOALS)), 1)
 ifneq ($(words $(_DIRECT_VALID)), 0)
+ifeq ($(_DIRECT_NON_BUILD),)
 IN_SUMMARY_OUTER := 1
 endif
 endif
 endif
 endif
+endif
 
-# $(call summary_build, TARGET_LIST)
-# Run TARGET_LIST through make (inheriting -k/-j from MAKEFLAGS), then print
-# a pass/fail summary.  Always runs the report even when targets fail.
-# IN_SUMMARY_BUILD=1 guards the sub-make from triggering IN_SUMMARY_OUTER.
-# _exit captures the inner make exit code — non-zero for both recipe
-# failures (tracked via markers) and "no rule to make target" errors from
-# unknown goals (not written to any marker but still cause exit != 0).
+# $(call summary_build, TARGET_LIST[, INVALID_GOALS])
+# $(1) TARGET_LIST    — targets forwarded to the sub-make.
+# $(2) INVALID_GOALS  — goals with no rule; pre-populated into the failed
+#         marker so they appear in the summary count.
+# Marker files live in a per-invocation mktemp directory — avoids collisions
+# when concurrent `make` invocations run in parallel (e.g. in CI).
+# _exit captures the inner make exit code — non-zero for recipe failures
+# (tracked via markers) and "no rule to make target" errors (not in markers).
 define summary_build
-@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
-@_exit=0; \
-$(MAKE) IN_SUMMARY_BUILD=1 $(1) || _exit=$$?; \
-passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
-failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
+@mkdir -p $(BIN_DIR); \
+_sumdir=$$(mktemp -d "$(BIN_DIR)/.build_summary.XXXXXX"); \
+trap 'rm -rf "$$_sumdir"' EXIT; \
+_passed="$$_sumdir/passed"; \
+_failed="$$_sumdir/failed"; \
+$(foreach t,$(2),echo "$(t)" >> "$$_failed"; )_exit=0; \
+$(MAKE) IN_SUMMARY_BUILD=1 BUILD_SUMMARY_PASSED="$$_passed" BUILD_SUMMARY_FAILED="$$_failed" $(1) || _exit=$$?; \
+passed=$$(cat "$$_passed" 2>/dev/null | wc -l); \
+failed=$$(cat "$$_failed" 2>/dev/null | wc -l); \
 echo ""; \
 echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
 if [ "$$failed" -gt 0 ]; then \
 	echo "Failed targets:"; \
-	cat $(BUILD_SUMMARY_FAILED); \
+	cat "$$_failed"; \
 fi; \
 [ "$$_exit" -eq 0 ] && [ "$$failed" -eq 0 ]
 endef
@@ -475,18 +485,21 @@ ifdef IN_SUMMARY_OUTER
 # summary_build exits non-zero on any failure, which causes the first goal's
 # recipe to fail — make reliably propagates a goal's own recipe failure to
 # the outer exit code (unlike prerequisite failure propagation in Make 4.4+).
+# _INVALID_GOALS are pre-populated into the failed marker so they appear in
+# the summary count even though they produce no marker entry themselves.
+_INVALID_GOALS := $(filter-out $(VALID_TARGETS), $(MAKECMDGOALS))
 .PHONY: $(MAKECMDGOALS)
 
 $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)):
 	@:
 
 $(firstword $(MAKECMDGOALS)):
-	$(call summary_build,$(MAKECMDGOALS))
+	$(call summary_build,$(MAKECMDGOALS),$(_INVALID_GOALS))
 
 else
 # Normal invocation (single target, named group, or inner sub-make).
 $(VALID_TARGETS):
-	$(V0) @echo "Building $@"; \
+	$(V0) echo "Building $@"; \
 	if $(MAKE) binary_hex TARGET=$@; then \
 		echo "Building $@ succeeded."; \
 		echo "$@" >> $(BUILD_SUMMARY_PASSED); \

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,9 @@ BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 ifndef IN_SUMMARY_BUILD
 _DIRECT_VALID       := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
 _SUMMARY_SKIP_GOALS := $(SUMMARY_PHONY_GOALS) $(NOBUILD_TARGETS)
-_DIRECT_NON_BUILD   := $(filter $(_SUMMARY_SKIP_GOALS), $(MAKECMDGOALS))
+# clean_% and %_clean are per-target clean aliases (not in SUMMARY_PHONY_GOALS).
+# $(filter) supports % wildcards, so these patterns match clean_HELIOSPRING etc.
+_DIRECT_NON_BUILD   := $(filter $(_SUMMARY_SKIP_GOALS) clean_% %_clean, $(MAKECMDGOALS))
 ifneq ($(words $(MAKECMDGOALS)), 0)
 ifneq ($(words $(MAKECMDGOALS)), 1)
 ifneq ($(words $(_DIRECT_VALID)), 0)
@@ -504,6 +506,11 @@ ifdef IN_SUMMARY_OUTER
 # the outer exit code (unlike prerequisite failure propagation in Make 4.4+).
 # _INVALID_GOALS are pre-populated into the failed marker so they appear in
 # the summary count even though they produce no marker entry themselves.
+# Only valid goals are forwarded to the inner make — invalid goals are
+# pre-counted in the failed marker and do not need to reach the sub-make.
+# Forwarding them caused the inner make to stop on the first bad goal
+# (without -k) before building the valid targets that followed it.
+_VALID_GOALS   := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
 _INVALID_GOALS := $(filter-out $(VALID_TARGETS), $(MAKECMDGOALS))
 .PHONY: $(MAKECMDGOALS)
 
@@ -511,7 +518,7 @@ $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)):
 	@:
 
 $(firstword $(MAKECMDGOALS)):
-	$(call summary_build,$(MAKECMDGOALS),$(_INVALID_GOALS))
+	$(call summary_build,$(_VALID_GOALS),$(_INVALID_GOALS))
 
 else
 # Normal invocation: named group, inner sub-make, or direct single target.

--- a/Makefile
+++ b/Makefile
@@ -314,12 +314,29 @@ BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 BUILD_SUMMARY_FAIL_LIST_MAX ?= 10
 
+# Detect direct multi-valid-target invocations: `make T1 T2 T3`.
+# When all MAKECMDGOALS are VALID_TARGETS and there are 2+, set IN_SUMMARY_OUTER
+# so the build graph can be restructured (targets become no-ops; _auto_summary
+# does the real work).  IN_SUMMARY_BUILD is the recursion guard passed to the
+# sub-make so that inner invocations skip this block and run real recipes.
+ifndef IN_SUMMARY_BUILD
+_DIRECT_VALID := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
+ifeq ($(words $(_DIRECT_VALID)), $(words $(MAKECMDGOALS)))
+ifneq ($(words $(MAKECMDGOALS)), 1)
+ifneq ($(words $(MAKECMDGOALS)), 0)
+IN_SUMMARY_OUTER := 1
+endif
+endif
+endif
+endif
+
 # $(call summary_build, TARGET_LIST)
 # Run TARGET_LIST through make (inheriting -k/-j from MAKEFLAGS), then print
 # a pass/fail summary.  Always runs the report even when targets fail.
+# IN_SUMMARY_BUILD=1 guards the sub-make from triggering IN_SUMMARY_OUTER.
 define summary_build
 @rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
--@$(MAKE) $(1)
+-@$(MAKE) IN_SUMMARY_BUILD=1 $(1)
 @passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
 failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
 echo ""; \
@@ -446,6 +463,20 @@ targets-group-11:
 targets-group-rest:
 	$(call summary_build,$(GROUP_OTHER_TARGETS))
 
+ifdef IN_SUMMARY_OUTER
+# Outer intercepted invocation: real work happens inside _auto_summary's
+# sub-make; individual target recipes are no-ops to avoid double-building.
+.PHONY: _auto_summary
+_auto_summary:
+	$(call summary_build,$(_DIRECT_VALID))
+
+$(firstword $(MAKECMDGOALS)): _auto_summary
+
+$(VALID_TARGETS):
+	@:
+
+else
+# Normal invocation (single target, named group, or inner sub-make).
 $(VALID_TARGETS):
 	$(V0) @echo "Building $@"; \
 	if $(MAKE) binary_hex TARGET=$@; then \
@@ -456,6 +487,7 @@ $(VALID_TARGETS):
 		echo "$@" >> $(BUILD_SUMMARY_FAILED); \
 		exit 1; \
 	fi
+endif
 
 
 $(NOBUILD_TARGETS):

--- a/Makefile
+++ b/Makefile
@@ -472,10 +472,11 @@ targets-group-rest:
 ifdef IN_SUMMARY_OUTER
 # Outer intercepted invocation: real work happens inside _auto_summary's
 # sub-make.  Every command-line goal (valid or not) becomes a no-op that
-# depends on _auto_summary, so if _auto_summary exits non-zero ALL goals
-# fail and make exits non-zero.  Unknown goals are silenced here; the inner
-# make reports the "no rule" error and _exit propagates it.
-.PHONY: _auto_summary
+# depends on _auto_summary.  Goals must be declared .PHONY so that GNU Make
+# propagates _auto_summary's failure through to the outer make's exit code;
+# non-phony targets with @: recipes are silently considered "up to date" and
+# do not cause a non-zero exit even when a prerequisite failed (Make 4.4+).
+.PHONY: _auto_summary $(MAKECMDGOALS)
 _auto_summary:
 	$(call summary_build,$(MAKECMDGOALS))
 

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,10 @@ CLEAN_ARTIFACTS += $(TARGET_LST)
 # Rebuild version.o whenever any source changes so the embedded timestamp stays current
 $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
-.PHONY: clean clean_test clean_all all_clean binary_hex \
+# All known non-board phony targets.  Used as the single source of truth
+# for both .PHONY and _SUMMARY_SKIP_GOALS — add new phony targets here only.
+SUMMARY_PHONY_GOALS := \
+    clean clean_test clean_all all_clean binary_hex \
     all supported all_with_unsupported unsupported \
     targets-group-1 targets-group-2 targets-group-3 targets-group-4 \
     targets-group-5 targets-group-6 targets-group-7 targets-group-8 \
@@ -318,6 +321,8 @@ $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
     targets-f3 targets-f4 targets-f7 targets-h7 \
     cppcheck test junittest \
     check-target-independence check-fastram-usage-correctness
+
+.PHONY: $(SUMMARY_PHONY_GOALS)
 
 BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
@@ -333,10 +338,7 @@ BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 # IN_SUMMARY_BUILD=1 is the recursion guard passed to sub-makes.
 ifndef IN_SUMMARY_BUILD
 _DIRECT_VALID       := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
-# Derived from .PHONY (minus board targets) + NOBUILD_TARGETS.
-# If any of these appear in MAKECMDGOALS, IN_SUMMARY_OUTER is suppressed.
-# New phony targets are automatically covered by updating .PHONY above.
-_SUMMARY_SKIP_GOALS := $(filter-out $(VALID_TARGETS), $(.PHONY)) $(NOBUILD_TARGETS)
+_SUMMARY_SKIP_GOALS := $(SUMMARY_PHONY_GOALS) $(NOBUILD_TARGETS)
 _DIRECT_NON_BUILD   := $(filter $(_SUMMARY_SKIP_GOALS), $(MAKECMDGOALS))
 ifneq ($(words $(MAKECMDGOALS)), 0)
 ifneq ($(words $(MAKECMDGOALS)), 1)

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,16 @@ CLEAN_ARTIFACTS += $(TARGET_LST)
 # Rebuild version.o whenever any source changes so the embedded timestamp stays current
 $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
-.PHONY: clean clean_test clean_all all_clean binary_hex
+.PHONY: clean clean_test clean_all all_clean binary_hex \
+    all supported all_with_unsupported unsupported \
+    targets-group-1 targets-group-2 targets-group-3 targets-group-4 \
+    targets-group-5 targets-group-6 targets-group-7 targets-group-8 \
+    targets-group-9 targets-group-10 targets-group-11 targets-group-rest \
+    flash st-flash binary hex unbrick openocd-gdb \
+    version help targets target-mcu targets-by-mcu \
+    targets-f3 targets-f4 targets-f7 targets-h7 \
+    cppcheck test junittest \
+    check-target-independence check-fastram-usage-correctness
 
 BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
@@ -324,18 +333,10 @@ BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 # IN_SUMMARY_BUILD=1 is the recursion guard passed to sub-makes.
 ifndef IN_SUMMARY_BUILD
 _DIRECT_VALID       := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
-# All known non-board-build targets.  If any appear in MAKECMDGOALS,
-# IN_SUMMARY_OUTER is suppressed so make handles them normally.
-_SUMMARY_SKIP_GOALS := \
-    clean clean_test clean_all all_clean binary_hex test \
-    all supported all_with_unsupported unsupported \
-    targets-group-1 targets-group-2 targets-group-3 targets-group-4 \
-    targets-group-5 targets-group-6 targets-group-7 targets-group-8 \
-    targets-group-9 targets-group-10 targets-group-11 targets-group-rest \
-    flash st-flash binary hex unbrick version help targets \
-    target-mcu targets-by-mcu cppcheck \
-    check-target-independence check-fastram-usage-correctness \
-    $(NOBUILD_TARGETS)
+# Derived from .PHONY (minus board targets) + NOBUILD_TARGETS.
+# If any of these appear in MAKECMDGOALS, IN_SUMMARY_OUTER is suppressed.
+# New phony targets are automatically covered by updating .PHONY above.
+_SUMMARY_SKIP_GOALS := $(filter-out $(VALID_TARGETS), $(.PHONY)) $(NOBUILD_TARGETS)
 _DIRECT_NON_BUILD   := $(filter $(_SUMMARY_SKIP_GOALS), $(MAKECMDGOALS))
 ifneq ($(words $(MAKECMDGOALS)), 0)
 ifneq ($(words $(MAKECMDGOALS)), 1)

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,10 @@ CLEAN_ARTIFACTS += $(TARGET_LST)
 # Rebuild version.o whenever any source changes so the embedded timestamp stays current
 $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
 
-.PHONY: clean clean_test clean_all all_clean binary_hex
+.PHONY: clean clean_test clean_all all_clean binary_hex build_summary_init build_summary
+
+BUILD_SUMMARY_PASSED := $(BIN_DIR)/.build_passed
+BUILD_SUMMARY_FAILED := $(BIN_DIR)/.build_failed
 
 # Build each output directory once, not once-per-file, for parallel-safe compilation
 $(TARGET_DIRS):
@@ -364,8 +367,8 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S | $$(dir $$@)
 	$(V1) $(CROSS_CC) -c -o $@ $(ASFLAGS) $<
 
 
-## all               : Build all targets (excluding unsupported)
-all supported: $(SUPPORTED_TARGETS)
+## all               : Build all targets (excluding unsupported); prints pass/fail summary
+all supported: build_summary
 
 ## all_with_unsupported : Build all targets (including unsupported)
 all_with_unsupported: $(VALID_TARGETS)
@@ -409,10 +412,31 @@ targets-group-11: $(GROUP_11_TARGETS)
 ## targets-group-rest: build the rest of the targets (not listed in groups 1-11)
 targets-group-rest: $(GROUP_OTHER_TARGETS)
 
+$(SUPPORTED_TARGETS): | build_summary_init
+
 $(VALID_TARGETS):
-	$(V0) @echo "Building $@" && \
-	$(MAKE) binary_hex TARGET=$@ && \
-	echo "Building $@ succeeded."
+	$(V0) @echo "Building $@"; \
+	if $(MAKE) binary_hex TARGET=$@; then \
+		echo "Building $@ succeeded."; \
+		echo "$@" >> $(BUILD_SUMMARY_PASSED); \
+	else \
+		echo "Building $@ FAILED."; \
+		echo "$@" >> $(BUILD_SUMMARY_FAILED); \
+	fi
+
+build_summary_init:
+	@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
+
+build_summary: $(SUPPORTED_TARGETS)
+	@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
+	failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
+	echo ""; \
+	echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
+	if [ "$$failed" -gt 0 ] && [ "$$failed" -le 10 ]; then \
+		echo "Failed targets:"; \
+		cat $(BUILD_SUMMARY_FAILED); \
+	fi; \
+	[ "$$failed" -eq 0 ]
 
 $(NOBUILD_TARGETS):
 	$(MAKE) TARGET=$@
@@ -450,6 +474,7 @@ $(TARGETS_CLEAN):
 clean_all:
 	@echo "Cleaning all targets"
 	$(V0) rm -rf $(OBJECT_DIR)
+	$(V0) rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
 	$(V0) cd src/test && $(MAKE) clean || true
 	@echo "All targets cleaned."
 

--- a/Makefile
+++ b/Makefile
@@ -679,17 +679,14 @@ target-mcu:
 ## targets-by-mcu    : make all targets that have a MCU_TYPE mcu
 targets-by-mcu:
 	@echo "Building all $(MCU_TYPE) targets..."
-	$(V1) for target in $(VALID_TARGETS); do \
+	$(V1) _targets=""; \
+	for target in $(VALID_TARGETS); do \
 		TARGET_MCU_TYPE=$$($(MAKE) -s TARGET=$${target} target-mcu); \
 		if [ "$${TARGET_MCU_TYPE}" = "$${MCU_TYPE}" ]; then \
-			echo "Building target $${target}..."; \
-			$(MAKE) TARGET=$${target}; \
-			if [ $$? -ne 0 ]; then \
-				echo "Building target $${target} failed, aborting."; \
-				exit 1; \
-			fi; \
+			_targets="$$_targets $$target"; \
 		fi; \
-	done
+	done; \
+	[ -n "$$_targets" ] && $(MAKE) $$_targets
 
 ## targets-f3        : make all F3 targets
 targets-f3:

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,18 @@ BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 # IN_SUMMARY_BUILD=1 is the recursion guard passed to sub-makes.
 ifndef IN_SUMMARY_BUILD
 _DIRECT_VALID       := $(filter $(VALID_TARGETS), $(MAKECMDGOALS))
-_SUMMARY_SKIP_GOALS := clean clean_test clean_all all_clean binary_hex test $(NOBUILD_TARGETS)
+# All known non-board-build targets.  If any appear in MAKECMDGOALS,
+# IN_SUMMARY_OUTER is suppressed so make handles them normally.
+_SUMMARY_SKIP_GOALS := \
+    clean clean_test clean_all all_clean binary_hex test \
+    all supported all_with_unsupported unsupported \
+    targets-group-1 targets-group-2 targets-group-3 targets-group-4 \
+    targets-group-5 targets-group-6 targets-group-7 targets-group-8 \
+    targets-group-9 targets-group-10 targets-group-11 targets-group-rest \
+    flash st-flash binary hex unbrick version help targets \
+    target-mcu targets-by-mcu cppcheck \
+    check-target-independence check-fastram-usage-correctness \
+    $(NOBUILD_TARGETS)
 _DIRECT_NON_BUILD   := $(filter $(_SUMMARY_SKIP_GOALS), $(MAKECMDGOALS))
 ifneq ($(words $(MAKECMDGOALS)), 0)
 ifneq ($(words $(MAKECMDGOALS)), 1)

--- a/Makefile
+++ b/Makefile
@@ -497,7 +497,10 @@ $(firstword $(MAKECMDGOALS)):
 	$(call summary_build,$(MAKECMDGOALS),$(_INVALID_GOALS))
 
 else
-# Normal invocation (single target, named group, or inner sub-make).
+# Normal invocation: named group, inner sub-make, or direct single target.
+ifdef IN_SUMMARY_BUILD
+# Inner sub-make (called from summary_build): run the actual build and
+# record pass/fail in the per-invocation marker files.
 $(VALID_TARGETS):
 	@echo "Building $@"; \
 	if $(MAKE) binary_hex TARGET=$@; then \
@@ -508,6 +511,13 @@ $(VALID_TARGETS):
 		echo "$@" >> $(BUILD_SUMMARY_FAILED); \
 		exit 1; \
 	fi
+else
+# Direct single-target invocation: route through summary_build so output
+# format (=== Build summary: N succeeded, M failed ===) is consistent
+# with multi-target and named-group invocations.
+$(VALID_TARGETS):
+	$(call summary_build,$@)
+endif
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,23 @@ BUILD_SUMMARY_PASSED        := $(BIN_DIR)/.build_passed
 BUILD_SUMMARY_FAILED        := $(BIN_DIR)/.build_failed
 BUILD_SUMMARY_FAIL_LIST_MAX ?= 10
 
+# $(call summary_build, TARGET_LIST)
+# Run TARGET_LIST through make (inheriting -k/-j from MAKEFLAGS), then print
+# a pass/fail summary.  Always runs the report even when targets fail.
+define summary_build
+@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
+-@$(MAKE) $(1)
+@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
+failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
+echo ""; \
+echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
+if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; then \
+	echo "Failed targets:"; \
+	cat $(BUILD_SUMMARY_FAILED); \
+fi; \
+[ "$$failed" -eq 0 ]
+endef
+
 # Build each output directory once, not once-per-file, for parallel-safe compilation
 $(TARGET_DIRS):
 	@mkdir -p $@
@@ -371,59 +388,63 @@ $(OBJECT_DIR)/$(TARGET)/%.o: %.S | $$(dir $$@)
 ## all               : Build all targets (excluding unsupported); prints pass/fail summary
 ##                     pass -k to continue on failure; summary always printed
 all supported:
-	@rm -f $(BUILD_SUMMARY_PASSED) $(BUILD_SUMMARY_FAILED)
-	-@$(MAKE) $(SUPPORTED_TARGETS)
-	@passed=$$(cat $(BUILD_SUMMARY_PASSED) 2>/dev/null | wc -l); \
-	failed=$$(cat $(BUILD_SUMMARY_FAILED) 2>/dev/null | wc -l); \
-	echo ""; \
-	echo "=== Build summary: $$passed succeeded, $$failed failed ==="; \
-	if [ "$$failed" -gt 0 ] && [ "$$failed" -le $(BUILD_SUMMARY_FAIL_LIST_MAX) ]; then \
-		echo "Failed targets:"; \
-		cat $(BUILD_SUMMARY_FAILED); \
-	fi; \
-	[ "$$failed" -eq 0 ]
+	$(call summary_build,$(SUPPORTED_TARGETS))
 
 ## all_with_unsupported : Build all targets (including unsupported)
-all_with_unsupported: $(VALID_TARGETS)
+all_with_unsupported:
+	$(call summary_build,$(VALID_TARGETS))
 
 ## unsupported : Build unsupported targets
-unsupported: $(UNSUPPORTED_TARGETS)
+unsupported:
+	$(call summary_build,$(UNSUPPORTED_TARGETS))
 
 ## targets-group-1   : build some targets
-targets-group-1: $(GROUP_1_TARGETS)
+targets-group-1:
+	$(call summary_build,$(GROUP_1_TARGETS))
 
 ## targets-group-2   : build some targets
-targets-group-2: $(GROUP_2_TARGETS)
+targets-group-2:
+	$(call summary_build,$(GROUP_2_TARGETS))
 
 ## targets-group-3   : build some targets
-targets-group-3: $(GROUP_3_TARGETS)
+targets-group-3:
+	$(call summary_build,$(GROUP_3_TARGETS))
 
 ## targets-group-4   : build some targets
-targets-group-4: $(GROUP_4_TARGETS)
+targets-group-4:
+	$(call summary_build,$(GROUP_4_TARGETS))
 
 ## targets-group-5   : build some targets
-targets-group-5: $(GROUP_5_TARGETS)
+targets-group-5:
+	$(call summary_build,$(GROUP_5_TARGETS))
 
 ## targets-group-6   : build some targets
-targets-group-6: $(GROUP_6_TARGETS)
+targets-group-6:
+	$(call summary_build,$(GROUP_6_TARGETS))
 
 ## targets-group-7   : build some targets
-targets-group-7: $(GROUP_7_TARGETS)
+targets-group-7:
+	$(call summary_build,$(GROUP_7_TARGETS))
 
 ## targets-group-8   : build some targets
-targets-group-8: $(GROUP_8_TARGETS)
+targets-group-8:
+	$(call summary_build,$(GROUP_8_TARGETS))
 
 ## targets-group-9   : build some targets
-targets-group-9: $(GROUP_9_TARGETS)
+targets-group-9:
+	$(call summary_build,$(GROUP_9_TARGETS))
 
 ## targets-group-10  : build some targets
-targets-group-10: $(GROUP_10_TARGETS)
+targets-group-10:
+	$(call summary_build,$(GROUP_10_TARGETS))
 
 ## targets-group-11  : build some targets
-targets-group-11: $(GROUP_11_TARGETS)
+targets-group-11:
+	$(call summary_build,$(GROUP_11_TARGETS))
 
 ## targets-group-rest: build the rest of the targets (not listed in groups 1-11)
-targets-group-rest: $(GROUP_OTHER_TARGETS)
+targets-group-rest:
+	$(call summary_build,$(GROUP_OTHER_TARGETS))
 
 $(VALID_TARGETS):
 	$(V0) @echo "Building $@"; \


### PR DESCRIPTION
AI Generated pull-request

Closes #1287

## Summary

- Every build invocation — single-target (`make HELIOSPRING`), named-group (`make all`, `make supported`, all `targets-group-*`, `make all_with_unsupported`, `make unsupported`), and arbitrary multi-target (`make HELIOSPRING FOXEERF405`) — prints `=== Build summary: N succeeded, M failed ===` via a single `summary_build` canned recipe
- Unknown/misspelled targets (e.g. `make HELIOSPRING FOOBAR`) are counted in the failed total, listed by name, and cause a non-zero exit
- Exit code is always non-zero when any target fails or is unknown — CI-safe
- `-k` remains user-controlled; not forced by the Makefile
- Failed targets always listed (no truncation)
- Summary machinery is internal; `make build_summary` is not a user-callable target

## Implementation notes

A `define summary_build` canned recipe is the single implementation point for all
summary logic. Named-group targets call it directly; multi-target direct invocations
are intercepted at parse time via `$(MAKECMDGOALS)` and routed through it; single-target
direct invocations call it from the `$(VALID_TARGETS)` rule.

The recipe uses a per-invocation `mktemp -d` directory for marker files (concurrent-CI-safe),
pre-populates invalid goals into the failed marker before the inner make runs, and captures
the inner make exit code for "no rule to make target" errors. A `trap` ensures temp dir
cleanup on EXIT.

## Test plan

- [x] `make HELIOSPRING` (single target) — 1 succeeded, 0 failed, exit 0
- [x] `make targets-group-1 -j 48` — 39 succeeded, 0 failed, exit 0
- [x] `make HELIOSPRING FOXEERF405 FOORBAR -j 48` — 2 succeeded, 1 failed (FOORBAR listed), exit 1
- [x] `make FOOBAR` — make native "no rule" error, exit 2
- [x] `make all -j 48` — 459 succeeded, 0 failed, exit 0
- [x] Full CI across all target groups


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `make` behavior for multiple targets so results are summarized clearly instead of failing silently or inconsistently.
  * Invalid targets are now included in the final build summary, making failures easier to spot.
  * `clean_all` now clears build summary state to avoid stale results on later runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->