### PR TITLE
fix: check DMA stream ownership before UART reopen claims it

### DIFF
--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -215,6 +215,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     if (hardware->rxDMAStream) {
         const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->rxDMAStream);
         if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
+            dmaEnable(identifier);
             s->rxDMAChannel = hardware->DMAChannel;
             s->rxDMAStream = hardware->rxDMAStream;
         } else {
@@ -226,6 +227,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     if (hardware->txDMAStream) {
         const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
         if (uartDmaClaim(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
+            dmaEnable(identifier);
             dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uart);
             s->txDMAChannel = hardware->DMAChannel;
             s->txDMAStream = hardware->txDMAStream;

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -255,7 +255,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
             IOConfigGPIOAF(rxIO, IOCFG_AF_PP_UP, hardware->af);
         }
     }
-    if (!(s->rxDMAChannel)) {
+    // Either side can now fall back to IRQ-driven mode independently (uartDmaClaim() conflict); enable the NVIC line whenever either does.
+    if (!(s->rxDMAChannel) || !(s->txDMAChannel)) {
         NVIC_InitTypeDef NVIC_InitStructure;
         NVIC_InitStructure.NVIC_IRQChannel = hardware->irqn;
         NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = NVIC_PRIORITY_BASE(hardware->rxPriority);

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -191,6 +191,14 @@ void dmaIRQHandler(dmaChannelDescriptor_t* descriptor) {
 
 // XXX Should serialUART be consolidated?
 
+// uartOpen() re-invokes serialUART() on every reopen, so a stream already held by this same owner must be re-claimable.
+static bool uartDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, portOptions_e options) {
     uartDevice_t *uart = uartDevmap[device];
     if (!uart) return NULL;
@@ -205,18 +213,29 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     s->port.txBufferSize = sizeof(uart->txBuffer);
     s->USARTx = hardware->reg;
     if (hardware->rxDMAStream) {
-        dmaInit(dmaGetIdentifier(hardware->rxDMAStream), OWNER_SERIAL_RX, RESOURCE_INDEX(device));
-        s->rxDMAChannel = hardware->DMAChannel;
-        s->rxDMAStream = hardware->rxDMAStream;
-        s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->rxDMAStream);
+        if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
+            s->rxDMAChannel = hardware->DMAChannel;
+            s->rxDMAStream = hardware->rxDMAStream;
+            s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+        } else {
+            // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven RX.
+            s->rxDMAChannel = 0;
+            s->rxDMAStream = NULL;
+        }
     }
     if (hardware->txDMAStream) {
         const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
-        dmaInit(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uart);
-        s->txDMAChannel = hardware->DMAChannel;
-        s->txDMAStream = hardware->txDMAStream;
-        s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+        if (uartDmaClaim(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
+            dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uart);
+            s->txDMAChannel = hardware->DMAChannel;
+            s->txDMAStream = hardware->txDMAStream;
+            s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+        } else {
+            // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven TX.
+            s->txDMAChannel = 0;
+            s->txDMAStream = NULL;
+        }
     }
     IO_t txIO = IOGetByTag(uart->tx);
     IO_t rxIO = IOGetByTag(uart->rx);

--- a/src/main/drivers/serial_uart_stm32f4xx.c
+++ b/src/main/drivers/serial_uart_stm32f4xx.c
@@ -217,7 +217,6 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
             s->rxDMAChannel = hardware->DMAChannel;
             s->rxDMAStream = hardware->rxDMAStream;
-            s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
         } else {
             // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven RX.
             s->rxDMAChannel = 0;
@@ -230,13 +229,14 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
             dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uart);
             s->txDMAChannel = hardware->DMAChannel;
             s->txDMAStream = hardware->txDMAStream;
-            s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
         } else {
             // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven TX.
             s->txDMAChannel = 0;
             s->txDMAStream = NULL;
         }
     }
+    s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
+    s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->DR;
     IO_t txIO = IOGetByTag(uart->tx);
     IO_t rxIO = IOGetByTag(uart->rx);
     if (hardware->rcc) {

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -60,7 +60,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART1_AHB1_PERIPHERALS,
 #endif
         .rcc_apb2 = RCC_APB2(USART1),
-        .txIrq = DMA2_ST7_HANDLER,
         .rxIrq = USART1_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART1_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART1
@@ -85,7 +84,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART2_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(USART2),
-        .txIrq = DMA1_ST6_HANDLER,
         .rxIrq = USART2_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART2_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART2
@@ -110,7 +108,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART3_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(USART3),
-        .txIrq = DMA1_ST3_HANDLER,
         .rxIrq = USART3_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART3_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART3
@@ -135,7 +132,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART4_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART4),
-        .txIrq = DMA1_ST4_HANDLER,
         .rxIrq = UART4_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART4_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART4
