### PR TITLE
fix: activate SPI DMA for STM32H7 targets

### DIFF
--- a/src/main/target/common_fc_pre.h
+++ b/src/main/target/common_fc_pre.h
@@ -97,6 +97,7 @@
 #define USE_USB_MSC
 #define I2C3_OVERCLOCK true
 #define I2C4_OVERCLOCK true
+#define USE_SPI_DMA_ENABLE_LATE
 #endif
 
 #if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)


### PR DESCRIPTION
AI Generated [pull-request]

## Summary

Closes #1353.

`spiInitBusDMA()` (`src/main/drivers/bus_spi.c`) already guards
`#if (defined(STM32F4) || defined(STM32F7) || defined(STM32H7)) && defined(USE_SPI)` — H7
support exists in the function itself. PR #1348 only defined `USE_SPI_DMA_ENABLE_LATE` for
`STM32F4`/`STM32F7` in `common_fc_pre.h`; H7 targets never reached the `fc_init.c` call
site (gated `#if defined(USE_SPI) && defined(USE_SPI_DMA_ENABLE_LATE)`), so `spiInitBusDMA()`
was dead code on every H7 target.

This PR adds the same define to the `STM32H7` block, mirroring the existing F4/F7 pattern.
One line, one file.

No `USE_GYRO_IMUF9001` target is STM32H7-based (HELIOSPRING/STRIXF10/MODE2FLUX are all
F4/F7), so this doesn't interact with the SPI1-exclusion guard PR #1359 added.

## Tier classification

**Tier 2 — behavioral change** (DMA path activation), per this project's production-
readiness gates. All requirements verified on real STELLARH7DEV hardware — see below.

- Gyro verified on: STELLARH7DEV (ICM42688P, on SPI3 — `dma` confirms `SPI_SDI/SDO 3`
  active; blackbox `gyroADC`/`gyroUnfilt` sane throughout a real hover flight)
- Motor test: STELLARH7DEV — `motor[0-3]` full-range utilization (152–2047), no stuck
  values, during the same flight

**Scope note**: this physical board has 4 IMU footprints (`ICM-42688-P`, `ICM-45686`,
`ICM-45605`, `ICM-40609-D`, per the board schematic). EmuFlight only implements
`ICM-42688-P` on STELLARH7DEV (`USE_GYRO_SPI_ICM42688P`) — the other three have no EF
driver and no multi-IMU selection mechanism (`USE_IMU1`/`USE_IMU2` is Betaflight-only,
doesn't exist in EF). All verification above is scoped to `ICM-42688-P` only.

## Verification done

- `make clean && CCACHE_DISABLE=1 make test`: 42/42 unit test binaries pass, 0 fail.
- `CCACHE_DISABLE=1 make STELLARH7DEV MATEKH743 KAKUTEH7`: clean compile, zero warnings.
- Link-map cross-reference on STELLARH7DEV: `spiInitBusDMA` is placed at a real address
  and cross-referenced from the LTRANS object — genuinely linked in under
  `-Wl,-gc-sections`, not just present-but-eliminated.
- CodeRabbit GitHub review: raised a finding requesting H7 hardware validation before
  default-on, then withdrew it after re-tracing `bus_spi.c`/`bus_spi_ll.c`/
  `dma_stm32h7xx.c`/the H7 linker scripts — confirmed H7's DTCM/cache DMA constraints are
  already handled generically, same fallback-to-polling model as the accepted F4/F7
  precedent. Full exchange: PR review thread starting at
  https://github.com/emuflight/EmuFlight/pull/1367#discussion_r3737138123.

### Real-hardware verification (STELLARH7DEV) — 2026-08-09

**CLI `dma`/`status`/`tasks`, master vs. this branch, same board/config:**
- `master` (`035fff1`): zero SPI DMA anywhere (expected — no H7 call site existed yet).
- This branch (`461bee6`): adds `DMA1 Stream4/5 = SPI_SDO/SDI 3` (gyro, ICM42688P) and
  `DMA1 Stream6/7 = SPI_SDO/SDI 4` (flash, W25M02G) — every pre-existing row (`MOTOR 1-4`
  on `DMA1 Stream0-3`, `ADC` on `DMA2 Stream1`) unchanged. Zero collision.
- `GYRO/PID` timing: master avg 30µs/31.2% maxload vs. branch avg 29-31µs/30-35% maxload
  across multiple captures — no regression, consistent with DMA offloading transfer work.

**3x flash + reboot power cycle**: byte-identical `dma` table and consistent `GYRO/PID`
timing across all 3 boots — no init-time race.

**Hover-flight test**: blackbox log confirmed on this exact firmware build (`461bee6`,
STELLARH7DEV), ~39s flight. 0 `failsafePhase` non-IDLE rows across 63,965 samples; 1
momentary `rxSignalReceived` blip (negligible — same pattern seen in PR #1348's own flight
test); `motor[0-3]` full utilization, no stuck values; `gyroUnfilt`/`gyroADC` ranges sane
for the maneuvers flown.

## Test plan

- [x] `make test` — 42/42 pass
- [x] Compile gate — STELLARH7DEV, MATEKH743, KAKUTEH7, zero warnings
- [x] Link-map confirms `spiInitBusDMA` genuinely activated on STELLARH7DEV
- [x] CodeRabbit GitHub review — code-level finding raised then withdrawn, no open findings
- [x] Gyro functional test on STELLARH7DEV — real hover flight, clean gyro data
- [x] Motor arming test on STELLARH7DEV — full-range utilization, no stuck values
- [x] Flash + reboot x3 on STELLARH7DEV — byte-identical DMA table each boot
