### PR TITLE
fix(msp): don't alias exhausted descriptor pool to descriptor 0

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -154,7 +154,7 @@ static int mspDescriptorCounter = 0;
 mspDescriptor_t mspDescriptorAlloc(void)
 {
     if (mspDescriptorCounter >= (int)(sizeof(uint32_t) * 8)) {
-        return (mspDescriptor_t)0;
+        return MSP_DESCRIPTOR_INVALID;
     }
     return (mspDescriptor_t)mspDescriptorCounter++;
 }
@@ -163,11 +163,17 @@ static uint32_t mspArmingDisableFlags = 0;
 
 static void mspArmingDisableByDescriptor(mspDescriptor_t desc)
 {
+    if (desc < 0 || desc >= (int)(sizeof(uint32_t) * 8)) {
+        return;
+    }
     mspArmingDisableFlags |= ((uint32_t)1 << desc);
 }
 
 static void mspArmingEnableByDescriptor(mspDescriptor_t desc)
 {
+    if (desc < 0 || desc >= (int)(sizeof(uint32_t) * 8)) {
+        return;
+    }
     mspArmingDisableFlags &= ~((uint32_t)1 << desc);
 }
 
@@ -2113,6 +2119,9 @@ mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t 
     break;
 #endif
         case MSP_SET_ARMING_DISABLED: {
+    if (srcDesc < 0 || srcDesc >= (int)(sizeof(uint32_t) * 8)) {
+    return MSP_RESULT_ERROR;
+    }
     const uint8_t command = sbufReadU8(src);
     uint8_t disableRunawayTakeoff = 0;
 #ifndef USE_RUNAWAY_TAKEOFF

--- a/src/main/interface/msp.h
+++ b/src/main/interface/msp.h
@@ -55,6 +55,7 @@ typedef struct mspPacket_s {
 } mspPacket_t;
 
 typedef int mspDescriptor_t;
+#define MSP_DESCRIPTOR_INVALID ((mspDescriptor_t)-1)
 
 struct serialPort_s;
 typedef void (*mspPostProcessFnPtr)(struct serialPort_s *port); // msp post process function, used for gracefully handling reboots, etc.


### PR DESCRIPTION
AI Generated pull-request

Closes #1319.

`mspDescriptorAlloc()` (added by #1159) returned `0` after all 32 descriptor slots were allocated,
aliasing the exhaustion fallback with the legitimately-allocated first descriptor. A 33rd
MSP-capable client (serial port, HDZero, telemetry MSP bridge, or CLI) could then clear
descriptor 0's arming-disable bit via `MSP_SET_ARMING_DISABLED(0)`, re-enabling arming while the
real descriptor-0 client still expected `ARMING_DISABLED_MSP` set — the same class of bypass
#1159/#211 was written to close.

Fix: return `MSP_DESCRIPTOR_INVALID` (-1) on exhaustion instead of `0`. Guard
`mspArmingDisableByDescriptor()`/`mspArmingEnableByDescriptor()` against out-of-range descriptors
before shifting. Reject an invalid `srcDesc` in the `MSP_SET_ARMING_DISABLED` handler with
`MSP_RESULT_ERROR`.

Surfaced by CodeRabbit during review of #1318 (backport of #1159 to `0.4.3-maintenance`) — this
bug pre-dates that backport and is independent of it; same fix applied there in
commit `fa5869905d`.

Verified: `HELIOSPRING` build succeeds. Mechanically exercised the descriptor-bitmask arithmetic
in a standalone harness (multi-client disable/enable ordering, UB-shift at descriptor 31,
exhaustion no longer aliasing descriptor 0) — all pass. No existing unit test targets `msp.c`
directly in this codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for arming-disable descriptors.
  * Invalid descriptor values are now safely rejected instead of modifying settings or causing unexpected behavior.
  * Added a standardized invalid descriptor value for clearer error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->