@@ -160,7 +156,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART5_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART5),
-        .txIrq = DMA1_ST7_HANDLER,
         .rxIrq = UART5_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART5_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART5
@@ -185,7 +180,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART6_AHB1_PERIPHERALS,
 #endif
         .rcc_apb2 = RCC_APB2(USART6),
-        .txIrq = DMA2_ST6_HANDLER,
         .rxIrq = USART6_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART6_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART6
@@ -210,7 +204,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART7_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART7),
-        .txIrq = DMA1_ST1_HANDLER,
         .rxIrq = UART7_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART7_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART7
@@ -235,7 +228,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
         .rcc_ahb1 = UART8_AHB1_PERIPHERALS,
 #endif
         .rcc_apb1 = RCC_APB1(UART8),
-        .txIrq = DMA1_ST0_HANDLER,
         .rxIrq = UART8_IRQn,
         .txPriority = NVIC_PRIO_SERIALUART8_TXDMA,
         .rxPriority = NVIC_PRIO_SERIALUART8
@@ -348,7 +340,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     const uartHardware_t *hardware = uartdev->hardware;
     s->USARTx = hardware->reg;
     if (hardware->rxDMAStream) {
-        // hardware->rxIrq is a USARTx_IRQn (NVIC), not a DMA identifier -- unlike txIrq, which is one.
+        // hardware->rxIrq is a USARTx_IRQn (NVIC), not a DMA identifier.
         const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->rxDMAStream);
         if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
             s->rxDMAChannel = hardware->DMAChannel;
