### PR TITLE
fix(msp): backport per-client arming disable to prevent DJI MSP bypass to 0.4.3-maintenance

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -169,6 +169,7 @@ extern uint8_t __config_end;
 
 
 static serialPort_t *cliPort;
+static mspDescriptor_t cliMspDescriptor;
 
 #ifdef STM32F1
 #define CLI_IN_BUFFER_SIZE 128
@@ -2621,7 +2622,7 @@ void cliMsp(char *cmdline) {
         //TODO need to fill inPtr with the rest of the bytes from the command line
         buft.ptr = buft.end = bufPtr;
         if (mspCommonProcessOutCommand(mspCommand, &buft, NULL) || mspProcessOutCommand(mspCommand, &buft)
-                || mspCommonProcessInCommand(mspCommand, &inBuf, NULL) > -1 || mspProcessInCommand(mspCommand, &inBuf) > -1) {
+                || mspCommonProcessInCommand(cliMspDescriptor, mspCommand, &inBuf, NULL) > -1 || mspProcessInCommand(cliMspDescriptor, mspCommand, &inBuf) > -1) {
             bufWriterAppend(cliWriter, '.');                 //"." is success
             bufWriterAppend(cliWriter, mspCommand);          //msp command sent
             bufWriterAppend(cliWriter, inBuf.ptr - inBuf.end);                  //msp command sent
@@ -4587,5 +4588,6 @@ void cliEnter(serialPort_t *serialPort) {
 
 void cliInit(const serialConfig_t *serialConfig) {
     UNUSED(serialConfig);
+    cliMspDescriptor = mspDescriptorAlloc();
 }
 #endif // USE_CLI

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -145,6 +145,33 @@ enum {
 
 static uint8_t rebootMode;
 
+static int mspDescriptorCounter = 0;
+
+mspDescriptor_t mspDescriptorAlloc(void)
+{
+    if (mspDescriptorCounter >= (int)(sizeof(uint32_t) * 8)) {
+        return (mspDescriptor_t)0;
+    }
+    return (mspDescriptor_t)mspDescriptorCounter++;
+}
+
+static uint32_t mspArmingDisableFlags = 0;
+
+static void mspArmingDisableByDescriptor(mspDescriptor_t desc)
+{
+    mspArmingDisableFlags |= ((uint32_t)1 << desc);
+}
+
+static void mspArmingEnableByDescriptor(mspDescriptor_t desc)
+{
+    mspArmingDisableFlags &= ~((uint32_t)1 << desc);
+}
+
+static bool mspIsMspArmingEnabled(void)
+{
+    return mspArmingDisableFlags == 0;
+}
+
 #ifndef USE_OSD_SLAVE
 
 typedef enum {
@@ -1410,7 +1437,8 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
         }
 #endif // USE_OSD_SLAVE
 
-static mspResult_e mspFcProcessOutCommandWithArg(uint8_t cmdMSP, sbuf_t *src, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn) {
+static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn) {
+    UNUSED(srcDesc);
 #if defined(USE_OSD_SLAVE)
     UNUSED(dst);
 #endif
@@ -1483,7 +1511,8 @@ static void mspFcDataFlashReadCommand(sbuf_t *dst, sbuf_t *src) {
 #endif
 
 #ifdef USE_OSD_SLAVE
-static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
+static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src) {
+    UNUSED(srcDesc);
     UNUSED(cmdMSP);
     UNUSED(src);
     switch(cmdMSP) {
@@ -1504,7 +1533,7 @@ static mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
 
 #else
 
-mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
+mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src) {
     uint32_t i;
     uint8_t value;
     const unsigned int dataSize = sbufBytesRemaining(src);
@@ -2085,6 +2114,7 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
     disableRunawayTakeoff = sbufReadU8(src);
     }
     if (command) {
+    mspArmingDisableByDescriptor(srcDesc);
     setArmingDisabled(ARMING_DISABLED_MSP);
     if (ARMING_FLAG(ARMED)) {
     disarm();
@@ -2093,10 +2123,13 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
     runawayTakeoffTemporaryDisable(false);
 #endif
     } else {
+    mspArmingEnableByDescriptor(srcDesc);
+    if (mspIsMspArmingEnabled()) {
     unsetArmingDisabled(ARMING_DISABLED_MSP);
 #ifdef USE_RUNAWAY_TAKEOFF
     runawayTakeoffTemporaryDisable(disableRunawayTakeoff);
 #endif
+    }
     }
     }
     break;
@@ -2355,7 +2388,7 @@ mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *src) {
         }
 #endif // USE_OSD_SLAVE
 
-mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPostProcessFnPtr *mspPostProcessFn) {
+mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src, mspPostProcessFnPtr *mspPostProcessFn) {
     UNUSED(mspPostProcessFn);
     const unsigned int dataSize = sbufBytesRemaining(src);
     UNUSED(dataSize); // maybe unused due to compiler options
@@ -2508,7 +2541,7 @@ mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPostProces
 #endif
 #endif // OSD || USE_OSD_SLAVE
     default:
-        return mspProcessInCommand(cmdMSP, src);
+        return mspProcessInCommand(srcDesc, cmdMSP, src);
     }
     return MSP_RESULT_ACK;
 }
@@ -2516,7 +2549,7 @@ mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *src, mspPostProces
 /*
  * Returns MSP_RESULT_ACK, MSP_RESULT_ERROR or MSP_RESULT_NO_REPLY
  */
-mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
     int ret = MSP_RESULT_ACK;
     sbuf_t *dst = &reply->buf;
     sbuf_t *src = &cmd->buf;
@@ -2527,7 +2560,7 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
         ret = MSP_RESULT_ACK;
     } else if (mspProcessOutCommand(cmdMSP, dst)) {
         ret = MSP_RESULT_ACK;
-    } else if ((ret = mspFcProcessOutCommandWithArg(cmdMSP, src, dst, mspPostProcessFn)) != MSP_RESULT_CMD_UNKNOWN) {
+    } else if ((ret = mspFcProcessOutCommandWithArg(srcDesc, cmdMSP, src, dst, mspPostProcessFn)) != MSP_RESULT_CMD_UNKNOWN) {
         /* ret */;
 #ifdef USE_SERIAL_4WAY_BLHELI_INTERFACE
     } else if (cmdMSP == MSP_SET_4WAY_IF) {
@@ -2545,7 +2578,7 @@ mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostPro
         ret = MSP_RESULT_ACK;
 #endif
     } else {
-        ret = mspCommonProcessInCommand(cmdMSP, src, mspPostProcessFn);
+        ret = mspCommonProcessInCommand(srcDesc, cmdMSP, src, mspPostProcessFn);
     }
     reply->result = ret;
     return ret;

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -150,7 +150,7 @@ static int mspDescriptorCounter = 0;
 mspDescriptor_t mspDescriptorAlloc(void)
 {
     if (mspDescriptorCounter >= (int)(sizeof(uint32_t) * 8)) {
-        return (mspDescriptor_t)0;
+        return MSP_DESCRIPTOR_INVALID;
     }
     return (mspDescriptor_t)mspDescriptorCounter++;
 }
@@ -159,11 +159,17 @@ static uint32_t mspArmingDisableFlags = 0;
 
 static void mspArmingDisableByDescriptor(mspDescriptor_t desc)
 {
+    if (desc < 0 || desc >= (int)(sizeof(uint32_t) * 8)) {
+        return;
+    }
     mspArmingDisableFlags |= ((uint32_t)1 << desc);
 }
 
 static void mspArmingEnableByDescriptor(mspDescriptor_t desc)
 {
+    if (desc < 0 || desc >= (int)(sizeof(uint32_t) * 8)) {
+        return;
+    }
     mspArmingDisableFlags &= ~((uint32_t)1 << desc);
 }
 
@@ -2105,6 +2111,9 @@ mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t 
     break;
 #endif
         case MSP_SET_ARMING_DISABLED: {
+    if (srcDesc < 0 || srcDesc >= (int)(sizeof(uint32_t) * 8)) {
+    return MSP_RESULT_ERROR;
+    }
     const uint8_t command = sbufReadU8(src);
     uint8_t disableRunawayTakeoff = 0;
 #ifndef USE_RUNAWAY_TAKEOFF

--- a/src/main/interface/msp.h
+++ b/src/main/interface/msp.h
@@ -54,16 +54,19 @@ typedef struct mspPacket_s {
     uint8_t direction;
 } mspPacket_t;
 
+typedef int mspDescriptor_t;
+
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.
-typedef mspResult_e (*mspProcessCommandFnPtr)(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
+typedef mspResult_e (*mspProcessCommandFnPtr)(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
 typedef void (*mspProcessReplyFnPtr)(mspPacket_t *cmd);
 
 
 void mspInit(void);
-mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
+mspDescriptor_t mspDescriptorAlloc(void);
+mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn);
 void mspFcProcessReply(mspPacket_t *reply);
 bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn);
-mspResult_e mspCommonProcessInCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn);
+mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn);
 bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst);
