### PR TITLE
fix(cli): cliTasks: include SERIAL in Total load, remove stale exclusion

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3637,10 +3637,8 @@ static void cliTasks(char *cmdline) {
             }
             const int maxLoad = taskInfo.maxExecutionTime == 0 ? 0 : (taskInfo.maxExecutionTime * taskFrequency) / 1000;
             const int averageLoad = taskInfo.averageExecutionTime == 0 ? 0 : (taskInfo.averageExecutionTime * taskFrequency) / 1000;
-            if (taskId != TASK_SERIAL) {
-                maxLoadSum += maxLoad;
-                averageLoadSum += averageLoad;
-            }
+            maxLoadSum += maxLoad;
+            averageLoadSum += averageLoad;
             if (systemConfig()->task_statistics) {
                 cliPrintLinef("%6d %7d %7d %4d.%1d%% %4d.%1d%% %9d",
                               taskFrequency, taskInfo.maxExecutionTime, taskInfo.averageExecutionTime,
@@ -3658,7 +3656,7 @@ static void cliTasks(char *cmdline) {
         cfCheckFuncInfo_t checkFuncInfo;
         getCheckFuncInfo(&checkFuncInfo);
         cliPrintLinef("RX Check Function %19d %7d %25d", checkFuncInfo.maxExecutionTime, checkFuncInfo.averageExecutionTime, checkFuncInfo.totalExecutionTime / 1000);
-        cliPrintLinef("Total (excluding SERIAL) %25d.%1d%% %4d.%1d%%", maxLoadSum / 10, maxLoadSum % 10, averageLoadSum / 10, averageLoadSum % 10);
+        cliPrintLinef("Total %44d.%1d%% %4d.%1d%%", maxLoadSum / 10, maxLoadSum % 10, averageLoadSum / 10, averageLoadSum % 10);
     }
 }
 #endif


### PR DESCRIPTION
AI Generated pull-request

Closes #1311

## Summary

`cliTasks()` (`src/main/interface/cli.c`) special-cased `TASK_SERIAL` out of the `tasks` CLI's aggregate load sum, and labeled it `"Total (excluding SERIAL)"`. This exclusion existed because `TASK_SERIAL`'s `maxExecutionTime` could get permanently corrupted to hundreds of ms / thousands of percent on the first USB VCP Configurator connect (issue #1282), which would have made the aggregate meaningless if SERIAL had been included.

#1285 fixed that root cause: `schedulerIgnoreTaskExecTime()` now suppresses `maxExecutionTime` updates only on genuine CDC TX backpressure, so `TASK_SERIAL`'s reported stats are accurate under normal operation (hardware-verified in the 2-3% maxload range across three boards, two USB backends). The exclusion is no longer necessary and the label was misleading.

**Change:**
- Removed the `if (taskId != TASK_SERIAL)` guard so `TASK_SERIAL` contributes to `maxLoadSum`/`averageLoadSum` like every other task.
- Changed the printed label from `"Total (excluding SERIAL)"` to `"Total"`, adjusting the printf field width (25 → 44) to preserve column alignment under the `maxload`/`avgload` header given the shorter label.

Small, low-risk cleanup — single file, 3 insertions / 5 deletions.

## Test plan

- [x] Build passes: FOXEERF405, zero warnings (`CCACHE_DISABLE=1`)
- [x] Unit tests: 39/39 test binaries pass, 0 failures
- [x] Hardware verified on HELIOSPRING (`bbb3b98`): `tasks` CLI shows `Total 93.1% 59.7%` with no "(excluding SERIAL)" text, and the sum correctly includes `SERIAL`'s `3.0%` maxload (`83.3+0.8+0.7+0.1+3.0+0.6+4.3+0.3 = 93.1`, verified arithmetically) — confirms the fix behaves as intended on real hardware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated task load totals to include all enabled tasks, including serial tasks.
  * Revised total load output to clearly report complete results without excluding serial tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->