### PR TITLE
chore: remove dead USE_OSD_SLAVE code

### DIFF
--- a/src/main/fc/config.c
+++ b/src/main/fc/config.c
@@ -69,9 +69,7 @@
 #include "drivers/accgyro/accgyro_imuf9001.h"
 #endif
 
-#ifndef USE_OSD_SLAVE
 pidProfile_t *currentPidProfile;
-#endif
 
 #ifndef RX_SPI_DEFAULT_PROTOCOL
 #define RX_SPI_DEFAULT_PROTOCOL 0
@@ -97,7 +95,6 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
                   .boardIdentifier = TARGET_BOARD_IDENTIFIER
                  );
 
-#ifndef USE_OSD_SLAVE
 uint8_t getCurrentPidProfileIndex(void) {
     return systemConfig()->pidProfileIndex;
 }
@@ -113,7 +110,6 @@ uint8_t getCurrentControlRateProfileIndex(void) {
 uint16_t getCurrentMinthrottle(void) {
     return motorConfig()->minthrottle;
 }
-#endif // USE_OSD_SLAVE
 
 void resetConfigs(void) {
     pgResetAll();
@@ -123,7 +119,6 @@ void resetConfigs(void) {
 }
 
 static void activateConfig(void) {
-#ifndef USE_OSD_SLAVE
     loadPidProfile();
     loadControlRateProfile();
     initRcProcessing();
@@ -134,14 +129,13 @@ static void activateConfig(void) {
     setAccelerationTrims(&accelerometerConfigMutable()->accZero);
     accInitFilters();
     imuConfigure(throttleCorrectionConfig()->throttle_correction_angle);
-#endif // USE_OSD_SLAVE
 #ifdef USE_LED_STRIP
     reevaluateLedConfig();
 #endif
 }
 
 static void validateAndFixConfig(void) {
-#if !defined(USE_QUAD_MIXER_ONLY) && !defined(USE_OSD_SLAVE)
+#if !defined(USE_QUAD_MIXER_ONLY)
     // Reset unsupported mixer mode to default.
     // This check will be gone when motor/servo mixers are loaded dynamically
     // by configurator as a part of configuration procedure.
@@ -165,7 +159,6 @@ static void validateAndFixConfig(void) {
         true) {
         featureClear(FEATURE_GPS);
     }
-#ifndef USE_OSD_SLAVE
     if (systemConfig()->activeRateProfile >= CONTROL_RATE_PROFILE_COUNT) {
         systemConfigMutable()->activeRateProfile = 0;
     }
@@ -256,7 +249,6 @@ static void validateAndFixConfig(void) {
             removeModeActivationCondition(BOXGPSRESCUE);
         }
     }
-#endif // USE_OSD_SLAVE
 #if defined(USE_ESC_SENSOR)
     if (!findSerialPortConfig(FUNCTION_ESC_SENSOR)) {
         featureClear(FEATURE_ESC_SENSOR);
@@ -385,7 +377,6 @@ int getImufRateFromGyroSyncDenom(int gyroSyncDenom) {
 }
 #endif
 
-#ifndef USE_OSD_SLAVE
 void validateAndFixGyroConfig(void) {
 #ifdef USE_GYRO_DATA_ANALYSE
     // Disable dynamic filter if gyro loop is less than 2KHz
@@ -487,31 +478,22 @@ void validateAndFixGyroConfig(void) {
 #endif // USE_SDCARD
 #endif // USE_BLACKBOX
 }
-#endif // USE_OSD_SLAVE
 
 bool readEEPROM(void) {
-#ifndef USE_OSD_SLAVE
     suspendRxPwmPpmSignal();
-#endif
     // Sanity check, read flash
     bool success = loadEEPROM();
     validateAndFixConfig();
     activateConfig();
-#ifndef USE_OSD_SLAVE
     resumeRxPwmPpmSignal();
-#endif
     return success;
 }
 
 void writeEEPROM(void) {
     validateAndFixConfig();
-#ifndef USE_OSD_SLAVE
     suspendRxPwmPpmSignal();
-#endif
     writeConfigToEEPROM();
-#ifndef USE_OSD_SLAVE
     resumeRxPwmPpmSignal();
-#endif
 }
 
 void resetEEPROM(void) {
@@ -555,7 +537,6 @@ void changePidProfileFromCellCount(uint8_t cellCount) {
     }
 }
 
-#ifndef USE_OSD_SLAVE
 void changePidProfile(uint8_t pidProfileIndex) {
     // The config switch will cause a big enough delay in the current task to upset the scheduler
     schedulerIgnoreTaskExecTime();
@@ -568,4 +549,3 @@ void changePidProfile(uint8_t pidProfileIndex) {
     }
     beeperConfirmationBeeps(pidProfileIndex + 1);
 }
-#endif

--- a/src/main/fc/fc_hardfaults.c
+++ b/src/main/fc/fc_hardfaults.c
@@ -113,13 +113,11 @@ void hard_fault_handler_c(unsigned long *hardfault_args) {
 #else
 void HardFault_Handler(void) {
     LED2_ON;
-#ifndef USE_OSD_SLAVE
     // fall out of the sky
     uint8_t requiredStateForMotors = SYSTEM_STATE_CONFIG_LOADED | SYSTEM_STATE_MOTORS_READY;
     if ((systemState & requiredStateForMotors) == requiredStateForMotors) {
         stopMotors();
     }
-#endif
 #ifdef USE_TRANSPONDER
     // prevent IR LEDs from burning out.
     uint8_t requiredStateForTransponder = SYSTEM_STATE_CONFIG_LOADED | SYSTEM_STATE_TRANSPONDER_ENABLED;

--- a/src/main/fc/fc_init.c
+++ b/src/main/fc/fc_init.c
@@ -504,10 +504,10 @@ void init(void) {
 #ifdef USE_CMS
     cmsInit();
 #endif
-#if (defined(USE_OSD) || (defined(USE_MSP_DISPLAYPORT) && defined(USE_CMS)) || defined(USE_OSD_SLAVE))
+#if (defined(USE_OSD) || (defined(USE_MSP_DISPLAYPORT) && defined(USE_CMS)))
     displayPort_t *osdDisplayPort = NULL;
 #endif
-#if defined(USE_OSD) && !defined(USE_OSD_SLAVE)
+#if defined(USE_OSD)
     //The OSD need to be initialised after GYRO to avoid GYRO initialisation failure on some targets
     if (feature(FEATURE_OSD)) {
 #if defined(USE_OSD_BEESIGN)
@@ -535,14 +535,6 @@ void init(void) {
         // osdInit  will register with CMS by itself.
         osdInit(osdDisplayPort);
     }
-#endif
-#if defined(USE_OSD_SLAVE) && !defined(USE_OSD)
-#if defined(USE_MAX7456)
-    // If there is a max7456 chip for the OSD then use it
-    osdDisplayPort = max7456DisplayPortInit(vcdProfile());
-    // osdInit  will register with CMS by itself.
-    osdSlaveInit(osdDisplayPort);
-#endif
 #endif
 #if defined(USE_CMS) && defined(USE_MSP_DISPLAYPORT)
     // If BFOSD is not active, then register MSP_DISPLAYPORT as a CMS device.

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -136,14 +136,6 @@ static void taskMain(timeUs_t currentTimeUs) {
 #endif
 }
 
-#ifdef USE_OSD_SLAVE
-static bool taskSerialCheck(timeUs_t currentTimeUs, timeDelta_t currentDeltaTimeUs) {
-    UNUSED(currentTimeUs);
-    UNUSED(currentDeltaTimeUs);
-    return mspSerialWaiting();
-}
-#endif
-
 static void taskHandleSerial(timeUs_t currentTimeUs) {
     UNUSED(currentTimeUs);
 #if defined(USE_VCP)
@@ -169,11 +161,7 @@ static void taskHandleSerial(timeUs_t currentTimeUs) {
         return;
     }
 #endif
-#ifndef OSD_SLAVE
     bool evaluateMspData = ARMING_FLAG(ARMED) ? MSP_SKIP_NON_MSP_DATA : MSP_EVALUATE_NON_MSP_DATA;
-#else
-    bool evaluateMspData = osdSlaveIsLocked ?  MSP_SKIP_NON_MSP_DATA : MSP_EVALUATE_NON_MSP_DATA;;
-#endif
     mspSerialProcess(evaluateMspData, mspFcProcessCommand, mspFcProcessReply);
 
 #ifdef USE_HDZERO_OSD
@@ -191,7 +179,6 @@ static void taskBatteryAlerts(timeUs_t currentTimeUs) {
     batteryUpdateAlarms();
 }
 
-#ifndef USE_OSD_SLAVE
 static void taskUpdateAccelerometer(timeUs_t currentTimeUs) {
     accUpdate(currentTimeUs, &accelerometerConfigMutable()->accelerometerTrims);
 }
@@ -218,7 +205,6 @@ static void taskUpdateRxMain(timeUs_t currentTimeUs) {
     updateRcCommands();
     updateArmingStatus();
 }
-#endif
 
 #ifdef USE_BARO
 static void taskUpdateBaro(timeUs_t currentTimeUs) {
@@ -265,11 +251,7 @@ void fcTasksInit(void) {
     setTaskEnabled(TASK_BATTERY_VOLTAGE, useBatteryVoltage);
     const bool useBatteryCurrent = batteryConfig()->currentMeterSource != CURRENT_METER_NONE;
     setTaskEnabled(TASK_BATTERY_CURRENT, useBatteryCurrent);
-#ifdef USE_OSD_SLAVE
-    const bool useBatteryAlerts = batteryConfig()->useVBatAlerts || batteryConfig()->useConsumptionAlerts;
-#else
     const bool useBatteryAlerts = batteryConfig()->useVBatAlerts || batteryConfig()->useConsumptionAlerts || feature(FEATURE_OSD);
-#endif
     setTaskEnabled(TASK_BATTERY_ALERTS, (useBatteryVoltage || useBatteryCurrent) && useBatteryAlerts);
 #ifdef USE_TRANSPONDER
     setTaskEnabled(TASK_TRANSPONDER, feature(FEATURE_TRANSPONDER));
@@ -277,9 +259,6 @@ void fcTasksInit(void) {
 #ifdef STACK_CHECK
     setTaskEnabled(TASK_STACK_CHECK, true);
 #endif
-#ifdef USE_OSD_SLAVE
-    setTaskEnabled(TASK_OSD_SLAVE, osdSlaveInitialized());
-#else
     if (sensors(SENSOR_GYRO)) {
         rescheduleTask(TASK_GYROPID, gyro.targetLooptime);
         setTaskEnabled(TASK_GYROPID, true);
@@ -364,7 +343,6 @@ void fcTasksInit(void) {
 #ifdef USE_RCDEVICE
     setTaskEnabled(TASK_RCDEVICE, rcdeviceIsEnabled());
 #endif
-#endif
 }
 
 FAST_RAM cfTask_t cfTasks[TASK_COUNT] = {
@@ -387,14 +365,8 @@ FAST_RAM cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_SERIAL] = {
         .taskName = "SERIAL",
         .taskFunc = taskHandleSerial,
-#ifdef USE_OSD_SLAVE
-        .checkFunc = taskSerialCheck,
-        .desiredPeriod = TASK_PERIOD_HZ(100),
-        .staticPriority = TASK_PRIORITY_REALTIME,
-#else
         .desiredPeriod = TASK_PERIOD_HZ(100),       // 100 Hz should be enough to flush up to 115 bytes @ 115200 baud
         .staticPriority = TASK_PRIORITY_LOW,
-#endif
     },
 
     [TASK_BATTERY_ALERTS] = {
@@ -434,17 +406,6 @@ FAST_RAM cfTask_t cfTasks[TASK_COUNT] = {
         .staticPriority = TASK_PRIORITY_IDLE,
     },
 #endif
-
-#ifdef USE_OSD_SLAVE
-    [TASK_OSD_SLAVE] = {
-        .taskName = "OSD_SLAVE",
-        .checkFunc = osdSlaveCheck,
-        .taskFunc = osdSlaveUpdate,
-        .desiredPeriod = TASK_PERIOD_HZ(60),        // 60 Hz
-        .staticPriority = TASK_PRIORITY_HIGH,
-    },
-
-#else
 
     [TASK_GYROPID] = {
         .taskName = "PID",
@@ -645,5 +606,4 @@ FAST_RAM cfTask_t cfTasks[TASK_COUNT] = {
     },
 #endif
 
-#endif
 };

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -159,9 +159,7 @@ typedef struct pidProfile_s {
     uint16_t dterm_dyn_notch_q;
 } pidProfile_t;
 
-#ifndef USE_OSD_SLAVE
 PG_DECLARE_ARRAY(pidProfile_t, PID_PROFILE_COUNT, pidProfiles);
-#endif
 
 typedef struct pidConfig_s {
     uint8_t pid_process_denom;                   // Processing denominator for PID controller vs gyro sampling rate

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -182,8 +182,6 @@ static bool mspIsMspArmingEnabled(void)
     return mspArmingDisableFlags == 0;
 }
 
-#ifndef USE_OSD_SLAVE
-
 typedef enum {
     MSP_SDCARD_STATE_NOT_PRESENT = 0,
     MSP_SDCARD_STATE_FATAL       = 1,
@@ -202,7 +200,6 @@ typedef enum {
 } mspFlashFsFlags_e;
 
 #define RATEPROFILE_MASK (1 << 7)
-#endif //USE_OSD_SLAVE
 
 #define RTC_NOT_SUPPORTED 0xff
 
@@ -260,9 +257,7 @@ static void mspFc4waySerialCommand(sbuf_t *dst, sbuf_t *src, mspPostProcessFnPtr
 
 static void mspRebootFn(serialPort_t *serialPort) {
     UNUSED(serialPort);
-#ifndef USE_OSD_SLAVE
     stopPwmAllMotors();
-#endif
     switch (rebootMode) {
     case MSP_REBOOT_FIRMWARE:
         systemReset();
@@ -283,7 +278,6 @@ static void mspRebootFn(serialPort_t *serialPort) {
     while (true) ;
 }
 
-#ifndef USE_OSD_SLAVE
 static void serializeSDCardSummaryReply(sbuf_t *dst) {
 #ifdef USE_SDCARD
     uint8_t flags = MSP_SDCARD_FLAG_SUPPORTTED;
@@ -431,7 +425,6 @@ static void serializeDataflashReadReply(sbuf_t *dst, uint32_t address, const uin
     }
 }
 #endif // USE_FLASHFS
-#endif // USE_OSD_SLAVE
 
 /*
  * Returns true if the command was processd, false otherwise.
@@ -460,14 +453,10 @@ bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr
 #else
         sbufWriteU16(dst, 0); // No other build targets currently have hardware revision detection.
 #endif
-#ifdef USE_OSD_SLAVE
-        sbufWriteU8(dst, 1);  // 1 == OSD
-#else
 #if defined(USE_OSD) && (defined(USE_MAX7456)  || defined(USE_USE_BEESIGN))
         sbufWriteU8(dst, 2);  // 2 == FC with OSD
 #else
         sbufWriteU8(dst, 0);  // 0 == FC
-#endif
 #endif
         // Board communication capabilities (uint8)
         // Bit 0: 1 iff the board has VCP
@@ -510,11 +499,7 @@ bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr
     case MSP_ANALOG:
         sbufWriteU8(dst, (uint8_t)constrain(getBatteryVoltage(), 0, 255));
         sbufWriteU16(dst, (uint16_t)constrain(getMAhDrawn(), 0, 0xFFFF)); // milliamp hours drawn from battery
-#ifdef USE_OSD_SLAVE
-        sbufWriteU16(dst, 0); // rssi
-#else
         sbufWriteU16(dst, getRssi());
-#endif
         sbufWriteU16(dst, (int16_t)constrain(getAmperage(), -0x8000, 0x7FFF)); // send current in 0.01 A steps, range is -320A to 320A
         sbufWriteU16(dst, getBatteryVoltage() * 10);
         break;
@@ -658,7 +643,6 @@ bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr
     }
     case MSP_OSD_CONFIG: {
 #define OSD_FLAGS_OSD_FEATURE           (1 << 0)
-#define OSD_FLAGS_OSD_SLAVE             (1 << 1)
 #define OSD_FLAGS_RESERVED_1            (1 << 2)
 #define OSD_FLAGS_RESERVED_2            (1 << 3)
 #define OSD_FLAGS_OSD_HARDWARE_MAX_7456 (1 << 4)
@@ -666,9 +650,6 @@ bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr
         uint8_t osdFlags = 0;
 #if defined(USE_OSD)
         osdFlags |= OSD_FLAGS_OSD_FEATURE;
-#endif
-#if defined(USE_OSD_SLAVE)
-        osdFlags |= OSD_FLAGS_OSD_SLAVE;
 #endif
 #ifdef USE_MAX7456
         osdFlags |= OSD_FLAGS_OSD_HARDWARE_MAX_7456;
@@ -715,36 +696,6 @@ bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr
     }
     return true;
 }
-
-#ifdef USE_OSD_SLAVE
-bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
-    switch (cmdMSP) {
-    case MSP_STATUS_EX:
-    case MSP_STATUS:
-        sbufWriteU16(dst, getTaskDeltaTime(TASK_SERIAL));
-#ifdef USE_I2C
-        sbufWriteU16(dst, i2cGetErrorCounter());
-#else
-        sbufWriteU16(dst, 0);
-#endif
-        sbufWriteU16(dst, 0); // sensors
-        sbufWriteU32(dst, 0); // flight modes
-        sbufWriteU8(dst, 0); // profile
-        sbufWriteU16(dst, constrain(averageSystemLoadPercent, 0, 100));
-        if (cmdMSP == MSP_STATUS_EX) {
-            sbufWriteU8(dst, 1); // max profiles
-            sbufWriteU8(dst, 0); // control rate profile
-        } else {
-            sbufWriteU16(dst, 0); // gyro cycle time
-        }
-        break;
-    default:
-        return false;
-    }
-    return true;
-}
-
-#else
 
 bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
     bool unsupportedCommand = false;
@@ -1446,15 +1397,10 @@ bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst) {
         }
         return !unsupportedCommand;
         }
-#endif // USE_OSD_SLAVE
 
 static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src, sbuf_t *dst, mspPostProcessFnPtr *mspPostProcessFn) {
     UNUSED(srcDesc);
-#if defined(USE_OSD_SLAVE)
-    UNUSED(dst);
-#endif
     switch (cmdMSP) {
-#if !defined(USE_OSD_SLAVE)
     case MSP_BOXNAMES: {
         const int page = sbufBytesRemaining(src) ? sbufReadU8(src) : 0;
         serializeBoxReply(dst, page, &serializeBoxNameFn);
@@ -1465,7 +1411,6 @@ static mspResult_e mspFcProcessOutCommandWithArg(mspDescriptor_t srcDesc, uint8_
         serializeBoxReply(dst, page, &serializeBoxPermanentIdFn);
     }
     break;
-#endif
     case MSP_REBOOT:
         if (sbufBytesRemaining(src)) {
             rebootMode = sbufReadU8(src);
@@ -1521,30 +1466,6 @@ static void mspFcDataFlashReadCommand(sbuf_t *dst, sbuf_t *src) {
     serializeDataflashReadReply(dst, readAddress, readLength, useLegacyFormat, allowCompression);
 }
 #endif
-
-#ifdef USE_OSD_SLAVE
-static mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src) {
-    UNUSED(srcDesc);
-    UNUSED(cmdMSP);
-    UNUSED(src);
-    switch(cmdMSP) {
-    case MSP_RESET_CONF:
-        resetEEPROM();
-        readEEPROM();
-        break;
-    case MSP_EEPROM_WRITE:
-        schedulerIgnoreTaskStateTime(); // EEPROM write is slow; don't inflate task maxload
-        writeEEPROM();
-        readEEPROM();
-        break;
-    default:
-        // we do not know how to handle the (valid) message, indicate error MSP $M!
-        return MSP_RESULT_ERROR;
-    }
-    return MSP_RESULT_ACK;
-}
-
-#else
 
 mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src) {
     uint32_t i;
@@ -2403,7 +2324,6 @@ mspResult_e mspProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t 
         }
         return MSP_RESULT_ACK;
         }
-#endif // USE_OSD_SLAVE
 
 mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, sbuf_t *src, mspPostProcessFnPtr *mspPostProcessFn) {
     UNUSED(mspPostProcessFn);
@@ -2489,7 +2409,7 @@ mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, s
         batteryConfigMutable()->voltageMeterSource = sbufReadU8(src);
         batteryConfigMutable()->currentMeterSource = sbufReadU8(src);
         break;
-#if defined(USE_OSD) || defined (USE_OSD_SLAVE)
+#if defined(USE_OSD)
     case MSP_SET_OSD_CONFIG: {
         const uint8_t addr = sbufReadU8(src);
         if ((int8_t)addr == -1) {
@@ -2556,7 +2476,7 @@ mspResult_e mspCommonProcessInCommand(mspDescriptor_t srcDesc, uint8_t cmdMSP, s
 #else
     return MSP_RESULT_ERROR;
 #endif
-#endif // OSD || USE_OSD_SLAVE
+#endif // USE_OSD
     default:
         return mspProcessInCommand(srcDesc, cmdMSP, src);
     }
@@ -2605,7 +2525,6 @@ void mspFcProcessReply(mspPacket_t *reply) {
     sbuf_t *src = &reply->buf;
     UNUSED(src); // potentially unused depending on compile options.
     switch (reply->cmd) {
-#ifndef OSD_SLAVE
     case MSP_ANALOG: {
         uint8_t batteryVoltage = sbufReadU8(src);
         uint16_t mAhDrawn = sbufReadU16(src);
@@ -2620,44 +2539,9 @@ void mspFcProcessReply(mspPacket_t *reply) {
 #endif
     }
     break;
-#endif
-#ifdef USE_OSD_SLAVE
-    case MSP_DISPLAYPORT: {
-        osdSlaveIsLocked = true; // lock it as soon as a MSP_DISPLAYPORT message is received to prevent accidental CLI/DFU mode.
-        const int subCmd = sbufReadU8(src);
-        switch (subCmd) {
-        case 0: // HEARTBEAT
-            osdSlaveHeartbeat();
-            break;
-        case 1: // RELEASE
-            break;
-        case 2: // CLEAR
-            osdSlaveClearScreen();
-            break;
-        case 3: {
-#define MSP_OSD_MAX_STRING_LENGTH 30 // FIXME move this
-            const uint8_t y = sbufReadU8(src); // row
-            const uint8_t x = sbufReadU8(src); // column
-            sbufReadU8(src); // reserved
-            char buf[MSP_OSD_MAX_STRING_LENGTH + 1];
-            const int len = MIN(sbufBytesRemaining(src), MSP_OSD_MAX_STRING_LENGTH);
-            sbufReadData(src, &buf, len);
-            buf[len] = 0;
-            osdSlaveWrite(x, y, buf);
-        }
-        break;
-        case 4:
-            osdSlaveDrawScreen();
-            break;
-        }
-    }
-    break;
-#endif
     }
 }
 
 void mspInit(void) {
-#ifndef USE_OSD_SLAVE
     initActiveBoxIds();
-#endif
 }

--- a/src/main/interface/msp_box.c
+++ b/src/main/interface/msp_box.c
@@ -44,7 +44,6 @@
 #include "pg/piniobox.h"
 
 
-#ifndef USE_OSD_SLAVE
 // permanent IDs must uniquely identify BOX meaning, DO NOT REUSE THEM!
 static const box_t boxes[CHECKBOX_ITEM_COUNT] = {
     { BOXARM, "ARM", 0 },
@@ -299,4 +298,3 @@ int packFlightModeFlags(boxBitmask_t *mspFlightModeFlags) {
     // return count of used bits
     return mspBoxIdx;
 }
-#endif // USE_OSD_SLAVE

--- a/src/main/io/displayport_max7456.c
+++ b/src/main/io/displayport_max7456.c
@@ -143,11 +143,7 @@ static const displayPortVTable_t max7456VTable = {
 
 displayPort_t *max7456DisplayPortInit(const vcdProfile_t *vcdProfile) {
     if (
-#ifdef USE_OSD_SLAVE
-        !max7456Init(max7456Config(), vcdProfile, false)
-#else
         !max7456Init(max7456Config(), vcdProfile, systemConfig()->cpu_overclock)
-#endif
     ) {
         return NULL;
     }

--- a/src/main/scheduler/scheduler.h
+++ b/src/main/scheduler/scheduler.h
@@ -105,9 +105,6 @@ typedef enum {
 #ifdef USE_OSD
     TASK_OSD,
 #endif
-#ifdef USE_OSD_SLAVE
-    TASK_OSD_SLAVE,
-#endif
 #ifdef USE_BST
     TASK_BST_MASTER_PROCESS,
 #endif


### PR DESCRIPTION
AI Generated pull-request

## Summary

`USE_OSD_SLAVE` is dead and broken on current master. `osd_slave.c`/`.h` don't exist anywhere in
the tree, and several symbols referenced under this macro (`osdSlaveIsLocked`,
`osdSlaveInitialized`, `osdSlaveCheck`, `osdSlaveUpdate`, `osdSlaveInit`, `osdSlaveHeartbeat`,
`osdSlaveClearScreen`, `osdSlaveWrite`, `osdSlaveDrawScreen`) have zero declarations or definitions
anywhere. Defining `USE_OSD_SLAVE` today would not compile. Only ever used by `SPRACINGF3OSD`,
removed in 2018 (commit `283e55e45`) — 7 years before the current STM32F1/F3 platform purges and
unrelated to them; `USE_OSD_SLAVE` is MCU-family-agnostic, not F1/F3-specific.

Removes all `USE_OSD_SLAVE`-gated code across 9 files: `scheduler.h`, `msp_box.c`, `msp.c`,
`displayport_max7456.c`, `fc_hardfaults.c`, `config.c`, `fc_tasks.c`, `fc_init.c`, `pid.h`.

Also fixes a separate pre-existing macro-name bug: `msp.c` and `fc_tasks.c` each guarded with bare
`#ifndef OSD_SLAVE` (missing the `USE_` prefix) instead of `#ifndef USE_OSD_SLAVE`, so the guard
was permanently stuck in its "not OSD_SLAVE" branch regardless of `USE_OSD_SLAVE`'s state — moot
now that the macro is gone entirely.

Closes #1377.

## Test plan

- [x] `make clean_test && make test`: 42/42 unit tests PASS, 0 FAIL, zero warnings — including CLI
      and MSP unit tests, the areas with the largest blast radius in this change
- [x] Bench + compile-only + H7 targets (HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7,
      FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7, MATEKF411, NBDHMBF4PRO, WORMFC, ALIENWHOOPF7,
      CRAZYFLIE2, STELLARH7DEV): 14/14 succeeded, zero real warnings
- [ ] Hardware verified: n/a — pure dead-code removal, zero reachable callers before this change on
      any live target (`USE_OSD_SLAVE` cannot be enabled by any real target and would not compile
      if forced on)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of configuration, PID profile, gyro validation, EEPROM, and MSP behavior across supported flight-controller builds.
  - Motors now stop reliably during hard faults and reboot conditions.
  - Improved task scheduling, battery alert handling, serial processing, and display initialization.
- **Refactor**
  - Removed legacy OSD-slave-specific behavior and scheduling paths.
  - Standardized OSD and flight-controller processing across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->