### PR TITLE
targets: prune OMNINXT4/OMNINXT7 dead sibling branches

### DIFF
--- a/src/main/config/config_streamer.c
+++ b/src/main/config/config_streamer.c
@@ -29,7 +29,7 @@
 #ifndef EEPROM_IN_RAM
 extern uint8_t __config_start;   // configured via linker script when building binaries.
 extern uint8_t __config_end;
-#elif !defined(SITL)
+#elif !defined(SIMULATOR_BUILD)
 // RAM-based config: eepromData[] is the backing store; __config_start/__config_end
 // are macro-aliased to it in common_fc_post.h. SITL defines eepromData in target.c.
 #if defined(PERSISTENT)

--- a/src/main/target/OMNINXT4/hardware_revision.c
+++ b/src/main/target/OMNINXT4/hardware_revision.c
@@ -63,17 +63,10 @@ typedef struct idDetect_s {
 #define IDDET_ERROR 12
 
 static idDetect_t idDetectTable[] = {
-#ifdef OMNINXT7
     { IDDET_RATIO(10000, 10000), 1 },
-#endif
-#ifdef OMNINXT4
-    { IDDET_RATIO(10000, 10000), 1 },
-#endif
 };
 
 ioTag_t idDetectTag;
-
-#if defined(OMNINXT4)
 
 #define VREFINT_CAL_ADDR  0x1FFF7A2A
 
@@ -132,90 +125,6 @@ static uint16_t adcIDDetectReadIDDet(void) {
 static uint16_t adcIDDetectReadVrefint(void) {
     return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_2);
 }
-#endif
-
-#if defined(OMNINXT7)
-#define VREFINT_CAL_ADDR  0x1FF07A2A
-
-#include "drivers/adc_impl.h"
-
-static adcDevice_t adcIDDetHardware =
-{ .ADCx = ADC1, .rccADC = RCC_APB2(ADC1), .DMAy_Streamx = ADC1_DMA_STREAM, .channel = DMA_CHANNEL_0 };
-
-// XXX adcIDDetectInitDevice is an exact copy of adcInitDevice() from adc_stm32f7xx.c. Export and use?
-
-static void adcIDDetectInitDevice(adcDevice_t *adcdev, int channelCount) {
-    adcdev->ADCHandle.Init.ClockPrescaler        = ADC_CLOCK_SYNC_PCLK_DIV8;
-    adcdev->ADCHandle.Init.ContinuousConvMode    = ENABLE;
-    adcdev->ADCHandle.Init.Resolution            = ADC_RESOLUTION_12B;
-    adcdev->ADCHandle.Init.ExternalTrigConv      = ADC_EXTERNALTRIGCONV_T1_CC1;
-    adcdev->ADCHandle.Init.ExternalTrigConvEdge  = ADC_EXTERNALTRIGCONVEDGE_NONE;
-    adcdev->ADCHandle.Init.DataAlign             = ADC_DATAALIGN_RIGHT;
-    adcdev->ADCHandle.Init.NbrOfConversion       = channelCount;
-#ifdef USE_ADC_INTERNAL
-    // Multiple injected channel seems to require scan conversion mode to be
-    // enabled even if main (non-injected) channel count is 1.
-    adcdev->ADCHandle.Init.ScanConvMode          = ENABLE;
-#else
-    adcdev->ADCHandle.Init.ScanConvMode          = channelCount > 1 ? ENABLE : DISABLE; // 1=scan more that one channel in group
-#endif
-    adcdev->ADCHandle.Init.DiscontinuousConvMode = DISABLE;
-    adcdev->ADCHandle.Init.NbrOfDiscConversion   = 0;
-    adcdev->ADCHandle.Init.DMAContinuousRequests = ENABLE;
-    adcdev->ADCHandle.Init.EOCSelection          = DISABLE;
-    adcdev->ADCHandle.Instance = adcdev->ADCx;
-    if (HAL_ADC_Init(&adcdev->ADCHandle) != HAL_OK) {
-        /* Initialization Error */
-    }
-}
-
-static void adcIDDetectInit(void) {
-    idDetectTag = IO_TAG(ADC_ID_DETECT_PIN);
-    IOConfigGPIO(IOGetByTag(idDetectTag), IO_CONFIG(GPIO_MODE_ANALOG, 0, GPIO_NOPULL));
-    adcIDDetectInitDevice(&adcIDDetHardware, 2);
-    ADC_InjectionConfTypeDef iConfig;
-    iConfig.InjectedSamplingTime = ADC_SAMPLETIME_480CYCLES;
-    iConfig.InjectedOffset       = 0;
-    iConfig.InjectedNbrOfConversion = 2;
-    iConfig.InjectedDiscontinuousConvMode = DISABLE;
-    iConfig.AutoInjectedConv     = DISABLE;
-    iConfig.ExternalTrigInjecConv = 0;     // Don't care
-    iConfig.ExternalTrigInjecConvEdge = 0; // Don't care
-    iConfig.InjectedChannel      = ADC_CHANNEL_VREFINT;
-    iConfig.InjectedRank         = 1;
-    if (HAL_ADCEx_InjectedConfigChannel(&adcIDDetHardware.ADCHandle, &iConfig) != HAL_OK) {
-        /* Channel Configuration Error */
-    }
-    iConfig.InjectedChannel      = adcChannelByTag(idDetectTag);
-    iConfig.InjectedRank         = 2;
-    if (HAL_ADCEx_InjectedConfigChannel(&adcIDDetHardware.ADCHandle, &iConfig) != HAL_OK) {
-        /* Channel Configuration Error */
-    }
-}
-
-static void adcIDDetectDeinit(void) {
-    HAL_ADC_DeInit(&adcIDDetHardware.ADCHandle);
-    IOConfigGPIO(IOGetByTag(idDetectTag), IOCFG_IPU);
-}
-
-static void adcIDDetectStart(void) {
-    HAL_ADCEx_InjectedStart(&adcIDDetHardware.ADCHandle);
-}
-
-static void adcIDDetectWait(void) {
-    while (HAL_ADCEx_InjectedPollForConversion(&adcIDDetHardware.ADCHandle, 0) != HAL_OK) {
-        // Empty
-    }
-}
-
-static uint16_t adcIDDetectReadVrefint(void) {
-    return HAL_ADCEx_InjectedGetValue(&adcIDDetHardware.ADCHandle, ADC_INJECTED_RANK_1);
-}
-
-static uint16_t adcIDDetectReadIDDet(void) {
-    return HAL_ADCEx_InjectedGetValue(&adcIDDetHardware.ADCHandle, ADC_INJECTED_RANK_2);
-}
-#endif
 
 void detectHardwareRevision(void) {
     adcIDDetectInit();

--- a/src/main/target/OMNINXT7/hardware_revision.c
+++ b/src/main/target/OMNINXT7/hardware_revision.c
@@ -63,78 +63,11 @@ typedef struct idDetect_s {
 #define IDDET_ERROR 12
 
 static idDetect_t idDetectTable[] = {
-#ifdef OMNINXT7
     { IDDET_RATIO(10000, 10000), 1 },
-#endif
-#ifdef OMNINXT4
-    { IDDET_RATIO(10000, 10000), 1 },
-#endif
 };
 
 ioTag_t idDetectTag;
 
-#if defined(OMNINXT4)
-
-#define VREFINT_CAL_ADDR  0x1FFF7A2A
-
-static void adcIDDetectInit(void) {
-    idDetectTag = IO_TAG(ADC_ID_DETECT_PIN);
-    IOConfigGPIO(IOGetByTag(idDetectTag), IO_CONFIG(GPIO_Mode_AN, 0, GPIO_OType_OD, GPIO_PuPd_NOPULL));
-    RCC_ClockCmd(RCC_APB2(ADC1), ENABLE);
-    ADC_CommonInitTypeDef ADC_CommonInitStructure;
-    ADC_CommonStructInit(&ADC_CommonInitStructure);
-    ADC_CommonInitStructure.ADC_Mode             = ADC_Mode_Independent;
-    ADC_CommonInitStructure.ADC_Prescaler        = ADC_Prescaler_Div8;
-    ADC_CommonInitStructure.ADC_DMAAccessMode    = ADC_DMAAccessMode_Disabled;
-    ADC_CommonInitStructure.ADC_TwoSamplingDelay = ADC_TwoSamplingDelay_5Cycles;
-    ADC_CommonInit(&ADC_CommonInitStructure);
-    ADC_InitTypeDef ADC_InitStructure;
-    ADC_StructInit(&ADC_InitStructure);
-    ADC_InitStructure.ADC_ContinuousConvMode       = ENABLE;
-    ADC_InitStructure.ADC_Resolution               = ADC_Resolution_12b;
-    ADC_InitStructure.ADC_ExternalTrigConv         = ADC_ExternalTrigConv_T1_CC1;
-    ADC_InitStructure.ADC_ExternalTrigConvEdge     = ADC_ExternalTrigConvEdge_None;
-    ADC_InitStructure.ADC_DataAlign                = ADC_DataAlign_Right;
-    ADC_InitStructure.ADC_NbrOfConversion          = 2; // Not used
-    ADC_InitStructure.ADC_ScanConvMode             = ENABLE;
-    ADC_Init(ADC1, &ADC_InitStructure);
-    ADC_Cmd(ADC1, ENABLE);
-    ADC_TempSensorVrefintCmd(ENABLE);
-    delayMicroseconds(10); // Maximum startup time for internal sensors (DM00037051 5.3.22 & 24)
-    uint32_t channel = adcChannelByTag(idDetectTag);
-    ADC_InjectedDiscModeCmd(ADC1, DISABLE);
-    ADC_InjectedSequencerLengthConfig(ADC1, 2);
-    ADC_InjectedChannelConfig(ADC1, channel, 1, ADC_SampleTime_480Cycles);
-    ADC_InjectedChannelConfig(ADC1, ADC_Channel_Vrefint, 2, ADC_SampleTime_480Cycles);
-}
-
-static void adcIDDetectDeinit(void) {
-    ADC_Cmd(ADC1, DISABLE);
-    ADC_DeInit();
-    IOConfigGPIO(IOGetByTag(idDetectTag), IOCFG_IPU);
-}
-
-static void adcIDDetectStart(void) {
-    ADC_ClearFlag(ADC1, ADC_FLAG_JEOC);
-    ADC_SoftwareStartInjectedConv(ADC1);
-}
-
-static void adcIDDetectWait(void) {
-    while (ADC_GetFlagStatus(ADC1, ADC_FLAG_JEOC) == RESET) {
-        // Empty
-    }
-}
-
-static uint16_t adcIDDetectReadIDDet(void) {
-    return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_1);
-}
-
-static uint16_t adcIDDetectReadVrefint(void) {
-    return ADC_GetInjectedConversionValue(ADC1, ADC_InjectedChannel_2);
-}
-#endif
-
-#if defined(OMNINXT7)
 #define VREFINT_CAL_ADDR  0x1FF07A2A
 
 #include "drivers/adc_impl.h"
@@ -215,7 +148,6 @@ static uint16_t adcIDDetectReadVrefint(void) {
 static uint16_t adcIDDetectReadIDDet(void) {
     return HAL_ADCEx_InjectedGetValue(&adcIDDetHardware.ADCHandle, ADC_INJECTED_RANK_2);
 }
-#endif
 
 void detectHardwareRevision(void) {
     adcIDDetectInit();


### PR DESCRIPTION
AI Generated pull-request

## Summary

Follow-up to #1302 (atomic-target split). Every other split file was pruned to keep only its own board's true-branch code, but `OMNINXT4/hardware_revision.c` and `OMNINXT7/hardware_revision.c` each still carried **both** boards' full MCU-specific ADC hardware-revision-detection implementation (StdPeriph API for OMNINXT4, HAL API for OMNINXT7), gated on `#ifdef OMNINXT4`/`#ifdef OMNINXT7`. Since each file now lives in a folder dedicated to exactly one board, the sibling branch can never be true and has been dead code since the split — this PR removes it, matching the atomic-per-board intent #1302 applied everywhere else. No functional change for either board.

Also fixed `src/main/config/config_streamer.c:32`: changed `#elif !defined(SITL)` to `#elif !defined(SIMULATOR_BUILD)`. This check decides whether to statically define `eepromData[]` in this shared file (SITL defines its own `eepromData` in `target.c`, so this file must skip it for SITL to avoid a duplicate definition). `SIMULATOR_BUILD` is the existing purpose-built macro already used pervasively elsewhere for exactly this check (`main.c`, `platform.h`, `scheduler.c`, `cli.c`, `serial.c`) — this file was the one inconsistent holdout still keying off the bare target name. Unrelated to the atomic-target split itself; independently correct regardless of it. Note: `make SITL` as a build invocation is completely unaffected by this — `SIMULATOR_BUILD` is a preprocessor macro the source checks internally (already produced by `make SITL` via `make/source.mk`), not a different build command.

## Verification

- `OMNINXT4`, `OMNINXT7`, `SITL` build clean, plus `HELIOSPRING`/`FOXEERF722V4`/`TMOTORF7` as a broader sanity sample — zero failures, zero new compiler warnings.
- Full unit test suite (`make test`, 39 suites) passes.

## Test plan

- [ ] Build passes: all targets (CI)
- [ ] Hardware verification: not required — no behavioral change to either board's selected hardware-revision-detection code path, and `config_streamer.c`'s macro swap doesn't change which branch compiles for any real target (only SITL's internal check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware revision detection across OMNINXT4 and OMNINXT7 variants.
  * Corrected configuration selection for simulator builds, improving EEPROM data handling during simulated operation.
  * Streamlined target-specific detection behavior for more consistent hardware identification and startup configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->