### PR TITLE
Add motorCount byte to MSP_MOTOR_CONFIG response (backport of #1309)

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -935,6 +935,7 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
         sbufWriteU16(dst, motorConfig()->minthrottle);
         sbufWriteU16(dst, motorConfig()->maxthrottle);
         sbufWriteU16(dst, motorConfig()->mincommand);
+        sbufWriteU8(dst, getMotorCount());
         break;
 #ifdef USE_MAG
     case MSP_COMPASS_CONFIG:


### PR DESCRIPTION
AI Generated pull-request

## Summary
Backport of #1309 (merged to `master` at `bac9c8a530`) to `0.4.3-maintenance`. Clean cherry-pick, no conflicts.

- `MSP_MOTOR_CONFIG` (cmd 131) wrote only 6 bytes (`minthrottle`, `maxthrottle`, `mincommand`), omitting a `motorCount` byte that consumers such as the AM32 ESC web configurator expect at offset 6. The missing byte caused an out-of-bounds `DataView` read and crashed the configurator's connect flow against EmuFlight-controlled boards (confirmed on HELIOSPRING).
- Fix appends `sbufWriteU8(dst, getMotorCount())`, reusing the existing `getMotorCount()` accessor - the same pattern already used for `MSP_ESC_SENSOR_DATA`.
- Confirmed backward compatible with the official EmuFlight Configurator (reads only the first 3 fields, ignores trailing bytes) and does not touch EEPROM/config-struct layout.
- `API_VERSION_MINOR` intentionally left unbumped on `master`; same applies here.

See #1309 for the full investigation and hardware verification details.

## Test plan
- [x] `make HELIOSPRING` - succeeded on `0.4.3-maintenance` base
- [x] Clean cherry-pick, no merge conflicts
- [x] Hardware-verified on master's identical change (real HELIOSPRING board, 4x ESCs, AM32 configurator connects and reads correctly)