### PR TITLE
chore: remove dead code surfaced by STM32F3 purge

### DIFF
--- a/make/source.mk
+++ b/make/source.mk
@@ -249,7 +249,6 @@ SPEED_OPTIMISED_SRC := $(SPEED_OPTIMISED_SRC) \
             common/kalman.c \
 
 SIZE_OPTIMISED_SRC := $(SIZE_OPTIMISED_SRC) \
-            bus_bst_stm32f30x.c \
             drivers/barometer/barometer_bmp085.c \
             drivers/barometer/barometer_bmp280.c \
             drivers/barometer/barometer_dps310.c \

--- a/src/main/drivers/rcc.h
+++ b/src/main/drivers/rcc.h
@@ -25,7 +25,6 @@
 enum rcc_reg {
     RCC_EMPTY = 0,   // make sure that default value (0) does not enable anything
 #ifdef STM32H7
-    RCC_AHB,
     RCC_APB2,
     RCC_APB1L,
     RCC_APB1H,
@@ -36,7 +35,6 @@ enum rcc_reg {
     RCC_AHB4,
     RCC_APB4,
 #else
-    RCC_AHB,
     RCC_APB2,
     RCC_APB1,
     RCC_AHB1,
@@ -47,7 +45,6 @@ enum rcc_reg {
 #define RCC_ENCODE(reg, mask) (((reg) << 5) | LOG2_32BIT(mask))
 
 #ifdef STM32H7
-#define RCC_AHB(periph)   RCC_ENCODE(RCC_AHB,   RCC_AHBENR_ ## periph ## EN)
 #define RCC_APB2(periph)  RCC_ENCODE(RCC_APB2,  RCC_APB2ENR_ ## periph ## EN)
 #define RCC_AHB1(periph)  RCC_ENCODE(RCC_AHB1,  RCC_AHB1ENR_ ## periph ## EN)
 #define RCC_AHB2(periph)  RCC_ENCODE(RCC_AHB2,  RCC_AHB2ENR_ ## periph ## EN)
@@ -61,7 +58,6 @@ enum rcc_reg {
 // Must not delegate to RCC_APB1L() — that would macro-expand 'periph' before ## pasting.
 #define RCC_APB1(periph)  RCC_ENCODE(RCC_APB1L, RCC_APB1LENR_ ## periph ## EN)
 #else
-#define RCC_AHB(periph)   RCC_ENCODE(RCC_AHB,  RCC_AHBENR_ ## periph ## EN)
 #define RCC_APB2(periph)  RCC_ENCODE(RCC_APB2, RCC_APB2ENR_ ## periph ## EN)
 #define RCC_APB1(periph)  RCC_ENCODE(RCC_APB1, RCC_APB1ENR_ ## periph ## EN)
 #define RCC_AHB1(periph)  RCC_ENCODE(RCC_AHB1, RCC_AHB1ENR_ ## periph ## EN)

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -310,14 +310,10 @@ void cliPrintLine(const char *str) {
     cliPrintLinefeed();
 }
 
-#ifdef MINIMAL_CLI
-#define cliPrintHashLine(str)
-#else
 static void cliPrintHashLine(const char *str) {
     cliPrint("\r\n# ");
     cliPrintLine(str);
 }
-#endif
 
 static void cliPutp(void *p, char ch) {
     bufWriterAppend(p, ch);
@@ -669,7 +665,7 @@ static void cliSetVar(const clivalue_t *var, const int16_t value) {
     }
 }
 
-#if defined(USE_RESOURCE_MGMT) && !defined(MINIMAL_CLI)
+#if defined(USE_RESOURCE_MGMT)
 static void cliRepeat(char ch, uint8_t len) {
     for (int i = 0; i < len; i++) {
         bufWriterAppend(cliWriter, ch);
@@ -1919,23 +1915,17 @@ static void cliFlashErase(char *cmdline) {
     if (!flashfsIsSupported()) {
         return;
     }
-#ifndef MINIMAL_CLI
     uint32_t i = 0;
     cliPrintLine("Erasing, please wait ... ");
-#else
-    cliPrintLine("Erasing,");
-#endif
     bufWriterFlush(cliWriter);
     flashfsEraseCompletely();
     while (!flashfsIsReady()) {
-#ifndef MINIMAL_CLI
         cliPrintf(".");
         if (i++ > 120) {
             i = 0;
             cliPrintLinefeed();
         }
         bufWriterFlush(cliWriter);
-#endif
         delay(100);
     }
     beeper(BEEPER_BLACKBOX_ERASE);
@@ -3027,7 +3017,6 @@ static void cliMotor(char *cmdline) {
     }
 }
 
-#ifndef MINIMAL_CLI
 static void cliPlaySound(char *cmdline) {
     int i;
     const char *name;
@@ -3058,7 +3047,6 @@ static void cliPlaySound(char *cmdline) {
     cliPrintLinef("Playing sound %d: %s", i, name);
     beeper(beeperModeForTableIndex(i));
 }
-#endif
 
 static void cliProfile(char *cmdline) {
     if (isEmpty(cmdline)) {
@@ -3604,13 +3592,11 @@ static void cliTasks(char *cmdline) {
     UNUSED(cmdline);
     int maxLoadSum = 0;
     int averageLoadSum = 0;
-#ifndef MINIMAL_CLI
     if (systemConfig()->task_statistics) {
         cliPrintLine("Task list             rate/hz  max/us  avg/us maxload avgload     total/ms");
     } else {
         cliPrintLine("Task list");
     }
-#endif
     for (cfTaskId_e taskId = 0; taskId < TASK_COUNT; taskId++) {
         cfTaskInfo_t taskInfo;
         getTaskInfo(taskId, &taskInfo);
@@ -3924,12 +3910,8 @@ static void cliResource(char *cmdline) {
         printResource(DUMP_MASTER | HIDE_UNUSED);
         return;
     } else if (strncasecmp(cmdline, "list", len) == 0) {
-#ifdef MINIMAL_CLI
-        cliPrintLine("IO");
-#else
         cliPrintLine("Currently active IO resource assignments:\r\n(reboot to update)");
         cliRepeat('-', 20);
-#endif
         for (int i = 0; i < DEFIO_IO_USED_COUNT; i++) {
             const char* owner;
             owner = ownerNames[ioRecs[i].owner];
@@ -3939,9 +3921,7 @@ static void cliResource(char *cmdline) {
             }
             cliPrintLinefeed();
         }
-#ifndef MINIMAL_CLI
         cliPrintLine("\r\nUse: 'resource' to see how to change resources.");
-#endif
         return;
     }
     uint8_t resourceIndex = 0;
@@ -3972,21 +3952,13 @@ static void cliResource(char *cmdline) {
     if (strlen(pch) > 0) {
         if (strToPin(pch, tag)) {
             if (*tag == IO_TAG_NONE) {
-#ifdef MINIMAL_CLI
-                cliPrintLine("Freed");
-#else
                 cliPrintLine("Resource is freed");
-#endif
                 return;
             } else {
                 ioRec_t *rec = IO_Rec(IOGetByTag(*tag));
                 if (rec) {
                     resourceCheck(resourceIndex, index, *tag);
-#ifdef MINIMAL_CLI
-                    cliPrintLinef(" %c%02d set", IO_GPIOPortIdx(rec) + 'A', IO_GPIOPinIdx(rec));
-#else
                     cliPrintLinef("\r\nResource is set to %c%02d", IO_GPIOPortIdx(rec) + 'A', IO_GPIOPinIdx(rec));
-#endif
                 } else {
                     cliShowParseError();
                 }
@@ -3999,12 +3971,8 @@ static void cliResource(char *cmdline) {
 
 static void printDma(void) {
     cliPrintLinefeed();
-#ifdef MINIMAL_CLI
-    cliPrintLine("DMA:");
-#else
     cliPrintLine("Currently active DMA:");
     cliRepeat('-', 20);
-#endif
     for (int i = 1; i <= DMA_LAST_HANDLER; i++) {
         const char* owner;
         owner = ownerNames[dmaGetOwner(i)];
@@ -4273,14 +4241,11 @@ static void cliMsc(char *cmdline) {
 
 typedef struct {
     const char *name;
-#ifndef MINIMAL_CLI
     const char *description;
     const char *args;
-#endif
     void (*func)(char *cmdline);
 } clicmd_t;
 
-#ifndef MINIMAL_CLI
 #define CLI_COMMAND_DEF(name, description, args, method) \
 { \
     name , \
@@ -4288,13 +4253,6 @@ typedef struct {
     args , \
     method \
 }
-#else
-#define CLI_COMMAND_DEF(name, description, args, method) \
-{ \
-    name, \
-    method \
-}
-#endif
 
 #ifdef USE_GYRO_IMUF9001
 static void cliReportImufErrors(char *cmdline);
@@ -4393,9 +4351,7 @@ const clicmd_t cmdTable[] = {
     CLI_COMMAND_DEF("msc", "switch into msc mode", NULL, cliMsc),
 #endif
     CLI_COMMAND_DEF("name", "name of craft", NULL, cliName),
-#ifndef MINIMAL_CLI
     CLI_COMMAND_DEF("play_sound", NULL, "[<index>]", cliPlaySound),
-#endif
     CLI_COMMAND_DEF("profile", "change profile", "[<index>]", cliProfile),
     CLI_COMMAND_DEF("rateprofile", "change rate profile", "[<index>]", cliRateProfile),
 #ifdef USE_RC_SMOOTHING_FILTER
@@ -4452,14 +4408,12 @@ static void cliHelp(char *cmdline) {
     UNUSED(cmdline);
     for (uint32_t i = 0; i < ARRAYLEN(cmdTable); i++) {
         cliPrint(cmdTable[i].name);
-#ifndef MINIMAL_CLI
         if (cmdTable[i].description) {
             cliPrintf(" - %s", cmdTable[i].description);
         }
         if (cmdTable[i].args) {
             cliPrintf("\r\n\t%s", cmdTable[i].args);
         }
-#endif
         cliPrintLinefeed();
     }
 }
@@ -4570,11 +4524,7 @@ void cliEnter(serialPort_t *serialPort) {
     setPrintfSerialPort(cliPort);
     cliWriter = bufWriterInit(cliWriteBuffer, sizeof(cliWriteBuffer), (bufWrite_t)serialWriteBufShim, serialPort);
     schedulerSetCalulateTaskStatistics(systemConfig()->task_statistics);
-#ifndef MINIMAL_CLI
     cliPrintLine("\r\nEntering CLI Mode, type 'exit' to return, or 'help'");
-#else
-    cliPrintLine("\r\nCLI");
-#endif
     cliPrompt();
     setArmingDisabled(ARMING_DISABLED_CLI);
 }


### PR DESCRIPTION
AI Generated pull-request

## Summary

Removes three dead-code items left over after PR#1369 (STM32F3 removal), none themselves
F3-conditional so out of scope for that purge:

- `src/main/drivers/rcc.h`: bare `RCC_AHB` enum value + macro (both arms) had zero callers
  tree-wide; its only consumers, `io.c`'s F3 GPIO array and `adc_stm32f30x.c`, were deleted by
  PR#1369. Distinct from `RCC_AHB1`/`RCC_AHB2`/`RCC_AHB3`/`RCC_AHB4`, which remain fully live for
  H7/F4/F7/G4 and are untouched by this change.
- `src/main/interface/cli.c`: `MINIMAL_CLI` has zero definer sites tree-wide since its sole
  definition (F3-only, `common_fc_pre.h`) was deleted by PR#1369. Resolved all 16
  `#ifdef`/`#ifndef MINIMAL_CLI` sites to their permanently-live branch.
- `make/source.mk`: removed a stale `SIZE_OPTIMISED_SRC` entry for `bus_bst_stm32f30x.c`, a file
  that does not exist anywhere in the tree.

Closes #1371.

## Test plan

- [x] `make clean_test && make test`: 42/42 unit tests PASS, 0 FAIL, zero warnings
- [x] Bench targets (HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF722V4,
      FOXEERF405, APEXF7, TMOTORF7): 8/8 succeeded, zero warnings
- [x] Compile-only targets (MATEKF411, NBDHMBF4PRO, WORMFC, ALIENWHOOPF7, CRAZYFLIE2): 5/5
      succeeded, zero warnings
- [ ] Hardware verified: n/a — pure dead-code removal, no live-target behavior possible (all
      three items had zero reachable call sites before this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CLI output now consistently includes detailed help text, command descriptions, argument information, and entry messaging.
  - Added full visibility for task, resource, and DMA listings.
  - Flash erase progress and hash information are now displayed.
  - Sound playback is available directly through the CLI.

- **Refactor**
  - Simplified command-line behavior for a more consistent experience across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->