### PR TITLE
feat(SITL): wire fake baro/mag sensors from FDM state

### DIFF
--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -114,7 +114,8 @@ void updateState(const fdm_packet* pkt) {
 
     // fake baro: derive pressure/temperature from NED altitude via ISA standard atmosphere
     const float altM = -(float)pkt->position_xyz[2]; // NED z is down; negate for altitude up
-    const int32_t pressurePa = (int32_t)(101325.0f * powf(1.0f - 2.25577e-5f * altM, 5.25588f));
+    const float baroBase = fmaxf(1.0f - 2.25577e-5f * altM, 0.0f); // avoid negative base -> NaN above ~44.3km
+    const int32_t pressurePa = (int32_t)(101325.0f * powf(baroBase, 5.25588f));
     const int32_t tempCentiC = (int32_t)((15.0f - 0.0065f * altM) * 100.0f);
     fakeBaroSet(pressurePa, tempCentiC);
 

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -120,14 +120,14 @@ void updateState(const fdm_packet* pkt) {
 
     // fake mag: rotate a fixed world-frame North vector into body frame using the attitude quaternion
     // (no field strength/dip modeled — sufficient to exercise heading hold / mag fusion in SITL)
-    const double qw = pkt->imu_orientation_quat[0];
-    const double qx = pkt->imu_orientation_quat[1];
-    const double qy = pkt->imu_orientation_quat[2];
-    const double qz = pkt->imu_orientation_quat[3];
+    const double magQw = pkt->imu_orientation_quat[0];
+    const double magQx = pkt->imu_orientation_quat[1];
+    const double magQy = pkt->imu_orientation_quat[2];
+    const double magQz = pkt->imu_orientation_quat[3];
     const double magScale = 4096.0; // matches compass_fake.c default full-scale reading
-    x = constrain((1.0 - 2.0 * (qy * qy + qz * qz)) * magScale, -32767, 32767);
-    y = constrain(2.0 * (qx * qy - qw * qz) * magScale, -32767, 32767);
-    z = constrain(2.0 * (qx * qz + qw * qy) * magScale, -32767, 32767);
+    x = constrain((1.0 - 2.0 * (magQy * magQy + magQz * magQz)) * magScale, -32767, 32767);
+    y = constrain(2.0 * (magQx * magQy - magQw * magQz) * magScale, -32767, 32767);
+    z = constrain(2.0 * (magQx * magQz + magQw * magQy) * magScale, -32767, 32767);
     fakeMagSet(x, y, z);
 #if defined(SKIP_IMU_CALC)
 #if defined(SET_IMU_FROM_EULER)

--- a/src/main/target/SITL/target.c
+++ b/src/main/target/SITL/target.c
@@ -42,6 +42,8 @@
 const timerHardware_t timerHardware[1]; // unused
 
 #include "drivers/accgyro/accgyro_fake.h"
+#include "drivers/barometer/barometer_fake.h"
+#include "drivers/compass/compass_fake.h"
 #include "flight/imu.h"
 
 #include "config/feature.h"
@@ -109,6 +111,24 @@ void updateState(const fdm_packet* pkt) {
     z = constrain(-pkt->imu_angular_velocity_rpy[2] * GYRO_SCALE * RAD2DEG, -32767, 32767);
     fakeGyroSet(fakeGyroDev, x, y, z);
 //    printf("[gyr]%lf,%lf,%lf\n", pkt->imu_angular_velocity_rpy[0], pkt->imu_angular_velocity_rpy[1], pkt->imu_angular_velocity_rpy[2]);
+
+    // fake baro: derive pressure/temperature from NED altitude via ISA standard atmosphere
+    const float altM = -(float)pkt->position_xyz[2]; // NED z is down; negate for altitude up
+    const int32_t pressurePa = (int32_t)(101325.0f * powf(1.0f - 2.25577e-5f * altM, 5.25588f));
+    const int32_t tempCentiC = (int32_t)((15.0f - 0.0065f * altM) * 100.0f);
+    fakeBaroSet(pressurePa, tempCentiC);
+
+    // fake mag: rotate a fixed world-frame North vector into body frame using the attitude quaternion
+    // (no field strength/dip modeled — sufficient to exercise heading hold / mag fusion in SITL)
+    const double qw = pkt->imu_orientation_quat[0];
+    const double qx = pkt->imu_orientation_quat[1];
+    const double qy = pkt->imu_orientation_quat[2];
+    const double qz = pkt->imu_orientation_quat[3];
+    const double magScale = 4096.0; // matches compass_fake.c default full-scale reading
+    x = constrain((1.0 - 2.0 * (qy * qy + qz * qz)) * magScale, -32767, 32767);
+    y = constrain(2.0 * (qx * qy - qw * qz) * magScale, -32767, 32767);
+    z = constrain(2.0 * (qx * qz + qw * qy) * magScale, -32767, 32767);
+    fakeMagSet(x, y, z);
 #if defined(SKIP_IMU_CALC)
 #if defined(SET_IMU_FROM_EULER)
     // set from Euler


### PR DESCRIPTION
AI Generated pull-request

## Summary

Follow-on from PR #1100 (SITL bring-up). Addresses issue #1149.

`target.c::updateState()` already wired fake acc/gyro from the FDM UDP packet, but the fake baro and fake mag sensors were compiled in and never fed data. This PR wires items 1 and 2 from #1149:

- `fakeBaroSet`: derives pressure (Pa) and temperature (centi-C) from NED altitude (`position_xyz[2]`) using the ISA standard atmosphere approximation. Enables altitude-hold / baro-based estimation in SITL.
- `fakeMagSet`: rotates a fixed world-frame North vector into body frame using the attitude quaternion (`imu_orientation_quat`), scaled to `compass_fake.c`'s default full-scale reading (4096). No field strength/dip is modeled — sufficient to exercise heading hold / mag fusion in SITL, not a physically accurate magnetic model.

Item 3 from #1149 (expanding `servo_packet.motor_speed` from 4 to 8 channels) is a wire-protocol change requiring a matching update to the external Gazebo sim plugin, and is left for a separate PR per the issue's own scoping.

## Test plan

- [x] `make TARGET=SITL` — clean build, zero warnings (verified with `CCACHE_DISABLE=1`)
- [x] `make test` — full unit suite passes, no regressions
- [x] SITL binary starts without crashing
- [ ] n/a — no real-hardware driver path touched (SITL-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated barometer and compass sensor readings in the SITL environment.
  * Sensor values now update automatically from simulator state, improving hardware-in-the-loop testing realism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->