### PR TITLE
Activate spiInitBusDMA() for F4/F7 targets (partial #1340)

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -142,17 +142,7 @@ bool spiInit(SPIDevice device) {
 #endif
         break;
     }
-    if (ok) {
-        busDevice_t *bus = spiBusByDevice(device);
-        if (bus) {
-            bus->busType = BUS_TYPE_SPI;
-            bus->busType_u.spi.instance = spiDevice[device].dev;
-#if defined(USE_HAL_DRIVER)
-            bus->busType_u.spi.handle = &spiDevice[device].hspi;
-#endif
-            bus->curSegment = (busSegment_t *)BUS_SPI_FREE;
-        }
-    }
+    // busDevice_t bookkeeping belongs to spiSetBusInstance()'s first-registration branch, not here.
     return ok;
 }
 

--- a/src/main/drivers/bus_spi.h
+++ b/src/main/drivers/bus_spi.h
@@ -119,8 +119,8 @@ SPIDevice spiDeviceByInstance(SPI_TypeDef *instance);
 SPI_TypeDef *spiInstanceByDevice(SPIDevice device);
 
 // Bus-abstraction accessor. Returns a pointer to the shared busDevice_t that
-// represents the given SPI peripheral (populated by spiInit()). Returns NULL
-// for invalid devices.
+// represents the given SPI peripheral (populated by spiSetBusInstance() on
+// first device registration). Returns NULL for invalid devices.
 busDevice_t *spiBusByDevice(SPIDevice device);
 
 // Mark an extDevice_t as belonging to an SPI bus, using the 1-based CLI device id.

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -671,6 +671,12 @@ void init(void) {
     latchActiveFeatures();
     pwmEnableMotors();
     setArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
+#if defined(USE_SPI) && defined(USE_SPI_DMA_ENABLE_LATE)
+    // Must run after every dmaInit() caller above (motors, ADC, LED strip,
+    // transponder, SD card) and before fcTasksInit(), which triggers the first
+    // gyro read that latches GYRO_EXTI_INT_DMA vs GYRO_EXTI_INT (accgyro_mpu.c).
+    spiInitBusDMA();
+#endif
     fcTasksInit();
     systemState |= SYSTEM_STATE_READY;
 }

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -672,9 +672,7 @@ void init(void) {
     pwmEnableMotors();
     setArmingDisabled(ARMING_DISABLED_BOOT_GRACE_TIME);
 #if defined(USE_SPI) && defined(USE_SPI_DMA_ENABLE_LATE)
-    // Must run after every dmaInit() caller above (motors, ADC, LED strip,
-    // transponder, SD card) and before fcTasksInit(), which triggers the first
-    // gyro read that latches GYRO_EXTI_INT_DMA vs GYRO_EXTI_INT (accgyro_mpu.c).
+    // Must run after every dmaInit() caller above and before fcTasksInit()'s first gyro read.
     spiInitBusDMA();
 #endif
     fcTasksInit();

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -30,8 +30,7 @@
 #undef USE_VTX_TRAMP
 #endif
 
-// IMUF9001 boards drive SPI1 DMA directly (accgyro_mpu.c); the generic path
-// must not also claim those streams.
+// IMUF9001 boards own SPI1 DMA directly (accgyro_mpu.c), not via the generic path
 #if defined(USE_GYRO_IMUF9001)
 #undef USE_SPI_DMA_ENABLE_LATE
 #endif

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -30,6 +30,12 @@
 #undef USE_VTX_TRAMP
 #endif
 
+// IMUF9001 boards drive SPI1 DMA directly (accgyro_mpu.c); the generic path
+// must not also claim those streams.
+#if defined(USE_GYRO_IMUF9001)
+#undef USE_SPI_DMA_ENABLE_LATE
+#endif
+
 #ifndef USE_DSHOT
 #undef USE_ESC_SENSOR
 #endif

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -59,6 +59,11 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
+// SPI DMA must claim its streams after every dmaInit() caller (motors, ADC, LED
+// strip, transponder, SD card) has already run — dmaInit() overwrites ownership
+// unconditionally, unlike dmaAllocate(). common_fc_post.h strips this for
+// USE_GYRO_IMUF9001 boards, which own SPI1 DMA directly.
+#define USE_SPI_DMA_ENABLE_LATE
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)
 #define USE_OVERCLOCK
@@ -78,6 +83,7 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
+#define USE_SPI_DMA_ENABLE_LATE
 #endif
 
 #ifdef STM32H7

--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -59,10 +59,7 @@
 #define USE_ADC_INTERNAL
 #define USE_USB_CDC_HID
 #define USE_USB_MSC
-// SPI DMA must claim its streams after every dmaInit() caller (motors, ADC, LED
-// strip, transponder, SD card) has already run — dmaInit() overwrites ownership
-// unconditionally, unlike dmaAllocate(). common_fc_post.h strips this for
-// USE_GYRO_IMUF9001 boards, which own SPI1 DMA directly.
+// dmaInit() (used elsewhere in fc_init.c) has no ownership check, unlike dmaAllocate(), so SPI must claim last.
 #define USE_SPI_DMA_ENABLE_LATE
 
 #if defined(STM32F40_41xxx) || defined(STM32F411xE)


### PR DESCRIPTION
AI Generated pull-request

## Scope vs. issue #1340 — partial resolution, not full closure

