### PR TITLE
fix: backport Smith Predictor compilation guard fix to 0.4.3-maintenance

### DIFF
--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -105,13 +105,12 @@ typedef struct smithPredictor_s {
     uint8_t enabled;
     uint8_t samples;
     uint8_t idx;
-
     float data[MAX_SMITH_SAMPLES + 1]; // This is gonna be a ring buffer. Max of 8ms delay at 8khz
-
     pt1Filter_t smithPredictorFilter; // filter the smith predictor output for RPY
-
     float smithPredictorStrength;
 } smithPredictor_t;
+
+float applySmithPredictor(smithPredictor_t *smithPredictor, float gyroFiltered);
 #endif // USE_SMITH_PREDICTOR
 
 typedef enum {
@@ -208,7 +207,6 @@ bool gyroOverflowDetected(void);
 bool gyroYawSpinDetected(void);
 uint16_t gyroAbsRateDps(int axis);
 uint8_t gyroReadRegister(uint8_t whichSensor, uint8_t reg);
-float applySmithPredictor(smithPredictor_t *smithPredictor, float gyroFiltered);
 #ifdef USE_GYRO_DATA_ANALYSE
 bool isDynamicFilterActive(void);
 #endif

--- a/src/main/sensors/gyro_filter_impl.h
+++ b/src/main/sensors/gyro_filter_impl.h
@@ -62,7 +62,9 @@ static FAST_CODE void GYRO_FILTER_FUNCTION_NAME(gyroSensor_t *gyroSensor) {
 #ifndef USE_GYRO_IMUF9001
         update_kalman_covariance(gyroADCf, axis);
 #endif
+#ifdef USE_SMITH_PREDICTOR
         applySmithPredictor(gyroSensor->smithPredictor, gyroADCf);
+#endif
 
 #ifdef USE_GYRO_IMUF9001
         // DEBUG_GYRO_FILTERED records the scaled, filtered, after all software filtering has been applied.


### PR DESCRIPTION
AI Generated pull-request

Backports master `62b68a89b5` (#1094) to `0.4.3-maintenance`.

`applySmithPredictor()` declaration in `gyro.h` sat outside the `#ifdef USE_SMITH_PREDICTOR` guard,
and its call site in `gyro_filter_impl.h` was unguarded. `USE_SMITH_PREDICTOR` is only defined when
`FLASH_SIZE > 128` (`common_fc_pre.h`), so any target at or under 128KB flash fails to compile on
`0.4.3-maintenance` today — `smithPredictor_t` is undefined outside that guard.

Fix: move the declaration inside the `USE_SMITH_PREDICTOR` guard in `gyro.h`, and guard the call
site in `gyro_filter_impl.h`.

Verified: clean cherry-pick onto `0.4.3-maintenance` tip `59e144e53c`, HELIOSPRING build succeeds
with identical binary size (359495 text bytes) to pre-fix baseline — confirms no behavior change
on targets where `USE_SMITH_PREDICTOR` is already defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gyro filtering behavior by ensuring Smith predictor processing is only applied when the feature is enabled.
  * Preserved compatibility for configurations that do not use Smith prediction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->