### PR TITLE
fix(dma): guard dmaDescriptors[] indexing on F4/F7 against invalid identifiers

### DIFF
--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -75,7 +75,7 @@ DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
 #define DMA_RCC(x) ((x) == DMA1 ? RCC_AHB1Periph_DMA1 : RCC_AHB1Periph_DMA2)
 
-// guards dmaDescriptors[] indexing against out-of-range/stale identifiers (issue #1341)
+// guards dmaDescriptors[] indexing against out-of-range/stale identifiers
 static inline bool dmaIdentifierIsValid(dmaIdentifier_e identifier) {
     return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
 }

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -75,8 +75,13 @@ DEFINE_DMA_IRQ_HANDLER(2, 7, DMA2_ST7_HANDLER)
 
 #define DMA_RCC(x) ((x) == DMA1 ? RCC_AHB1Periph_DMA1 : RCC_AHB1Periph_DMA2)
 
+// guards dmaDescriptors[] indexing against out-of-range/stale identifiers (issue #1341)
+static inline bool dmaIdentifierIsValid(dmaIdentifier_e identifier) {
+    return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
+}
+
 bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
-    if (identifier == DMA_NONE) {
+    if (!dmaIdentifierIsValid(identifier)) {
         return false;
     }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
@@ -89,7 +94,7 @@ bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t reso
 }
 
 void dmaEnable(dmaIdentifier_e identifier) {
-    if (identifier == DMA_NONE) {
+    if (!dmaIdentifierIsValid(identifier)) {
         return;
     }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
@@ -97,6 +102,9 @@ void dmaEnable(dmaIdentifier_e identifier) {
 }
 
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     RCC_AHB1PeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);
     dmaDescriptors[index].owner = owner;
@@ -118,6 +126,9 @@ uint32_t dmaFlag_IT_TCIF(const DMA_Stream_TypeDef *stream) {
 }
 
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     NVIC_InitTypeDef NVIC_InitStructure;
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     RCC_AHB1PeriphClockCmd(DMA_RCC(dmaDescriptors[index].dma), ENABLE);
@@ -132,10 +143,16 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
 }
 
 resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return OWNER_FREE;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return 0;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
@@ -158,10 +175,16 @@ dmaChannelDescriptor_t* dmaGetDescriptor(const DMA_Stream_TypeDef* stream) {
 }
 
 DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return NULL;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }
 
 dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return NULL;
+    }
     return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)];
 }
 

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -85,7 +85,7 @@ static void enableDmaClock(int index) {
     } while (0);
 }
 
-// guards dmaDescriptors[] indexing against out-of-range/stale identifiers (issue #1341)
+// guards dmaDescriptors[] indexing against out-of-range/stale identifiers
 static inline bool dmaIdentifierIsValid(dmaIdentifier_e identifier) {
     return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
 }

--- a/src/main/drivers/dma_stm32f7xx.c
+++ b/src/main/drivers/dma_stm32f7xx.c
@@ -85,8 +85,13 @@ static void enableDmaClock(int index) {
     } while (0);
 }
 
+// guards dmaDescriptors[] indexing against out-of-range/stale identifiers (issue #1341)
+static inline bool dmaIdentifierIsValid(dmaIdentifier_e identifier) {
+    return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
+}
+
 bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
-    if (identifier == DMA_NONE) {
+    if (!dmaIdentifierIsValid(identifier)) {
         return false;
     }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
@@ -99,7 +104,7 @@ bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t reso
 }
 
 void dmaEnable(dmaIdentifier_e identifier) {
-    if (identifier == DMA_NONE) {
+    if (!dmaIdentifierIsValid(identifier)) {
         return;
     }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
@@ -107,6 +112,9 @@ void dmaEnable(dmaIdentifier_e identifier) {
 }
 
 void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     enableDmaClock(index);
     dmaDescriptors[index].owner = owner;
@@ -114,6 +122,9 @@ void dmaInit(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resource
 }
 
 void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uint32_t userParam) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return;
+    }
     const int index = DMA_IDENTIFIER_TO_INDEX(identifier);
     enableDmaClock(index);
     dmaDescriptors[index].irqHandlerCallback = callback;
@@ -123,10 +134,16 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
 }
 
 resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return OWNER_FREE;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].owner;
 }
 
 uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return 0;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].resourceIndex;
 }
 