Issue #1340's third comment declares two things in scope: (a) generic `spiInitBusDMA()`
activation fleet-wide, explicitly including HELIOSPRING's own SPI2 (Ext SPI) and SPI3
(Flash/OSD), and (b) confirms SPI1 on IMUF9001 boards stays permanently on PR #1283's
dedicated path. This PR delivers (a) only for non-`USE_GYRO_IMUF9001` targets — it
excludes HELIOSPRING/STRIXF10/MODE2FLUX **entirely** (not just their SPI1), deferring their
SPI2/SPI3 to a follow-up despite the issue calling that in scope. H7 is also out of scope
here (no H7 real-aircraft testing done in this PR). This does **not** close #1340 outright;
it resolves the F4/F7-non-IMUF9001 portion. A follow-up PR is needed for IMUF9001-board
SPI2/SPI3 and H7 before #1340 can actually close.

## Issue #1340's own root-cause theory was incorrect

The issue attributes the activation gap to EmuFlight lacking BF's
`motorPostInit()`/`motorEnable()` split (BF's `USE_SPI_DMA_ENABLE_EARLY`/`_LATE`
ordering). Direct comparison shows that's not the real blocker: DSHOT/PWM claims its DMA
inside `motorDevInit()` in both codebases, before either ordering's call site; BF's
EARLY/LATE distinction only matters for DSHOT bitbang, which EmuFlight doesn't implement
at all. The actual reason SPI must claim its DMA streams last: EmuFlight's `dmaInit()` (26
call sites — motors, UART, ADC, LED strip, transponder, SD card) overwrites DMA stream
ownership unconditionally, unlike BF's ownership-checked `dmaAllocate()`. No
`motorDevInit()` split was needed or attempted. The call site is placed after every
`dmaInit()` caller and before `fcTasksInit()` (gyro mode latches on first scheduled read).

## The actual blocker: a second, unrelated, pre-existing bug

Activating `spiInitBusDMA()` exposed a latent bug with nothing to do with motor-init
ordering: `spiInit()` (`bus_spi.c`) was setting `bus->busType = BUS_TYPE_SPI` at boot-time
peripheral bring-up, before any device attaches. `spiSetBusInstance()`'s "first device on
this bus" branch — the only place `bus->initTx`/`initRx` get assigned — gates on
`busType != BUS_TYPE_SPI`, so with `spiInit()` pre-setting it, that branch never fires, for
any SPI bus, on any target. `initTx`/`initRx` have been NULL fleet-wide since the Stage M
refactor; invisible because nothing dereferenced them until this PR's `spiInitBusDMA()`
call did, where it NULL-pointer hard-faults inside `spiInternalResetDescriptors()` (F7 LL
backend).

Confirmed via direct diff this is an EF-only divergence: BF 4.5-maintenance's `spiInit()`
calls only `spiInitDevice()` and never touches `busDevice_t` at all. EF's extra block was
also fully redundant even before being wrong — `spiSetBusInstance()`'s own first-
registration branch already sets the same fields correctly. F7 targets (FOXEERF722V4,
PYRODRONEF7) hard-faulted immediately and reliably on this bug (confirmed via LED-based
hardware bisection, no debugger available). F4 (SKYSTARSF405AIO) silently tolerated the
same NULL-pointer write as undefined behavior without crashing — meaning it was never
actually working correctly either, just not visibly broken. Fixed by removing the
redundant block from `spiInit()`, matching BF exactly (`bus_spi.c`, net -11 lines).

## Test plan
- [x] `make test` — 39/39 unit test suites pass (before and after the `spiInit()` fix)
- [x] Build clean, zero warnings: HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7,
      FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7, MATEKF411, NBDHMBF4PRO, WORMFC,
      ALIENWHOOPF7, CRAZYFLIE2, STRIXF10, MODE2FLUX
- [x] Link-map cross-reference confirms `spiInitBusDMA()` is dead-code-eliminated on
      HELIOSPRING/STRIXF10/MODE2FLUX and live on all other checked targets
- [x] Bench hardware verification post-fix: FOXEERF722V4, PYRODRONEF7, SKYSTARSF405AIO,
      TMOTORF7 all boot cleanly with correct live gyro/accel data (Configurator sensors
      tab); `dma` CLI output shows expected new `SPI_SDO`/`SPI_SDI` allocations with zero
      collision against existing motor/ADC DMA usage
- [x] Master-vs-branch sensor comparison (same physical board, same orientation): matching
      accelerometer magnitude (~1g) and gyro bias (single-digit deg/s, normal MEMS
      variance) — no scale, offset, or data-corruption difference between the polling and
      DMA-driven read paths
- [x] FOXEERF722V4 real-aircraft hover test flown on this branch (commit `4684ffd7`),
      line-of-sight, non-acrobatic. Blackbox confirms: 0 failsafe events, motor range
      fully utilized with no stuck values, unfiltered gyro (`gyroUnfilt`) shows normal
      sensor behavior with no rail-pinning or repeated/stuck samples, and blackbox
      loop-logging gap rate (1.92%, max gap 205) is identical to an unrelated prior flight
      on the same aircraft — confirming that characteristic predates this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI bus initialization and DMA activation during flight controller startup.
  * Enabled late SPI DMA setup on supported STM32F4 and STM32F7 hardware.
  * Added board-specific handling for IMUF9001 targets to prevent conflicting SPI DMA configuration.
  * Improved initialization reliability and compatibility for SPI-connected components across supported flight controller hardware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->