### PR TITLE
fix(h7): align D-cache invalidate address in uartRead()

### DIFF
--- a/src/main/drivers/serial_uart_hal.c
+++ b/src/main/drivers/serial_uart_hal.c
@@ -43,6 +43,12 @@
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
 
+// Cache-line constants for DMA buffer maintenance (32-byte L1D cache lines on Cortex-M7).
+#if defined(STM32H7)
+#define CACHE_LINE_SIZE  32
+#define CACHE_LINE_MASK  (CACHE_LINE_SIZE - 1)
+#endif
+
 static void usartConfigurePinInversion(uartPort_t *uartPort) {
     bool inverted = uartPort->port.options & SERIAL_INVERTED;
     if (inverted) {
@@ -282,7 +288,11 @@ uint8_t uartRead(serialPort_t *instance) {
     uartPort_t *s = (uartPort_t *)instance;
     if (s->rxDMAStream) {
 #if defined(STM32H7)
-        SCB_InvalidateDCache_by_Addr((uint32_t *)&s->port.rxBuffer[s->port.rxBufferSize - s->rxDMAPos], sizeof(uint8_t));
+        // SCB_InvalidateDCache_by_Addr requires a 32-byte aligned address; align
+        // down to the enclosing cache line and invalidate the whole line so a
+        // stale D-cache line can't mask the byte DMA just wrote to RAM.
+        const uint32_t rawAddr = (uint32_t)&s->port.rxBuffer[s->port.rxBufferSize - s->rxDMAPos];
+        SCB_InvalidateDCache_by_Addr((uint32_t *)(rawAddr & ~CACHE_LINE_MASK), CACHE_LINE_SIZE);
 #endif
         ch = s->port.rxBuffer[s->port.rxBufferSize - s->rxDMAPos];
         if (--s->rxDMAPos == 0)


### PR DESCRIPTION
AI Generated pull-request

## Summary
`uartRead()` in `src/main/drivers/serial_uart_hal.c` called `SCB_InvalidateDCache_by_Addr` with an address that is not 32-byte cache-line aligned and a size of 1 byte, both invalid for the Cortex-M7 D-cache API (CMSIS requires 32-byte alignment; invalidation always operates on whole cache lines). This is undefined behavior and can leave adjacent bytes stale.

Currently dormant: `rxDMAStream` is NULL on all current H7 targets, so UART DMA RX never exercises this path yet. It will activate the moment a future H7 target enables UART DMA RX.

Fix aligns the address down to the enclosing 32-byte cache line and invalidates the whole line, matching the pattern already used in `bus_spi.c`/`bus_spi_ll.c` for the same class of issue.

Closes #1207

## Test plan
- [x] Build passes: `CCACHE_DISABLE=1 make STELLARH7DEV` — clean, zero warnings/errors
- [x] Unit tests: `make clean_test && make test` — all 39 suites pass
- [ ] Hardware verified: n/a — path is unreachable at runtime on all current H7 targets (rxDMAStream always NULL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial UART DMA data handling on STM32H7 devices.
  * Fixed cache invalidation to ensure received bytes are read correctly and reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->