### PR TITLE
feat: activate SPI DMA for IMUF9001 boards' SPI2/SPI3

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -307,6 +307,12 @@ void spiInitBusDMA(void)
 {
 #if (defined(STM32F4) || defined(STM32F7) || defined(STM32H7)) && defined(USE_SPI)
     for (uint32_t device = 0; device < SPIDEV_COUNT; device++) {
+#if defined(USE_GYRO_IMUF9001)
+        // SPI1 is claimed by accgyro_mpu.c's dedicated IMUF9001 DMA path; leave it alone here.
+        if (device == SPIDEV_1) {
+            continue;
+        }
+#endif
         busDevice_t *bus = &spiBusDevice[device];
 
         if (bus->busType != BUS_TYPE_SPI) {

--- a/src/main/target/common_fc_post.h
+++ b/src/main/target/common_fc_post.h
@@ -30,10 +30,9 @@
 #undef USE_VTX_TRAMP
 #endif
 
-// IMUF9001 boards own SPI1 DMA directly (accgyro_mpu.c), not via the generic path
-#if defined(USE_GYRO_IMUF9001)
-#undef USE_SPI_DMA_ENABLE_LATE
-#endif
+// IMUF9001 boards own SPI1 DMA directly (accgyro_mpu.c); spiInitBusDMA() itself
+// skips SPIDEV_1 under USE_GYRO_IMUF9001, so SPI2/SPI3 on these boards still
+// activate the generic path here.
 
 #ifndef USE_DSHOT
 #undef USE_ESC_SENSOR


### PR DESCRIPTION
AI Generated pull-request

## Summary

HELIOSPRING, STRIXF10, and MODE2FLUX (`USE_GYRO_IMUF9001`) were excluded from generic SPI
DMA activation (PR #1348) entirely, via `common_fc_post.h` undefining
`USE_SPI_DMA_ENABLE_LATE` for the whole board. Only SPI1 (the IMUF9001 link, owned by
`accgyro_mpu.c`'s dedicated DMA path) needs protecting — SPI2 and SPI3 on these same boards
have no such conflict, and issue #1340's own comments called SPI2/SPI3 in scope for the
original activation work.

Moves the guard from board-wide to bus-specific: `common_fc_post.h` no longer undefines
`USE_SPI_DMA_ENABLE_LATE` for these boards; `spiInitBusDMA()` itself now skips `SPIDEV_1`
under `USE_GYRO_IMUF9001`, letting the existing per-device loop activate SPI2/SPI3 normally.

Verified per-board rather than assumed: all three boards wire IMUF9001 to `SPIDEV_1`
specifically (checked each `target.mk`/`target.h`, not inferred). SPI2 has no driver
consumer on any of the three — SPI3 (flash + MAX7456 OSD) is the bus that actually gains
DMA.

Deferred once before: a prior direct `spiInitBusDMA()` attempt on HELIOSPRING (commit
`e8dd9df829`, reverted) broke MSP entirely, root-caused at the time to a bug in IMUF9001's
old bespoke DMA state machine — a state machine PR #1283 has since fully replaced.
Flight-verified on HELIOSPRING 2026-08-06 (see Test plan and Flight verification section
below) — no MSP regression of that failure mode.

Closes #1354

## Test plan

- [x] `make HELIOSPRING`, `make STRIXF10`, `make MODE2FLUX` — all clean, no warnings
- [x] Link-map/symbol verification: differential build (guard stashed/restored) confirms
      `spiInitBusDMA` dead-code-eliminates under the old guard and is present under the new
      one on HELIOSPRING; `nm` confirms `spiInitBusDMA`, `imufDmaAllocateChannels`,
      `mpuImufSetupDma`, `imufDmaStartTransfer` all coexist post-fix on all three targets
- [x] `make clean_test && make test` — 80/80 test binaries PASS
- [x] **Flight-verification — HELIOSPRING done, 2026-08-06.** STRIXF10/MODE2FLUX not
      flight-tested (no hardware available to this contributor). This PR's own stated bar —
      "flight on at least one of the three boards" — is satisfied by HELIOSPRING. Details
      below.

## Flight verification (HELIOSPRING, 2026-08-06)

Bench-verified first (real hardware, USB power only — SPI3 DMA confirmed live via `dma` CLI,
flash/OSD chip integrity, zero IMUF9001 comm errors under bench load), then four
line-of-sight hover flights at different `gyro_sync_denom`/`pid_process_denom` configs:

| Config | IMUF9001 comm errors | Blackbox CRC errors | Notes |
|---|---|---|---|
| 16k/16k gyro/pid, run 1 | 1 | 1 | Not reproduced — see run 2 |
| 16k/16k gyro/pid, run 2 (identical config, repeat) | 0 | 0 | Clean |
| 10.67k/10.67k gyro/pid | 0 | 0 | Clean |
| 8k gyro / 4k pid | 0 | 0 | Clean — see note below |

- The single comm-error/CRC-error pair in run 1 did not reproduce on an immediate repeat of
  the identical config (comparable load/duration, ~1.86M vs ~1.175M logged SPI1 iterations).
  Consistent with a one-off transient rather than a systematic timing-margin regression from
  SPI3 sharing NVIC space with SPI1 — a repeatable issue would be expected to recur at a
  comparable rate on the repeat.
- The 8k/4k flight included a near-loss-of-control/disarm/mis-arm/rearm sequence (pilot-side
  per the flying pilot, not attributed to firmware) — `reportimuferrors` stayed at 0
  throughout, ruling out SPI1/IMUF9001 corruption as a contributing cause of that incident.
- MSP/CLI/Configurator reconnected normally after every flight — directly re-tests the
  historical MSP-breakage failure mode (`e8dd9df829`) under real post-flight conditions.
- STRIXF10/MODE2FLUX remain flight-unverified; no hardware available to this contributor.

Full data and methodology:
`AI/EF/feat/imuf9001-spi23-activation/CONTEXT_imuf9001-spi23-activation.md` (nerdCopter AI
tracking repo, not part of this PR's diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPI and DMA initialization for IMUF9001 configurations.
  * Preserved dedicated SPI1 DMA resources for the IMUF9001 path.
  * Continued supporting generic DMA initialization for other SPI devices, including SPI2 and SPI3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
