### PR TITLE
fix(h7): bounds-validate dmaIdentifier_e before dmaDescriptors[] indexing

### DIFF
--- a/src/main/drivers/dma_stm32h7xx.c
+++ b/src/main/drivers/dma_stm32h7xx.c
@@ -80,8 +80,17 @@ static void enableDmaClock(int index)
     /* DMAMUX1 has no separate clock bit in this HAL; it is gated by DMA1/DMA2 */
 }
 
+// guards dmaDescriptors[] indexing against out-of-range/stale identifiers (issue #1205)
+static inline bool dmaIdentifierIsValid(dmaIdentifier_e identifier)
+{
+    return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
+}
+
 void dmaEnable(dmaIdentifier_e identifier)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
 
     enableDmaClock(index);
@@ -89,6 +98,9 @@ void dmaEnable(dmaIdentifier_e identifier)
 
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
 
     enableDmaClock(index);
@@ -101,7 +113,7 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
 
 bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)
 {
-    if (identifier == DMA_NONE) {
+    if (!dmaIdentifierIsValid(identifier)) {
         return false;
     }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
@@ -115,6 +127,9 @@ bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t reso
 
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     enableDmaClock(index);
     dmaDescriptors[index].owner = owner;
@@ -123,11 +138,17 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
 
 resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return OWNER_FREE;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return 0;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
@@ -143,11 +164,17 @@ dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef *stream)
 
 DMA_Stream_TypeDef *dmaGetRefByIdentifier(const dmaIdentifier_e identifier)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return NULL;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }
 
 dmaChannelDescriptor_t *dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier)
 {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return NULL;
+    }
     return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)];
 }
 


### PR DESCRIPTION
AI Generated pull-request

Closes #1205

## Summary

`dma_stm32h7xx.c` indexes `dmaDescriptors[DMA_LAST_HANDLER]` (16 entries) via `DMA_IDENTIFIER_TO_INDEX(identifier) = identifier - 1` in 8 functions. Only `dmaAllocate` checked for `DMA_NONE`; the other 7 (`dmaEnable`, `dmaSetHandler`, `dmaInit`, `dmaGetOwner`, `dmaGetResourceIndex`, `dmaGetRefByIdentifier`, `dmaGetDescriptorByIdentifier`) performed no validation.

- `identifier == DMA_NONE` (0) → index -1 → out-of-bounds access before the array.
- `identifier > DMA_LAST_HANDLER` (16) → index past the array end.

Both cases read/write adjacent memory; corrupted `.irqN`/`.dma` fields subsequently feed `HAL_NVIC_SetPriority`/`RCC_ClockCmd`, which is undefined behavior and a potential hardfault. Currently latent — no known caller passes an out-of-range identifier on existing targets — but the guard is missing for any future caller.

## Fix

Adds `dmaIdentifierIsValid()`:
```c
static inline bool dmaIdentifierIsValid(dmaIdentifier_e identifier) {
    return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
}
```
and guards all 8 access points with an early return. Widens `dmaAllocate`'s existing `== DMA_NONE` check to the full-range validator.

## BF-equivalence check

Checked Betaflight 4.5-maintenance `drivers/dma_common.c` and `drivers/stm32/dma_stm32h7xx.c` — BF has **no bounds validation at all** on this same index path (less defensive than EF's pre-existing partial `DMA_NONE` check in `dmaAllocate`). There is no BF guard pattern to port; this is a standalone defensive addition, not a backport. Matches the fix already proposed in issue #1205.

## Scope

Limited to `dma_stm32h7xx.c` per issue #1205. `dma_stm32f7xx.c` and `dma_stm32f4xx.c` have the identical unguarded pattern (EF duplicates the shared-descriptor logic per MCU file, where BF centralizes it in `dma_common.c`) — flagged as a related pre-existing finding, intentionally left out of this PR's scope.

## Verification

- `make clean && CCACHE_DISABLE=1 make STELLARH7DEV` — build succeeds, 0 warnings, 0 errors.
- `make test` — 39/39 unit test binaries pass (227 individual test cases, 0 failures).
- `coderabbit review --agent --base upstream/master` — 0 findings.

## Hardware verification — PENDING

This is a driver-level DMA change. Per project AGENTS.md, any driver change touching flash/SPI/gyro/DMA/USB requires hardware verification on a real aircraft before merge. **This PR has NOT been flight-tested or bench-verified on real STELLARH7DEV hardware (H7 bring-up board).** Only host-native unit tests and a clean compile have been performed; DMA/interrupt timing, real hardware fault behavior, and runtime correctness on target are unverified. PR stays DRAFT until hardware verification on STELLARH7DEV is completed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or outdated DMA identifiers.
  * Prevented invalid requests from changing DMA state, enabling hardware resources, or activating interrupts.
  * Added safe default responses when querying ownership, resource indexes, references, or descriptors with invalid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->