-mspResult_e mspProcessInCommand(uint8_t cmdMSP, sbuf_t *dst);
+mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *dst);

--- a/src/main/interface/msp.h
+++ b/src/main/interface/msp.h
@@ -55,6 +55,7 @@ typedef struct mspPacket_s {
 } mspPacket_t;
 
 typedef int mspDescriptor_t;
+#define MSP_DESCRIPTOR_INVALID ((mspDescriptor_t)-1)
 
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.

--- a/src/main/io/displayport_hdzero_osd.c
+++ b/src/main/io/displayport_hdzero_osd.c
@@ -377,7 +377,7 @@ displayPort_t* hdzeroOsdDisplayPortInit(void)
  * VTX sends an MSP command every 125ms or so.
  * VTX will have be marked as not ready if no commands received within VTX_TIMEOUT.
  */
-static mspResult_e hdZeroProcessMspCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn)
+static mspResult_e hdZeroProcessMspCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn)
 {
     if (vtxSeen && !vtxActive) {
         vtxReset = true;
@@ -409,7 +409,7 @@ static mspResult_e hdZeroProcessMspCommand(mspPacket_t *cmd, mspPacket_t *reply,
     }
 
     // Process MSP command
-    return mspProcessCommand(cmd, reply, mspPostProcessFn);
+    return mspProcessCommand(srcDesc, cmd, reply, mspPostProcessFn);
 }
 
 void hdzeroOsdSerialProcess(mspProcessCommandFnPtr mspProcessCommandFn)

--- a/src/main/msp/msp_serial.c
+++ b/src/main/msp/msp_serial.c
@@ -44,6 +44,7 @@ static mspPort_t mspPorts[MAX_MSP_PORT_COUNT];
 void resetMspPort(mspPort_t *mspPortToReset, serialPort_t *serialPort) {
     memset(mspPortToReset, 0, sizeof(mspPort_t));
     mspPortToReset->port = serialPort;
+    mspPortToReset->descriptor = mspDescriptorAlloc();
 }
 
 void mspSerialAllocatePorts(void) {
@@ -344,7 +345,7 @@ static mspPostProcessFnPtr mspSerialProcessReceivedCommand(mspPort_t *msp, mspPr
         .direction = MSP_DIRECTION_REQUEST,
     };
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    const mspResult_e status = mspProcessCommandFn(&command, &reply, &mspPostProcessFn);
+    const mspResult_e status = mspProcessCommandFn(msp->descriptor, &command, &reply, &mspPostProcessFn);
     if (status != MSP_RESULT_NO_REPLY) {
         sbufSwitchToReader(&reply.buf, outBufHead); // change streambuf direction
         mspSerialEncode(msp, &reply, msp->mspVersion);

--- a/src/main/msp/msp_serial.h
+++ b/src/main/msp/msp_serial.h
@@ -113,6 +113,7 @@ typedef struct mspPort_s {
     uint8_t checksum1;
     uint8_t checksum2;
     bool sharedWithTelemetry;
+    mspDescriptor_t descriptor;
 } mspPort_t;
 
 void mspSerialInit(void);

--- a/src/main/telemetry/msp_shared.c
+++ b/src/main/telemetry/msp_shared.c
@@ -59,8 +59,14 @@ static mspRxBuffer_t mspRxBuffer;
 static mspTxBuffer_t mspTxBuffer;
 static mspPacket_t mspRxPacket;
 static mspPacket_t mspTxPacket;
+static mspDescriptor_t mspSharedDescriptor;
+static bool mspSharedDescriptorInitialized;
 
 void initSharedMsp(void) {
+    if (!mspSharedDescriptorInitialized) {
+        mspSharedDescriptor = mspDescriptorAlloc();
+        mspSharedDescriptorInitialized = true;
+    }
     mspPackage.requestBuffer = (uint8_t *)&mspRxBuffer;
     mspPackage.requestPacket = &mspRxPacket;
     mspPackage.requestPacket->buf.ptr = mspPackage.requestBuffer;
@@ -76,7 +82,7 @@ static void processMspPacket(void) {
     mspPackage.responsePacket->result = 0;
     mspPackage.responsePacket->buf.end = mspPackage.responseBuffer;
     mspPostProcessFnPtr mspPostProcessFn = NULL;
-    if (mspFcProcessCommand(mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
+    if (mspFcProcessCommand(mspSharedDescriptor, mspPackage.requestPacket, mspPackage.responsePacket, &mspPostProcessFn) == MSP_RESULT_ERROR) {
         sbufWriteU8(&mspPackage.responsePacket->buf, TELEMETRY_MSP_ERROR);
     }
     if (mspPostProcessFn) {

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -369,4 +369,6 @@ bool boardInformationIsSet(void) { return true; };
 bool setBoardName(char *newBoardName) { UNUSED(newBoardName); return true; };
 bool setManufacturerId(char *newManufacturerId) { UNUSED(newManufacturerId); return true; };
 bool persistBoardInformation(void) { return true; };
+
+mspDescriptor_t mspDescriptorAlloc(void) { return 0; }
 }

--- a/src/test/unit/telemetry_crsf_msp_unittest.cc
+++ b/src/test/unit/telemetry_crsf_msp_unittest.cc
@@ -273,7 +273,8 @@ extern "C" {
 
     bool isAirmodeActive(void) {return true;}
 
-    mspResult_e mspFcProcessCommand(mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+    mspResult_e mspFcProcessCommand(mspDescriptor_t srcDesc, mspPacket_t *cmd, mspPacket_t *reply, mspPostProcessFnPtr *mspPostProcessFn) {
+        UNUSED(srcDesc);
 
         UNUSED(mspPostProcessFn);
 
@@ -297,4 +298,6 @@ extern "C" {
     int32_t getMAhDrawn(void) {
       return testmAhDrawn;
     }
+
+    mspDescriptor_t mspDescriptorAlloc(void) { return 0; }
 }


### PR DESCRIPTION
AI Generated pull-request

Backports master `7b1eae2e29` (#1159) to `0.4.3-maintenance`. Fixes issue #211: a second MSP
client (e.g. DJI OSD/system) could send `MSP_SET_ARMING_DISABLED(0)` and clear the
`ARMING_DISABLED_MSP` flag even while another client (e.g. the configurator) had legitimately
disabled arming. Adds `mspDescriptor_t`: each serial port, HDZero port, telemetry MSP path, and
CLI gets a unique descriptor allocated at init; `ARMING_DISABLED_MSP` is now only cleared once
every client that set it has released it (per-client bitmask). BF ref: betaflight/betaflight#9040.

Production code (`msp.c`, `msp.h`, `cli.c`, `displayport_hdzero_osd.c`, `msp_serial.c/h`,
`telemetry/msp_shared.c`) cherry-picked with zero conflicts. One conflict in
`src/test/unit/telemetry_crsf_msp_unittest.cc`: master's patch anchors on a CRSF/battery test-stub
block that PR #1099 (unit-test fixes, not backported here) added later; that block is unrelated to
this fix. Resolved by adding only the `mspDescriptorAlloc()` stub this fix's production code
actually requires, without pulling in #1099's unrelated stubs.

**Fix on top of the backport** (commit `fa5869905d`): CodeRabbit flagged that
`mspDescriptorAlloc()` returned `0` on descriptor-pool exhaustion (all 32 slots allocated),
aliasing the fallback with the legitimately-allocated first descriptor — a 33rd client could then
clear descriptor 0's arming-disable bit and re-enable arming while the real descriptor-0 client
still expected it disabled. This exact bug is still present on master's own `msp.c` today, unrelated
to this backport. Fixed here by returning a distinct `MSP_DESCRIPTOR_INVALID` (-1) sentinel and
rejecting out-of-range descriptors in both bitmask helpers and the `MSP_SET_ARMING_DISABLED`
handler.

Verified:
- `0.4.3-maintenance`'s existing local unit-test suite (`arming_prevention_unittest`,
  `cli_unittest`, `telemetry_crsf_msp_unittest`) fails to build with the current toolchain
  independent of this change — confirmed byte-identical failures on a clean, unpatched
  `0.4.3-maintenance` checkout. Pre-existing gap (maintenance has no `test.yml` CI at all).
- Master's original PR #1159 added no behavioral unit test for the per-client bitmask logic either
  — `msp.c` has no direct-compile unit test target in this codebase.
- Extracted the bitmask arithmetic into a standalone harness and mechanically exercised: the issue
  #211 bypass scenario, multi-client release ordering, the UB-shift fix at descriptor 31, and
  (post-fix) the descriptor-pool-exhaustion case no longer aliasing descriptor 0. All passed.
- Full `HELIOSPRING` firmware build succeeds (both before and after the exhaustion fix);
  `USE_HDZERO_OSD` is unconditionally enabled in that build, exercising `displayport_hdzero_osd.c`.