### PR TITLE
fix: backport pidCopyProfile Nth-profile-copy rejection fix to 0.4.3-maintenance

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -447,7 +447,7 @@ void pidInit(const pidProfile_t *pidProfile) {
 }
 
 void pidCopyProfile(uint8_t dstPidProfileIndex, uint8_t srcPidProfileIndex) {
-    if ((dstPidProfileIndex < PID_PROFILE_COUNT - 1 && srcPidProfileIndex < PID_PROFILE_COUNT - 1) && dstPidProfileIndex != srcPidProfileIndex) {
+    if ((dstPidProfileIndex < PID_PROFILE_COUNT && srcPidProfileIndex < PID_PROFILE_COUNT) && dstPidProfileIndex != srcPidProfileIndex) {
         memcpy(pidProfilesMutable(dstPidProfileIndex), pidProfilesMutable(srcPidProfileIndex), sizeof(pidProfile_t));
     }
 }


### PR DESCRIPTION
AI Generated pull-request

Backports master `b84d4a3d17` (#1104) to `0.4.3-maintenance`.

`pidCopyProfile()` compared both profile indices against `PID_PROFILE_COUNT - 1` instead of
`PID_PROFILE_COUNT`, so a copy targeting the last valid profile index (`PID_PROFILE_COUNT - 1`)
was silently rejected — no error, no copy performed.

Fix: compare against `PID_PROFILE_COUNT` (exclusive upper bound), matching the valid index range.

Verified: clean cherry-pick onto `0.4.3-maintenance` tip `59e144e53c`, HELIOSPRING build succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PID profile copying so the final available profile can be used as either the source or destination.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->