### PR TITLE
fix: correct ICM-20689/MPU6500 SPI initialisation sequence

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -89,6 +89,9 @@ imufData_t imufData;
 
 #define MPU_INQUIRY_MASK   0x7E
 
+// Allow 100ms before attempting to access SPI bus
+#define GYRO_SPI_STARTUP_MS 100
+
 #define GYRO_EXTI_DETECT_THRESHOLD 1000
 
 #if defined(USE_I2C) && !defined(USE_DMA_SPI_DEVICE)
@@ -367,6 +370,10 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     UNUSED(gyro); // since there are FCs which have gyro on I2C but other devices on SPI
     uint8_t sensor = MPU_NONE;
     UNUSED(sensor);
+
+    // Allow 100ms before attempting to access gyro's SPI bus
+    while (millis() < GYRO_SPI_STARTUP_MS);
+
     // note, when USE_DUAL_GYRO is enabled the gyro->dev must already be initialised.
 #ifdef USE_GYRO_SPI_MPU6000
 #ifndef USE_DUAL_GYRO

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -372,6 +372,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     UNUSED(sensor);
 
     // Allow 100ms before attempting to access gyro's SPI bus
+    // Do this once here rather than in each detection routine to speed boot
     while (millis() < GYRO_SPI_STARTUP_MS);
 
     // note, when USE_DUAL_GYRO is enabled the gyro->dev must already be initialised.

--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -89,7 +89,7 @@ imufData_t imufData;
 
 #define MPU_INQUIRY_MASK   0x7E
 
-// Allow 100ms before attempting to access SPI bus
+// Minimum system uptime (ms) before SPI bus access — boot-time guard, not a relative delay
 #define GYRO_SPI_STARTUP_MS 100
 
 #define GYRO_EXTI_DETECT_THRESHOLD 1000
@@ -371,7 +371,7 @@ static bool detectSPISensorsAndUpdateDetectionResult(gyroDev_t *gyro) {
     uint8_t sensor = MPU_NONE;
     UNUSED(sensor);
 
-    // Allow 100ms before attempting to access gyro's SPI bus
+    // Spin until system uptime reaches GYRO_SPI_STARTUP_MS; no-op if already past that point.
     // Do this once here rather than in each detection routine to speed boot
     while (millis() < GYRO_SPI_STARTUP_MS);
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -113,7 +113,7 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
     } while (attemptsRemaining--);
 
     // We now know the device is recognised so it's safe to perform device-specific register accesses
-    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_SLOW);
 
     // Disable Primary I2C Interface
     spiWriteReg(dev, MPU_RA_USER_CTRL, ICM20689_I2C_IF_DIS);
@@ -122,6 +122,7 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
     spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, ICM20689_ACCEL_RST | ICM20689_TEMP_RST);
     delay(ICM20689_PATH_RESET_DELAY_MS);
 
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
     return icmDetected;
 }
 
@@ -144,6 +145,7 @@ bool icm20689SpiAccDetect(accDev_t *acc) {
 
 void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
+    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_SLOW);
 
     // Device was already reset during detection so proceed with configuration
     spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -112,7 +112,9 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
         }
     } while (attemptsRemaining--);
 
-    // We now know the device is recognised so it's safe to perform device-specific register accesses
+    // We now know the device is recognised so it's safe to perform device-specific register accesses.
+    // ICM-20689 SPI write clock max is 8 MHz (datasheet s6.1). SPI_CLOCK_STANDARD exceeds this on
+    // F4 (~10.5 MHz) and H7 (~9 MHz); SPI_CLOCK_SLOW (~0.65 MHz) is the nearest enum within spec.
     spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_SLOW);
 
     // Disable Primary I2C Interface
@@ -147,7 +149,8 @@ void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
     spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_SLOW);
 
-    // Device was already reset during detection so proceed with configuration
+    // Device was reset and I2C_IF_DIS + SIGNAL_PATH_RESET applied during detection; proceed
+    // directly with configuration. This function assumes icm20689SpiDetect() has already run.
     spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
     delayMicroseconds(ICM20689_CLKSEL_SETTLE_US);
     spiWriteReg(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -113,8 +113,9 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
     } while (attemptsRemaining--);
 
     // We now know the device is recognised so it's safe to perform device-specific register accesses.
