### PR TITLE
fix(pid): unify directFF pure-P-term gate with pidLevel() call site

### DIFF
--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -354,6 +354,7 @@ typedef struct pidCoefficient_s {
 static FAST_RAM_ZERO_INIT pidCoefficient_t pidCoefficient[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT float directFF[3];
 static FAST_RAM_ZERO_INIT float angleModeP[2];
+static FAST_RAM_ZERO_INIT bool pidLevelActive[2]; // true when pidLevel() ran for this axis this cycle, regardless of which flight mode triggered it
 static FAST_RAM_ZERO_INIT float maxVelocity[XYZ_AXIS_COUNT];
 static FAST_RAM_ZERO_INIT float feathered_pids;
 static FAST_RAM_ZERO_INIT float setPointPTransition[XYZ_AXIS_COUNT];
@@ -542,6 +543,7 @@ static float pidLevel(int axis, const pidProfile_t *pidProfile, const rollAndPit
 
     currentPidSetpoint = p_term_low + p_term_high;
     angleModeP[axis] = p_term_low + p_term_high;
+    pidLevelActive[axis] = true;
     currentPidSetpoint += d_term_low + d_term_high;
     currentPidSetpoint += f_term_low;
 
@@ -712,6 +714,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
         // disable directFF for pitch and roll while not in angle
         if (axis != FD_YAW) {
             directFF[axis] = 0.0f;
+            pidLevelActive[axis] = false;
         }
 
         if (axis == FD_YAW) {
@@ -856,7 +859,7 @@ void pidController(const pidProfile_t *pidProfile, const rollAndPitchTrims_t *an
         // since yaw acts different this will only work for yaw
         // actually this also works in angle mode so pitch and roll have angle mode values
         float directFeedForward;
-        if ((FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) && axis <= FD_PITCH) {
+        if (axis <= FD_PITCH && pidLevelActive[axis]) {
             directFeedForward = angleModeP[axis] * directFF[axis];
         } else {
             directFeedForward = currentPidSetpoint * directFF[axis];

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -442,12 +442,12 @@ TEST(pidControllerTest, testPidHorizon) {
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 }
 
-// Identical priming + step sequence under the given flight mode so pidLevel()'s internal state starts equal for any mode compared.
-void primeAndStepUnderFlightMode(flightModeFlags_e flightMode) {
+// Identical priming + step sequence under the given flight mode mask (0 = plain rate/acro) so pidLevel()'s internal state starts equal for any mode compared.
+void primeAndStepUnderFlightMode(int flightModeMask) {
     resetTest();
     ENABLE_ARMING_FLAG(ARMED);
     pidStabilisationState(PID_STABILISATION_ON);
-    enableFlightMode(flightMode);
+    enableFlightMode(static_cast<flightModeFlags_e>(flightModeMask));
 
     // Default test profile has PID_LEVEL_LOW.I=0, which zeroes directFF entirely.
     pidProfile->pid[PID_LEVEL_LOW].I = 70;
@@ -468,7 +468,7 @@ void primeAndStepUnderFlightMode(flightModeFlags_e flightMode) {
     attitude.values.pitch = -550;
     pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
 
-    disableFlightMode(flightMode);
+    disableFlightMode(static_cast<flightModeFlags_e>(flightModeMask));
 }
 
 TEST(pidControllerTest, testGpsRescueUsesPidLevelDirectFF) {
@@ -491,43 +491,19 @@ TEST(pidControllerTest, testGpsRescueUsesPidLevelDirectFF) {
 }
 
 TEST(pidControllerTest, testNfeRaceModeOnlyEngagesPidLevelOnRoll) {
-    // NFE_RACE_MODE + ANGLE_MODE excludes pitch from the pidLevel() call site; pitch must match plain rate/acro exactly.
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-
-    setStickPosition(FD_ROLL, 1.0f);
-    setStickPosition(FD_PITCH, -1.0f);
-    attitude.values.roll = 0;
-    attitude.values.pitch = 0;
-
-    enableFlightMode(ANGLE_MODE);
-    enableFlightMode(NFE_RACE_MODE);
-    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
-    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    // NFE_RACE_MODE + ANGLE_MODE excludes pitch from the pidLevel() call site; pitch must match plain rate/acro exactly, with directFF actually non-zero (PID_LEVEL_LOW.I set via the shared helper).
+    primeAndStepUnderFlightMode(ANGLE_MODE | NFE_RACE_MODE);
     const float nfeRollSum = pidData[FD_ROLL].Sum;
     const float nfePitchSum = pidData[FD_PITCH].Sum;
-    disableFlightMode(NFE_RACE_MODE);
-    disableFlightMode(ANGLE_MODE);
 
-    resetTest();
-    ENABLE_ARMING_FLAG(ARMED);
-    pidStabilisationState(PID_STABILISATION_ON);
-    setStickPosition(FD_ROLL, 1.0f);
-    setStickPosition(FD_PITCH, -1.0f);
-    attitude.values.roll = 0;
-    attitude.values.pitch = 0;
-
-    // Plain rate/acro mode - pidLevel() never runs for either axis
-    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
-    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    primeAndStepUnderFlightMode(0);
     const float rateRollSum = pidData[FD_ROLL].Sum;
     const float ratePitchSum = pidData[FD_PITCH].Sum;
 
-    // Roll engaged pidLevel() (angle mode P-term path) - output must differ from plain rate
+    // Roll engaged pidLevel() (angle mode P-term path) - output must differ from plain rate.
     EXPECT_GT(fabs(nfeRollSum - rateRollSum), 1.0f);
-    // Pitch never engaged pidLevel() under NFE - output matches plain rate exactly
-    EXPECT_NEAR(ratePitchSum, nfePitchSum, calculateToleranceWithFloor(ratePitchSum));
+    // Pitch never engaged pidLevel() under NFE - output matches plain rate exactly.
+    EXPECT_NEAR(ratePitchSum, nfePitchSum, 1.0f);
 }
 
 TEST(pidControllerTest, testMixerSaturation) {

--- a/src/test/unit/pid_unittest.cc
+++ b/src/test/unit/pid_unittest.cc
@@ -442,6 +442,94 @@ TEST(pidControllerTest, testPidHorizon) {
     EXPECT_FLOAT_EQ(0, pidData[FD_YAW].I);
 }
 
+// Identical priming + step sequence under the given flight mode so pidLevel()'s internal state starts equal for any mode compared.
+void primeAndStepUnderFlightMode(flightModeFlags_e flightMode) {
+    resetTest();
+    ENABLE_ARMING_FLAG(ARMED);
+    pidStabilisationState(PID_STABILISATION_ON);
+    enableFlightMode(flightMode);
+
+    // Default test profile has PID_LEVEL_LOW.I=0, which zeroes directFF entirely.
+    pidProfile->pid[PID_LEVEL_LOW].I = 70;
+    pidInitConfig(pidProfile);
+
+    setStickPosition(FD_ROLL, 0.2f);
+    setStickPosition(FD_PITCH, -0.2f);
+    attitude.values.roll = 100;
+    attitude.values.pitch = -100;
+    for (int i = 0; i < 5; i++) {
+        pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    }
+
+    // Step change - D/F terms are non-zero on this single next call.
+    setStickPosition(FD_ROLL, 1.0f);
+    setStickPosition(FD_PITCH, -1.0f);
+    attitude.values.roll = 550;
+    attitude.values.pitch = -550;
+    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+
+    disableFlightMode(flightMode);
+}
+
+TEST(pidControllerTest, testGpsRescueUsesPidLevelDirectFF) {
+    // GPS_RESCUE_MODE must select the same pure-P-term directFF path as ANGLE_MODE, not the pre-#1257 D/F-contaminated fallback.
+    primeAndStepUnderFlightMode(ANGLE_MODE);
+    const float angleModeRollSum = pidData[FD_ROLL].Sum;
+    const float angleModePitchSum = pidData[FD_PITCH].Sum;
+
+    primeAndStepUnderFlightMode(GPS_RESCUE_MODE);
+    const float gpsRescueRollSum = pidData[FD_ROLL].Sum;
+    const float gpsRescuePitchSum = pidData[FD_PITCH].Sum;
+
+    // Transient must be non-zero or the two paths can't be distinguished.
+    ASSERT_GT(fabs(angleModeRollSum), 1.0f);
+    ASSERT_GT(fabs(angleModePitchSum), 1.0f);
+
+    // ~0.03 residual noise when fixed vs ~7.8 divergence when GPS Rescue falls back to the D/F-contaminated path.
+    EXPECT_NEAR(angleModeRollSum, gpsRescueRollSum, 1.0f);
+    EXPECT_NEAR(angleModePitchSum, gpsRescuePitchSum, 1.0f);
+}
+
+TEST(pidControllerTest, testNfeRaceModeOnlyEngagesPidLevelOnRoll) {
+    // NFE_RACE_MODE + ANGLE_MODE excludes pitch from the pidLevel() call site; pitch must match plain rate/acro exactly.
+    resetTest();
+    ENABLE_ARMING_FLAG(ARMED);
+    pidStabilisationState(PID_STABILISATION_ON);
+
+    setStickPosition(FD_ROLL, 1.0f);
+    setStickPosition(FD_PITCH, -1.0f);
+    attitude.values.roll = 0;
+    attitude.values.pitch = 0;
+
+    enableFlightMode(ANGLE_MODE);
+    enableFlightMode(NFE_RACE_MODE);
+    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    const float nfeRollSum = pidData[FD_ROLL].Sum;
+    const float nfePitchSum = pidData[FD_PITCH].Sum;
+    disableFlightMode(NFE_RACE_MODE);
+    disableFlightMode(ANGLE_MODE);
+
+    resetTest();
+    ENABLE_ARMING_FLAG(ARMED);
+    pidStabilisationState(PID_STABILISATION_ON);
+    setStickPosition(FD_ROLL, 1.0f);
+    setStickPosition(FD_PITCH, -1.0f);
+    attitude.values.roll = 0;
+    attitude.values.pitch = 0;
+
+    // Plain rate/acro mode - pidLevel() never runs for either axis
+    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    pidController(pidProfile, &rollAndPitchTrims, currentTestTime());
+    const float rateRollSum = pidData[FD_ROLL].Sum;
+    const float ratePitchSum = pidData[FD_PITCH].Sum;
+
+    // Roll engaged pidLevel() (angle mode P-term path) - output must differ from plain rate
+    EXPECT_GT(fabs(nfeRollSum - rateRollSum), 1.0f);
+    // Pitch never engaged pidLevel() under NFE - output matches plain rate exactly
+    EXPECT_NEAR(ratePitchSum, nfePitchSum, calculateToleranceWithFloor(ratePitchSum));
+}
+
 TEST(pidControllerTest, testMixerSaturation) {
     resetTest();
     ENABLE_ARMING_FLAG(ARMED);


### PR DESCRIPTION
AI Generated pull-request

## Summary

Resolves #1323. `pid.c` gated which flight modes call `pidLevel()` (call site, ~L717-724 —
includes `GPS_RESCUE_MODE`) and which directFF source to use (~L859, added in #1257 —
`ANGLE_MODE`/`HORIZON_MODE` only) with two independently-maintained conditionals that had
drifted: GPS Rescue populated `directFF[axis]` via `pidLevel()` but never got routed through the
pure-P-term fix from #1257, silently falling back to the pre-fix D/F-contaminated
`currentPidSetpoint`-based calc.

## Changes (`src/main/flight/pid.c`, 4 lines added, 1 changed)

- Added `static FAST_RAM_ZERO_INIT bool pidLevelActive[2];` next to `angleModeP[2]` (same sizing
  — `pidLevel()` never runs for YAW).
- Reset `pidLevelActive[axis] = false` each cycle alongside the existing `directFF[axis] = 0.0f`
  reset (~L713-716).
- Set `pidLevelActive[axis] = true` inside `pidLevel()` itself (~L544, next to the existing
  `angleModeP[axis]` capture) — single point of truth, regardless of which of the three
  call-site branches invoked it.
- L859 now reads `axis <= FD_PITCH && pidLevelActive[axis]` instead of re-deriving
  `(FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) && axis <= FD_PITCH`. `axis <= FD_PITCH`
  kept for array-bounds safety (same reasoning as #1257).

Call-site conditional (~L717-724) intentionally left untouched — collapsing its three branches
into one is a separate simplification not required to close this gap.

Net effect: `GPS_RESCUE_MODE` gets the same pure-P-term directFF treatment as
`ANGLE_MODE`/`HORIZON_MODE`, and any future flight mode calling `pidLevel()` inherits the fix
automatically with no second gate to remember to update.

## Test plan

- [x] Unit tests: `make test` — 0 failures
- [x] Compile-gate real-aircraft targets: `make HELIOSPRING FOXEERF722V4 STELLARH7DEV` — 3
      succeeded, 0 failed
- [ ] Hardware flight test — not performed. This is PID control logic, not a
      flash/SPI/gyro/DMA/USB driver change, so mandatory hardware-verification doesn't apply;
      the RTH-flyoff magnitude in real flight remains unconfirmed per #1323 (this closes the
      structural gate gap, not a hardware-validated behavior change)

Related: #1257, #1184, #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved roll/pitch direct-feedforward scaling by using whether leveling control actually ran during the current PID cycle, instead of depending on flight-mode conditions.
  * Updated handling when non-YAW direct feedforward is disabled to ensure consistent roll/pitch behavior.

* **Tests**
  * Added regression coverage confirming GPS RESCUE uses the same PID-level direct-feedforward path as ANGLE mode.
  * Added coverage confirming NFE RACE engages PID-level only for roll (with pitch matching expected behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->