### PR TITLE
chore: remove dead STM32H7 RCC bus tags

### DIFF
--- a/src/main/drivers/rcc.c
+++ b/src/main/drivers/rcc.c
@@ -58,12 +58,6 @@ void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
         __HAL_RCC_CLK(AHB1, NOSUFFIX, mask, NewState);
         break;
 
-#ifdef STM32H7
-    case RCC_AHB2:
-        __HAL_RCC_CLK(AHB2, NOSUFFIX, mask, NewState);
-        break;
-#endif
-
 #if !(defined(STM32H7) || defined(STM32G4))
     case RCC_APB1:
         __HAL_RCC_CLK(APB1, NOSUFFIX, mask, NewState);
@@ -90,10 +84,6 @@ void RCC_ClockCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 
     case RCC_APB1H:
         __HAL_RCC_CLK(APB1H, NOSUFFIX, mask, NewState);
-        break;
-
-    case RCC_APB3:
-        __HAL_RCC_CLK(APB3, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB4:
@@ -146,12 +136,6 @@ void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
         __HAL_RCC_RESET(AHB1, NOSUFFIX, mask, NewState);
         break;
 
-#ifdef STM32H7
-    case RCC_AHB2:
-        __HAL_RCC_RESET(AHB2, NOSUFFIX, mask, NewState);
-        break;
-#endif
-
 #if !(defined(STM32H7) || defined(STM32G4))
     case RCC_APB1:
         __HAL_RCC_RESET(APB1, NOSUFFIX, mask, NewState);
@@ -178,10 +162,6 @@ void RCC_ResetCmd(rccPeriphTag_t periphTag, FunctionalState NewState)
 
     case RCC_APB1H:
         __HAL_RCC_RESET(APB1H, NOSUFFIX, mask, NewState);
-        break;
-
-    case RCC_APB3:
-        __HAL_RCC_RESET(APB3, NOSUFFIX, mask, NewState);
         break;
 
     case RCC_APB4:

--- a/src/main/drivers/rcc.h
+++ b/src/main/drivers/rcc.h
@@ -29,16 +29,13 @@ enum rcc_reg {
     RCC_APB1L,
     RCC_APB1H,
     RCC_AHB1,
-    RCC_AHB2,
     RCC_AHB3,
-    RCC_APB3,
     RCC_AHB4,
     RCC_APB4,
 #else
     RCC_APB2,
     RCC_APB1,
     RCC_AHB1,
-    RCC_AHB4,
 #endif
 };
 
@@ -47,9 +44,7 @@ enum rcc_reg {
 #ifdef STM32H7
 #define RCC_APB2(periph)  RCC_ENCODE(RCC_APB2,  RCC_APB2ENR_ ## periph ## EN)
 #define RCC_AHB1(periph)  RCC_ENCODE(RCC_AHB1,  RCC_AHB1ENR_ ## periph ## EN)
-#define RCC_AHB2(periph)  RCC_ENCODE(RCC_AHB2,  RCC_AHB2ENR_ ## periph ## EN)
 #define RCC_AHB3(periph)  RCC_ENCODE(RCC_AHB3,  RCC_AHB3ENR_ ## periph ## EN)
-#define RCC_APB3(periph)  RCC_ENCODE(RCC_APB3,  RCC_APB3ENR_ ## periph ## EN)
 #define RCC_AHB4(periph)  RCC_ENCODE(RCC_AHB4,  RCC_AHB4ENR_ ## periph ## EN)
 #define RCC_APB4(periph)  RCC_ENCODE(RCC_APB4,  RCC_APB4ENR_ ## periph ## EN)
 #define RCC_APB1L(periph) RCC_ENCODE(RCC_APB1L, RCC_APB1LENR_ ## periph ## EN)
@@ -61,7 +56,6 @@ enum rcc_reg {
 #define RCC_APB2(periph)  RCC_ENCODE(RCC_APB2, RCC_APB2ENR_ ## periph ## EN)
 #define RCC_APB1(periph)  RCC_ENCODE(RCC_APB1, RCC_APB1ENR_ ## periph ## EN)
 #define RCC_AHB1(periph)  RCC_ENCODE(RCC_AHB1, RCC_AHB1ENR_ ## periph ## EN)
-#define RCC_AHB4(periph)  RCC_ENCODE(RCC_AHB4, RCC_AHB4ENR_ ## periph ## EN)
 // APB1L alias used in H7-specific files; on non-H7 this maps to APB1
 #define RCC_APB1L(periph) RCC_ENCODE(RCC_APB1, RCC_APB1ENR_ ## periph ## EN)
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary

Removes three dead RCC bus-tag/macro items surfaced while resolving #1371, all STM32H7-specific
and distinct from that ticket's scope. Not a functional change — none of these items has a
reachable caller on current master.

- `src/main/drivers/rcc.h`/`rcc.c`: `RCC_AHB4` in the non-H7 arm had zero reachable callers on
  F4/F7 — its only two real callers (`io.c`'s H7 GPIO array, `adc_stm32h7xx.c`) are H7-exclusive;
  F4/F7 use `RCC_AHB1` instead. The H7 arm's own `RCC_AHB4` definition is untouched and remains
  live.
- `rcc.h`/`rcc.c`: `RCC_AHB2` macro, enum tag, and both `case RCC_AHB2:` switch arms had zero
  callers anywhere.
- `rcc.h`/`rcc.c`: `RCC_APB3` macro, enum tag, and both `case RCC_APB3:` switch arms had zero
  callers anywhere.

The enum-tag removal for `RCC_AHB2`/`RCC_APB3` goes slightly beyond the issue's literal wording
(which named only the macro and case arms) — with both of those gone, the enum tag itself has no
purpose left, matching how bare `RCC_AHB` was treated in #1371.

Closes #1375.

## Test plan

- [x] `make clean_test && make test`: 42/42 unit tests PASS, 0 FAIL, zero warnings
- [x] Bench + compile-only targets (HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7,
      FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7, MATEKF411, NBDHMBF4PRO, WORMFC, ALIENWHOOPF7,
      CRAZYFLIE2): 13/13 succeeded, zero warnings
- [x] STELLARH7DEV (H7 bring-up board — this issue is H7-specific, no standard bench-list target
      is H7): 1/1 succeeded, zero warnings
- [ ] Hardware verified: n/a — pure dead-code removal, zero reachable callers before this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clock and reset control compatibility across STM32H7 and STM32G4 hardware variants.
  * Standardized peripheral clock and reset handling for supported processor families.
  * Preserved existing behavior for non-HAL builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->