### PR TITLE
Add motorCount byte to MSP_MOTOR_CONFIG response

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -967,6 +967,7 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
         sbufWriteU16(dst, motorConfig()->minthrottle);
         sbufWriteU16(dst, motorConfig()->maxthrottle);
         sbufWriteU16(dst, motorConfig()->mincommand);
+        sbufWriteU8(dst, getMotorCount());
         break;
 #ifdef USE_MAG
     case MSP_COMPASS_CONFIG:


### PR DESCRIPTION
AI Generated pull-request

## Summary
- `MSP_MOTOR_CONFIG` (cmd 131) wrote only 6 bytes (`minthrottle`, `maxthrottle`, `mincommand`), omitting a `motorCount` byte that consumers such as the AM32 ESC web configurator expect at offset 6. The missing byte caused an out-of-bounds `DataView` read (`RangeError: Offset is outside the bounds of the DataView`) and crashed the configurator's connect flow against EmuFlight-controlled boards (confirmed on HELIOSPRING).
- Fix appends `sbufWriteU8(dst, getMotorCount())`, reusing the existing `getMotorCount()` accessor (`flight/mixer.h`) - the same pattern already used at `msp.c:979` for `MSP_ESC_SENSOR_DATA`, not new/untested logic.
- Confirmed backward compatible with the official EmuFlight Configurator: its `MSP_MOTOR_CONFIG` parser (`MSPHelper.js:414-418`) reads only the first 3 fields and ignores trailing bytes.
- Does not touch EEPROM/config-struct layout - `getMotorCount()` reads a runtime variable (`flight/mixer.c`), not a stored config field. `EEPROM_CONF_VERSION` (currently `173`) is unaffected.

## Important finding: API_VERSION_MINOR intentionally left unbumped
Neither consumer (EmuConfigurator, AM32 configurator) gates parsing of this field on API version, so there's no functional need to bump it. Bumping would also be actively risky right now: EmuFlight Configurator's shipped release (`0.4.3`) pins a hard version ceiling (`max_msp: "1.54.0"` in `src/version.json`, enforced via `semver.lte(CONFIG.apiVersion, CONFIGURATOR.max_msp)` in `serial_backend.js:230,267`) that gates its entire connect sequence for EmuFlight-identified boards. Any version increase above `1.54.0` would break connectivity for the currently-released configurator. This broader architectural gap (no patch-level MSP versioning end-to-end) has been filed as two companion issues: emuflight/EmuFlight#1308 and emuflight/EmuConfigurator#634.

## Test plan
- [x] `make HELIOSPRING` - succeeded (FLASH 90.84% used, pre-existing, unaffected by this 1-byte addition)
- [x] Hardware-verified on a real HELIOSPRING board: AM32 ESC web configurator now connects and displays ESC configs (previously crashed)
- [x] EmuFlight Configurator tabs read correctly post-flash - no regression observed
- [ ] EmuFlight Configurator save/write paths - not tested (this PR only touches the read-direction `MSP_MOTOR_CONFIG`; `MSP_SET_MOTOR_CONFIG` is a separate, untouched case)
- No new unit test added - no existing host-side harness covers individual MSP out-command payloads in this repo, and the change reuses an already-proven accessor/pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the current motor count to responses for the motor configuration command, enabling connected tools to accurately identify the configured number of motors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->