### PR TITLE
fix: disable SPI DMA during AK8963 aux-I2C-passthrough init

### DIFF
--- a/src/main/drivers/compass/compass_ak8963.c
+++ b/src/main/drivers/compass/compass_ak8963.c
@@ -325,6 +325,8 @@ void ak8963BusInit(const extDevice_t *dev) {
 #if defined(USE_MAG_AK8963) && (defined(USE_GYRO_SPI_MPU6500) || defined(USE_GYRO_SPI_MPU9250))
     case BUS_TYPE_MPU_SLAVE:
         rescheduleTask(TASK_COMPASS, TASK_PERIOD_HZ(40));
+        // gyro DMA completion timing upsets I2C-master slave access
+        spiDmaEnable(dev->busType_u.mpuSlave.master, false);
         // initialze I2C master via SPI bus
         ak8963SpiWriteRegisterDelay(dev->busType_u.mpuSlave.master, MPU_RA_INT_PIN_CFG, MPU6500_BIT_INT_ANYRD_2CLEAR | MPU6500_BIT_BYPASS_EN);
         ak8963SpiWriteRegisterDelay(dev->busType_u.mpuSlave.master, MPU_RA_I2C_MST_CTRL, 0x0D); // I2C multi-master / 400kHz

--- a/src/test/unit/bus_spi_unittest.cc
+++ b/src/test/unit/bus_spi_unittest.cc
@@ -348,3 +348,24 @@ TEST(BusSpiUnittest, TxIrqHandlerPreservesDevicePointerThroughUserParam)
 
     EXPECT_EQ((uintptr_t)dev.bus->curSegment, (uintptr_t)BUS_SPI_FREE);
 }
+
+// --- spiDmaEnable(): per-device flag, independent of bus-level useDMA ---
+
+TEST(BusSpiUnittest, DmaEnableSetsPerDeviceFlagIndependentOfBus)
+{
+    resetSpiTestState();
+    extDevice_t dev = {};
+    ASSERT_TRUE(spiSetBusInstance(&dev, SPI_DEV_TO_CFG(SPIDEV_1)));
+    spiInitBusDMA();
+    busDevice_t *bus = spiBusByDevice(SPIDEV_1);
+    ASSERT_TRUE(bus->useDMA);
+
+    spiDmaEnable(&dev, false);
+
+    EXPECT_FALSE(dev.useDMA); // gates this device only
+    EXPECT_TRUE(bus->useDMA); // other devices sharing the bus keep DMA
+
+    spiDmaEnable(&dev, true);
+
+    EXPECT_TRUE(dev.useDMA);
+}


### PR DESCRIPTION
AI Generated pull-request

## Summary

`spiDmaEnable()` lets a device opt in/out of DMA independently of its bus but had zero
callers in this codebase. `ak8963BusInit()`'s `BUS_TYPE_MPU_SLAVE` case matches the upstream
reference driver except for one missing call: disabling DMA on the gyro's SPI bus before the
three writes that bring up the MPU-aux-I2C master used to reach the compass through
passthrough.

Reachable on six targets defining both `USE_MAG_AK8963` and (`USE_GYRO_SPI_MPU6500` or
`USE_GYRO_SPI_MPU9250`): SPARKY2, ALIENFLIGHTNGF7, ALIENFLIGHTF4, ALIENWHOOPF4, ALIENWHOOPF7,
ELLE0. No longer a purely theoretical gap now that generic SPI DMA activation is live on
F4/F7 — gyro-bus DMA completion timing during passthrough init previously had nothing
enforcing the disable.

Direct diff against the upstream reference driver also found the issue's second call site
(RX-SPI) doesn't apply to this codebase: it uses raw `spiTransferByte()` register-level
polling that never touches `dev->useDMA`, so a ported call would set a flag nothing
downstream reads. That half was closed separately via issue comment, not implemented here.

Partial #1352 — closes the compass half only; the RX-SPI half is closed as won't-fix via
https://github.com/emuflight/EmuFlight/issues/1352#issuecomment-5181335719, so #1352 stays
open pending review of this PR.

## Test plan

- [x] `make TARGET=ALIENWHOOPF4` — clean build, no warnings (exercises the exact edited code
      path: `USE_GYRO_SPI_MPU6500` + `USE_GYRO_SPI_MPU9250` + `USE_MAG_AK8963`)
- [x] `make clean_test && make test` — full host suite green
- [x] Added `BusSpiUnittest.DmaEnableSetsPerDeviceFlagIndependentOfBus` (`bus_spi_unittest.cc`)
      covering `spiDmaEnable()` itself, previously untested at zero callers. The
      `compass_ak8963.c` call site's MPU-slave path isn't host-testable without new
      register-write mocking infra, out of proportion to a one-line change.
- [x] `coderabbit review --agent --base upstream/master` — 0 findings
- [ ] Hardware-verified — **not possible for this PR**. None of the six affected targets
      (SPARKY2, ALIENFLIGHTNGF7, ALIENFLIGHTF4, ALIENWHOOPF4, ALIENWHOOPF7, ELLE0) are
      available. Review and merge proceed on software/logic inspection only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AK8963 sensor initialization by preventing SPI DMA conflicts during I2C-master configuration.
  * Improved reliability when switching DMA usage for individual SPI devices.

* **Tests**
  * Added coverage to verify device-level DMA changes do not affect shared SPI bus settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->