@@ -140,10 +157,16 @@ dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef* stream) {
 }
 
 DMA_Stream_TypeDef* dmaGetRefByIdentifier(const dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return NULL;
+    }
     return dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)].ref;
 }
 
 dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier) {
+    if (!dmaIdentifierIsValid(identifier)) {
+        return NULL;
+    }
     return &dmaDescriptors[DMA_IDENTIFIER_TO_INDEX(identifier)];
 }
 

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -112,6 +112,10 @@ common_filter_unittest_SRC := \
 		$(USER_DIR)/common/maths.c
 
 
+dma_bounds_unittest_DEFINES := \
+		STM32F4
+
+
 encoding_unittest_SRC := \
 		$(USER_DIR)/common/encoding.c
 

--- a/src/test/unit/dma_bounds_unittest.cc
+++ b/src/test/unit/dma_bounds_unittest.cc
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// Mirrors the identifier-range guard duplicated in dma_stm32f4xx.c / dma_stm32f7xx.c / dma_stm32h7xx.c.
+static bool dmaIdentifierIsValid(dmaIdentifier_e identifier) {
+    return identifier > DMA_NONE && identifier <= DMA_LAST_HANDLER;
+}
+
+TEST(DmaBoundsUnittest, RejectsNoneIdentifier)
+{
+    EXPECT_FALSE(dmaIdentifierIsValid(DMA_NONE));
+}
+
+TEST(DmaBoundsUnittest, RejectsIdentifierPastLastHandler)
+{
+    const dmaIdentifier_e pastLast = static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1);
+    EXPECT_FALSE(dmaIdentifierIsValid(pastLast));
+}
+
+TEST(DmaBoundsUnittest, AcceptsFirstAndLastHandler)
+{
+    const dmaIdentifier_e first = static_cast<dmaIdentifier_e>(DMA_NONE + 1);
+    EXPECT_TRUE(dmaIdentifierIsValid(first));
+    EXPECT_TRUE(dmaIdentifierIsValid(DMA_LAST_HANDLER));
+}

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -79,6 +79,10 @@ typedef struct {
     void* test;
 } DMA_Channel_TypeDef;
 
+typedef struct {
+    void* test;
+} DMA_Stream_TypeDef;
+
 uint8_t DMA_GetFlagStatus(void *);
 void DMA_Cmd(DMA_Channel_TypeDef*, FunctionalState );
 void DMA_ClearFlag(uint32_t);


### PR DESCRIPTION
AI Generated [pull-request]

## Summary

- Ports `dmaIdentifierIsValid()` from PR #1325 (H7 fix for issue #1205) to `dma_stm32f4xx.c` and `dma_stm32f7xx.c`
- `dmaGetOwner`, `dmaGetResourceIndex`, `dmaGetRefByIdentifier`, `dmaGetDescriptorByIdentifier`, `dmaSetHandler`, and `dmaInit` indexed `dmaDescriptors[]` via `DMA_IDENTIFIER_TO_INDEX()` with no bounds check; `dmaAllocate`/`dmaEnable` only checked `identifier != DMA_NONE`, not the upper bound
- `identifier == DMA_NONE` underflows the index, `identifier > DMA_LAST_HANDLER` overflows it — undefined behavior/potential hardfault on any caller that passes an invalid identifier
- Currently latent: no known caller passes an out-of-range identifier to these functions on F4/F7 today
- BF 4.5-maintenance has zero bounds validation on the equivalent path (verified directly for the H7 fix) — this is EF-original defensive hardening, not a BF port

Closes #1341.

## Test plan

- [x] `make clean_test && make test` — all suites pass, 0 failures
- [x] `make HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7` — 8 succeeded, 0 failed, no new warnings
- [x] CodeRabbit (`--base upstream/master`): 0 findings
- [ ] Hardware verification — not required; this is a defensive-only guard on a currently-latent, never-triggered path (matches PR #1325's rationale); no behavior change on any valid identifier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DMA handling by validating incoming DMA identifiers before accessing internal descriptor tables.
  * Prevented invalid or stale identifiers from triggering unintended state changes or unsafe memory access.
  * Standardized safe fallback behavior for invalid identifiers: allocation fails, enable/init/set-handler become no-ops, and queries for owner, resource index, descriptors, and references return safe defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->