-    // ICM-20689 SPI write clock max is 8 MHz (datasheet s6.1). SPI_CLOCK_STANDARD exceeds this on
-    // F4 (~10.5 MHz) and H7 (~9 MHz); SPI_CLOCK_SLOW (~0.65 MHz) is the nearest enum within spec.
+    // ICM-20689 max SPI clock is 8 MHz (datasheet s6.1). SPI_CLOCK_STANDARD exceeds this on F4
+    // (~10.5 MHz) only (F7/H7 STANDARD is ~6.58 MHz, already within spec). SPI_CLOCK_SLOW (~0.65 MHz)
+    // is used uniformly across all MCUs for a single safe code path.
     spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_SLOW);
 
     // Disable Primary I2C Interface

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.c
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.c
@@ -36,6 +36,29 @@
 #include "drivers/sensor.h"
 #include "drivers/time.h"
 
+// Register 0x37 - INT_PIN_CFG
+#define ICM20689_INT_ANYRD_2CLEAR   0x10
+
+// Register 0x68 - SIGNAL_PATH_RESET
+#define ICM20689_ACCEL_RST          0x02
+#define ICM20689_TEMP_RST           0x01
+
+// Register 0x6a - USER_CTRL
+#define ICM20689_I2C_IF_DIS         0x10
+
+// Register 0x6b - PWR_MGMT_1
+#define ICM20689_BIT_RESET          0x80
+
+/* Allow CLKSEL setting time to settle when PLL is selected.
+ * Testing has shown that 60us is required, so double to allow a margin.
+ */
+#define ICM20689_CLKSEL_SETTLE_US   120
+
+/* MPU-6000 datasheet (section 4.28) suggests 100ms after a reset */
+#define ICM20689_RESET_DELAY_MS     100
+
+/* MPU-6000 datasheet (section 4.28) suggests 100ms after a path reset */
+#define ICM20689_PATH_RESET_DELAY_MS 100
 
 static void icm20689SpiInit(const extDevice_t *dev) {
     static bool hardwareInitialised = false;
@@ -53,12 +76,16 @@ static void icm20689SpiInit(const extDevice_t *dev) {
 
 uint8_t icm20689SpiDetect(const extDevice_t *dev) {
     icm20689SpiInit(dev);
-    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION); //low speed
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
+
+    // Note that the following reset is being done repeatedly by each MPU6000
+    // compatible device being probed
     spiWriteReg(dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
+
     uint8_t icmDetected = MPU_NONE;
     uint8_t attemptsRemaining = 20;
     do {
-        delay(150);
+        delay(ICM20689_RESET_DELAY_MS);
         const uint8_t whoAmI = spiReadRegMsk(dev, MPU_RA_WHO_AM_I);
         switch (whoAmI) {
         case ICM20601_WHO_AM_I_CONST:
@@ -84,7 +111,17 @@ uint8_t icm20689SpiDetect(const extDevice_t *dev) {
             return MPU_NONE;
         }
     } while (attemptsRemaining--);
+
+    // We now know the device is recognised so it's safe to perform device-specific register accesses
     spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
+
+    // Disable Primary I2C Interface
+    spiWriteReg(dev, MPU_RA_USER_CTRL, ICM20689_I2C_IF_DIS);
+
+    // Reset the device signal paths
+    spiWriteReg(dev, MPU_RA_SIGNAL_PATH_RESET, ICM20689_ACCEL_RST | ICM20689_TEMP_RST);
+    delay(ICM20689_PATH_RESET_DELAY_MS);
+
     return icmDetected;
 }
 
@@ -107,30 +144,22 @@ bool icm20689SpiAccDetect(accDev_t *acc) {
 
 void icm20689GyroInit(gyroDev_t *gyro) {
     mpuGyroInit(gyro);
-    spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
-    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, ICM20689_BIT_RESET);
-    delay(100);
-    spiWriteReg(&gyro->dev, MPU_RA_SIGNAL_PATH_RESET, 0x03);
-    delay(100);
-//    spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, 0);
-//    delay(100);
+
+    // Device was already reset during detection so proceed with configuration
     spiWriteReg(&gyro->dev, MPU_RA_PWR_MGMT_1, INV_CLK_PLL);
-    delay(15);
+    delayMicroseconds(ICM20689_CLKSEL_SETTLE_US);
     spiWriteReg(&gyro->dev, MPU_RA_GYRO_CONFIG, INV_FSR_2000DPS << 3 | mpuGyroFCHOICE(gyro));
-    delay(15);
     spiWriteReg(&gyro->dev, MPU_RA_ACCEL_CONFIG, INV_FSR_16G << 3);
-    delay(15);
     spiWriteReg(&gyro->dev, MPU_RA_CONFIG, mpuGyroDLPF(gyro));
-    delay(15);
-    spiWriteReg(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops); // Get Divider Drops
-    delay(100);
+    spiWriteReg(&gyro->dev, MPU_RA_SMPLRT_DIV, gyro->mpuDividerDrops);
+
     // Data ready interrupt configuration
-//    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0 << 7 | 0 << 6 | 0 << 5 | 1 << 4 | 0 << 3 | 0 << 2 | 0 << 1 | 0 << 0);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, 0x10);  // INT_ANYRD_2CLEAR, BYPASS_EN
-    delay(15);
+    spiWriteReg(&gyro->dev, MPU_RA_INT_PIN_CFG, ICM20689_INT_ANYRD_2CLEAR);
+
 #ifdef USE_MPU_DATA_READY_SIGNAL
-    spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, 0x01); // RAW_RDY_EN interrupt enable
+    spiWriteReg(&gyro->dev, MPU_RA_INT_ENABLE, MPU_RF_DATA_RDY_EN);
 #endif
+
     spiSetDivisor(gyro->dev.bus->busType_u.spi.instance, SPI_CLOCK_STANDARD);
 }
 

--- a/src/main/drivers/accgyro/accgyro_spi_icm20689.h
+++ b/src/main/drivers/accgyro/accgyro_spi_icm20689.h
@@ -22,8 +22,6 @@
 
 #include "drivers/bus.h"
 
-#define ICM20689_BIT_RESET                  (0x80)
-
 bool icm20689AccDetect(accDev_t *acc);
 bool icm20689GyroDetect(gyroDev_t *gyro);
 

--- a/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
+++ b/src/main/drivers/accgyro/accgyro_spi_mpu6500.c
@@ -45,7 +45,7 @@ static void mpu6500SpiInit(const extDevice_t *dev) {
     IOConfigGPIO(dev->busType_u.spi.csnPin, SPI_IO_CS_CFG);
     IOHi(dev->busType_u.spi.csnPin);
 #endif
-    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_FAST);
+    spiSetDivisor(dev->bus->busType_u.spi.instance, SPI_CLOCK_INITIALIZATION);
 }
 
 uint8_t mpu6500SpiDetect(const extDevice_t *dev) {


### PR DESCRIPTION
AI Generated pull-request

Ports BF PR #11584 (merged 2022). Fixes initialisation bugs in the ICM-20689
gyro family that could leave the device in I2C mode or corrupt reserved
registers, causing permanent yaw-axis failure across power cycles.

Credit to @SteveCEvans for the original investigation and fix in Betaflight.
Thanks to @nikybiasion and @wrych who noted EmuFlight was affected in the BF PR comments.

## Changes

**accgyro_spi_icm20689.c**
- `icm20689SpiDetect`: write `I2C_IF_DIS` and `SIGNAL_PATH_RESET` only after
  WHO_AM_I confirms device identity (datasheet section 6.1 requirement — must
  be set immediately after reset to prevent accidental I2C switch)
- `icm20689GyroInit`: remove redundant second device reset and signal-path
  write (already performed in detect); replace 15ms inter-register delays and
  100ms post-divider delay with `ICM20689_CLKSEL_SETTLE_US` (120µs) after
  clock source change only
- Add named defines for all register bits and timing constants; move
  `ICM20689_BIT_RESET` from public header to file-private .c

**accgyro_mpu.c**
- Add `GYRO_SPI_STARTUP_MS` (100ms) guard in `detectSPISensorsAndUpdateDetectionResult`
  so the SPI bus has settled before any device is probed

**accgyro_spi_mpu6500.c**
- Change `mpu6500SpiInit` clock from `SPI_CLOCK_FAST` (~20MHz) to
  `SPI_CLOCK_INITIALIZATION` — the fast clock during detection could cause
  erroneous register accesses on MPU6500-family devices

## Test plan
- [x] Build passes: SPEEDYBEEF7, YUPIF7, IFLIGHT_F722_TWING, IFLIGHT_H7_TWING, MATEKF405MINI, EXF722DUAL, FURYF7, BEEROTORF4 (ICM-20689-only targets)
- [ ] Hardware verified on an ICM-20689 board — request testing from owners of:
  - `SPEEDYBEEF7` (SpeedyBee F7 — ICM-20689 only)
  - `YUPIF7` (YupiF7 — ICM-20689 only)
  - `KAKUTEF7` / `KAKUTEF7MINI` / `KAKUTEF7HDV` (Kakute F7 v1.3 ships with ICM-20689)
  - `IFLIGHT_F722_TWING` / `IFLIGHT_H7_TWING` (iFlight Twig — ICM-20689 only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for SPI-based gyroscope detection to avoid early bus access issues.
  * Refined initialization timing for supported sensors, which should make device startup more reliable.
  * Updated SPI setup timing for one sensor model to better match initialization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->