@@ -360,10 +352,11 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         }
     }
     if (hardware->txDMAStream) {
-        if (uartDmaClaim(hardware->txIrq, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
+        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
+        if (uartDmaClaim(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
             s->txDMAChannel = hardware->DMAChannel;
             s->txDMAStream = hardware->txDMAStream;
-            dmaSetHandler(hardware->txIrq, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
+            dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
         } else {
             // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven TX.
             s->txDMAChannel = 0;

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -348,7 +348,9 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     const uartHardware_t *hardware = uartdev->hardware;
     s->USARTx = hardware->reg;
     if (hardware->rxDMAStream) {
-        if (uartDmaClaim(hardware->rxIrq, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
+        // hardware->rxIrq is a USARTx_IRQn (NVIC), not a DMA identifier -- unlike txIrq, which is one.
+        const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->rxDMAStream);
+        if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
             s->rxDMAChannel = hardware->DMAChannel;
             s->rxDMAStream = hardware->rxDMAStream;
         } else {
@@ -391,7 +393,8 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
             IOConfigGPIOAF(rxIO, IOCFG_AF_PP, hardware->af);
         }
     }
-    if (!s->rxDMAChannel) {
+    // Either side can now fall back to IRQ-driven mode independently (uartDmaClaim() conflict); enable the NVIC line whenever either does.
+    if (!s->rxDMAChannel || !s->txDMAChannel) {
         HAL_NVIC_SetPriority(hardware->rxIrq, NVIC_PRIORITY_BASE(hardware->rxPriority), NVIC_PRIORITY_SUB(hardware->rxPriority));
         HAL_NVIC_EnableIRQ(hardware->rxIrq);
     }

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -325,6 +325,14 @@ void dmaIRQHandler(dmaChannelDescriptor_t* descriptor) {
 
 // XXX Should serialUART be consolidated?
 
+// uartOpen() re-invokes serialUART() on every reopen, so a stream already held by this same owner must be re-claimable.
+static bool uartDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, portOptions_e options) {
     uartDevice_t *uartdev = uartDevmap[device];
     if (!uartdev) {
@@ -340,15 +348,25 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     const uartHardware_t *hardware = uartdev->hardware;
     s->USARTx = hardware->reg;
     if (hardware->rxDMAStream) {
-        s->rxDMAChannel = hardware->DMAChannel;
-        s->rxDMAStream = hardware->rxDMAStream;
+        if (uartDmaClaim(hardware->rxIrq, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
+            s->rxDMAChannel = hardware->DMAChannel;
+            s->rxDMAStream = hardware->rxDMAStream;
+        } else {
+            // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven RX.
+            s->rxDMAChannel = 0;
+            s->rxDMAStream = NULL;
+        }
     }
     if (hardware->txDMAStream) {
-        s->txDMAChannel = hardware->DMAChannel;
-        s->txDMAStream = hardware->txDMAStream;
-        // DMA TX Interrupt
-        dmaInit(hardware->txIrq, OWNER_SERIAL_TX, RESOURCE_INDEX(device));
-        dmaSetHandler(hardware->txIrq, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
+        if (uartDmaClaim(hardware->txIrq, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
+            s->txDMAChannel = hardware->DMAChannel;
+            s->txDMAStream = hardware->txDMAStream;
+            dmaSetHandler(hardware->txIrq, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);
+        } else {
+            // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven TX.
+            s->txDMAChannel = 0;
+            s->txDMAStream = NULL;
+        }
     }
     s->txDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->TDR;
     s->rxDMAPeripheralBaseAddr = (uint32_t)&s->USARTx->RDR;

--- a/src/main/drivers/serial_uart_stm32f7xx.c
+++ b/src/main/drivers/serial_uart_stm32f7xx.c
@@ -343,6 +343,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
         // hardware->rxIrq is a USARTx_IRQn (NVIC), not a DMA identifier.
         const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->rxDMAStream);
         if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
+            dmaEnable(identifier);
             s->rxDMAChannel = hardware->DMAChannel;
             s->rxDMAStream = hardware->rxDMAStream;
         } else {
@@ -354,6 +355,7 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     if (hardware->txDMAStream) {
         const dmaIdentifier_e identifier = dmaGetIdentifier(hardware->txDMAStream);
         if (uartDmaClaim(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
+            dmaEnable(identifier);
             s->txDMAChannel = hardware->DMAChannel;
             s->txDMAStream = hardware->txDMAStream;
             dmaSetHandler(identifier, dmaIRQHandler, hardware->txPriority, (uint32_t)uartdev);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -120,6 +120,10 @@ encoding_unittest_SRC := \
 		$(USER_DIR)/common/encoding.c
 
 
+serial_uart_dma_claim_unittest_DEFINES := \
+		STM32F4
+
+
 flight_failsafe_unittest_SRC := \
 		$(USER_DIR)/common/bitarray.c \
 		$(USER_DIR)/fc/rc_modes.c \

--- a/src/test/unit/serial_uart_dma_claim_unittest.cc
+++ b/src/test/unit/serial_uart_dma_claim_unittest.cc
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// Mirrors the same-owner reclaim guard duplicated in serial_uart_stm32f4xx.c / serial_uart_stm32f7xx.c.
+// uartOpen() re-invokes serialUART() on every reopen, so a stream already held by this same
+// owner+resourceIndex must be re-claimable without going through dmaAllocate()'s OWNER_FREE check.
+namespace {
+
+resourceOwner_e fakeOwner = OWNER_FREE;
+uint8_t fakeResourceIndex = 0;
+
+void resetFakeDmaState() {
+    fakeOwner = OWNER_FREE;
+    fakeResourceIndex = 0;
+}
+
+resourceOwner_e fakeDmaGetOwner(dmaIdentifier_e) {
+    return fakeOwner;
+}
+
+uint8_t fakeDmaGetResourceIndex(dmaIdentifier_e) {
+    return fakeResourceIndex;
+}
+
+bool fakeDmaAllocate(dmaIdentifier_e, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (fakeOwner != OWNER_FREE) {
+        return false;
+    }
+    fakeOwner = owner;
+    fakeResourceIndex = resourceIndex;
+    return true;
+}
+
+bool uartDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (fakeDmaGetOwner(identifier) == owner && fakeDmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return fakeDmaAllocate(identifier, owner, resourceIndex);
+}
+
+const dmaIdentifier_e kStream = DMA1_ST3_HANDLER;
+
+}  // namespace
+
+TEST(SerialUartDmaClaimUnittest, FirstClaimOnFreeStreamSucceeds) {
+    resetFakeDmaState();
+    EXPECT_TRUE(uartDmaClaim(kStream, OWNER_SERIAL_TX, RESOURCE_INDEX(2)));
+    EXPECT_EQ(fakeOwner, OWNER_SERIAL_TX);
+}
+
+TEST(SerialUartDmaClaimUnittest, ReopenBySameOwnerAndIndexSucceeds) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SERIAL_RX;
+    fakeResourceIndex = RESOURCE_INDEX(4);
+    EXPECT_TRUE(uartDmaClaim(kStream, OWNER_SERIAL_RX, RESOURCE_INDEX(4)));
+}
+
+TEST(SerialUartDmaClaimUnittest, ConflictWithForeignOwnerFails) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SPI_SDI;
+    fakeResourceIndex = RESOURCE_INDEX(1);
+    EXPECT_FALSE(uartDmaClaim(kStream, OWNER_SERIAL_RX, RESOURCE_INDEX(1)));
+    // failed claim must not disturb the existing owner's bookkeeping.
+    EXPECT_EQ(fakeOwner, OWNER_SPI_SDI);
+}
+
+TEST(SerialUartDmaClaimUnittest, SameOwnerEnumDifferentResourceIndexFails) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SERIAL_RX;
+    fakeResourceIndex = RESOURCE_INDEX(1);
+    // same owner value but a different UART device instance: must not be treated as a reopen.
+    EXPECT_FALSE(uartDmaClaim(kStream, OWNER_SERIAL_RX, RESOURCE_INDEX(2)));
+}


### PR DESCRIPTION
AI Generated pull-request

## Summary

`dmaInit()` unconditionally overwrites `dmaDescriptors[index].owner` with no check of the
current owner, unlike `dmaAllocate()`, which rejects an already-owned stream. `serialUART()`
called `dmaInit()` directly on every UART open/reopen (MSP passthrough, telemetry provider
switches), so a later reopen could silently steal a DMA stream another peripheral (e.g. SPI)
had already claimed.

Adds `uartDmaClaim()` in `serial_uart_stm32f4xx.c` and `serial_uart_stm32f7xx.c`: returns
true immediately for a self-reopen (same owner + resourceIndex), otherwise delegates to the
existing `dmaAllocate()` ownership check. On a foreign-owner conflict, falls back to the
already-supported IRQ-driven path. The NVIC-IRQ-enable gate on both files now checks both
RX and TX DMA status, not just RX — needed once either side can independently fall back.

Scoped to `serial_uart_stm32{f4,f7}xx.c` only — the only `dmaInit()` call sites that are both
runtime-reentrant and reachable after `USE_SPI_DMA_ENABLE_LATE` activates DMA on F4/F7. The
other 17 `dmaInit()` call sites (motors, ADC, LED strip, SD card, transponder, F1/F3, H7) are
boot-time single-shot with no live collision path and no non-DMA fallback designed in — now
tracked as their own follow-up issues (#1362, #1363).

Also fixes `serial_uart_stm32f7xx.c`'s RX branch, which never called
`dmaInit()`/`dmaAllocate()` at all — it copied `hardware->rxDMAStream` into the port struct
without registering ownership, unlike F4's equivalent RX branch and this file's own TX
branch. Wrapped with the same `uartDmaClaim()` helper, deriving the identifier from
`hardware->rxDMAStream` via `dmaGetIdentifier()`.

Also removes `serial_uart_stm32f7xx.c`'s baked-in `txIrq` DMA identifiers (e.g.
`.txIrq = DMA2_ST7_HANDLER`) and resolves TX's identifier at runtime via
`dmaGetIdentifier(hardware->txDMAStream)` instead — matching BF 4.5-maintenance
(`serial_uart.c:440,452`, which resolves both directions this way and never assigns `txIrq`
on F7) and EF's own F4 driver, which already worked this way. `txIrq` and `rxIrq` held two
different types on F7 (a `dmaIdentifier_e` and a raw NVIC `IRQn`, respectively) despite the
parallel naming — that ambiguity is exactly what caused the RX identifier bug this PR also
fixes: the RX fix was originally drafted by pattern-matching the TX branch's use of
`txIrq`, which only worked because `txIrq` genuinely was a DMA identifier there. Confirmed
H7's driver has no equivalent gap.

Also adds the missing `dmaEnable(identifier)` call on all four success branches (F4 RX/TX,
F7 RX/TX). `dmaAllocate()` only sets ownership bookkeeping; `dmaInit()` used to also enable
the DMA controller's peripheral clock in the same call. Swapping to `uartDmaClaim()`
(`dmaAllocate()`-based) dropped that clock-enable half — matches `bus_spi.c`'s own
established pattern of calling `dmaEnable()` immediately after a successful `dmaAllocate()`.

Adds `serial_uart_dma_claim_unittest.cc` covering `uartDmaClaim()`'s four cases: free-stream
claim, same-owner reopen, foreign-owner conflict, and same-owner-enum-but-different-
resourceIndex conflict.

Closes #1349
Closes #1355
Closes #1361

## Test plan

- [x] `make clean_test && make test` — 41/41 test binaries PASS, 240/240 assertions PASSED
      (236 pre-existing + 4 new)
- [x] `make TARGET=OMNIBUSF4` (F4/stdperiph), `make TARGET=MATEKF722` (F7/HAL),
      `make TARGET=FOXEERF722V4` (real F7 aircraft target), `make TARGET=FOXEERF405`,
      `make TARGET=PYRODRONEF7` — all clean, no warnings
- [x] Real-hardware regression testing: done, twice, zero discrepancies found. (1)
      FOXEERF405, user's actual aircraft config: `dma` CLI output and task-list timing
      identical between `upstream/master` and this branch. (2) FOXEERF722V4 (unsoldered
      bench unit), user's actual aircraft config: clean boot, CPU 4%, GYRO/PID at 8000Hz,
      no fault, SPI1/SPI2 DMA active as expected. Also cross-checked against the actual
      pre-#1348 EmuFlight 0.4.3 release and Betaflight 4.5.6 on the same FOXEERF722V4
      hardware — no discrepancy in any DMA-relevant or motor-timing figure.
- [x] Local CodeRabbit review (`coderabbit review --agent`) + opencode second opinion found
      and fixed two real defects before this line: the F7 RX identifier type confusion
      above, and the RX-only NVIC gate above. Also fixed a minor F4/F7 base-address
      assignment inconsistency (harmless — every reader gates on the stream pointer being
      non-NULL first — but the two files diverged for no reason).
- [x] Root cause of the RX identifier bug traced and fixed at its source (the `txIrq`/`rxIrq`
      type ambiguity itself, see Summary), not just the one symptom CodeRabbit flagged.
- [x] GitHub PR review bot (CodeRabbit, review #4857738495) flagged 2 actionables + 1
      nitpick. Both actionables verified against the actual `dmaAllocate()`/`dmaEnable()`/
      `dmaInit()` implementations before fixing, not accepted on the bot's word alone: the
      F7 identifier fix above (bot independently re-confirmed resolved at this PR's HEAD),
      and the missing `dmaEnable()` call above (bot independently re-confirmed still open
      before this fix, now addressed). The nitpick (test mirrors `uartDmaClaim()`'s logic
      instead of exercising the real driver, F4-only) is acknowledged, not fixed — see
      `CONTEXT_dmainit-ownership-check.md` for why that's out of scope at this PR's size.
- [x] **Root cause of why the conflict-fallback branch can't be exercised, found and
      confirmed**: no UART on any F4/F7 EmuFlight target has DMA compiled in, for any UART
      number, anywhere. `common_fc_pre.h` defines `USE_UART1_RX_DMA`/`TX_DMA` only under
      `#ifdef STM32F1`; a fleet-wide search across every `target.h` finds zero F4/F7
      targets defining any `USE_UARTx_RX_DMA`/`TX_DMA` flag. Confirmed live via temporary
      debug instrumentation on FOXEERF722V4: `serialUART()` and `uartPinConfigure()` both
      work correctly (pins match, `uartDevmap[]` populates, function is entered, no early
      return) — but `hardware->rxDMAStream`/`txDMAStream` are compile-time NULL, so neither
      DMA-claim branch this PR touches is ever reached. Cross-checked against BF's own
      reference config for this exact board — it has no per-target UART DMA flag either,
      because BF 4.5-maintenance resolves this dynamically (`USE_DMA_SPEC`) rather than via
      static flags, a mechanism EF never ported. Tracked as its own issue, #1364.
- [ ] **Consequence, the one remaining gap**: because of the above, `uartDmaClaim()`'s
      fallback logic is currently unreachable on every existing F4/F7 target — correct,
      matches BF's intent, but structurally cannot execute today, on any target, until
      #1364 (or any future target) ever defines a `USE_UARTx_RX_DMA` flag. This PR changes
      zero observable behavior on any current target by construction. A normal test flight
      is still recommended before merge, since that's this project's policy for any
      DMA-touching change regardless; full safe-to-merge reasoning posted separately as PR
      comments.

