### PR TITLE
fix(uart): port H7 DMA resolution to shared dmaopt mechanism

### DIFF
--- a/src/main/drivers/serial_uart_impl.h
+++ b/src/main/drivers/serial_uart_impl.h
@@ -20,10 +20,6 @@
 
 #pragma once
 
-#if defined(STM32H7)
-#include "drivers/dma.h"
-#endif
-
 // Configuration constants
 
 #if defined(STM32F4)
@@ -133,14 +129,6 @@ typedef struct uartPinDef_s {
 typedef struct uartHardware_s {
     UARTDevice_e device;    // XXX Not required for full allocation
     USART_TypeDef* reg;
-#if defined(STM32H7)
-#ifdef USE_DMA
-    dmaResource_t *txDMAResource;
-    dmaResource_t *rxDMAResource;
-    uint32_t txDMAChannel;   // DMAMUX request ID (DMA_REQUEST_USARTx_TX)
-    uint32_t rxDMAChannel;   // DMAMUX request ID (DMA_REQUEST_USARTx_RX)
-#endif
-#endif
 #if defined(STM32H7)
     uartPinDef_t rxPins[UARTHARDWARE_MAX_PINS];
     uartPinDef_t txPins[UARTHARDWARE_MAX_PINS];

--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -430,7 +430,9 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     }
 
 #ifdef USE_DMA
-    if (!s->rxDMAStream)
+    // Either side can fall back to IRQ-driven mode independently (uartDmaClaim()
+    // conflict); enable the shared NVIC line whenever either does, matching F4/F7.
+    if (!s->rxDMAStream || !s->txDMAStream)
 #endif
     {
         HAL_NVIC_SetPriority(hardware->rxIrq, NVIC_PRIORITY_BASE(hardware->rxPriority), NVIC_PRIORITY_SUB(hardware->rxPriority));

--- a/src/main/drivers/serial_uart_stm32h7xx.c
+++ b/src/main/drivers/serial_uart_stm32h7xx.c
@@ -31,6 +31,7 @@
 
 #include "drivers/system.h"
 #include "drivers/dma.h"
+#include "drivers/dma_reqmap.h"
 #include "drivers/io.h"
 #include "drivers/nvic.h"
 #include "drivers/rcc.h"
@@ -38,6 +39,8 @@
 #include "drivers/serial.h"
 #include "drivers/serial_uart.h"
 #include "drivers/serial_uart_impl.h"
+
+#include "pg/serial_uart.h"
 
 // DMA-accessible UART buffers (H7: must be in AXI SRAM for DMA cache coherency)
 #ifdef USE_UART1
@@ -85,78 +88,12 @@ static DMA_RW_AXI volatile uint8_t lpuart1TxBuffer[UART_TX_BUFFER_SIZE];
 static DMA_RW_AXI volatile uint8_t lpuart1RxBuffer[UART_RX_BUFFER_SIZE];
 #endif
 
-#ifndef UART1_TX_DMA_STREAM
-#define UART1_TX_DMA_STREAM NULL
-#endif
-#ifndef UART1_RX_DMA_STREAM
-#define UART1_RX_DMA_STREAM NULL
-#endif
-#ifndef UART2_TX_DMA_STREAM
-#define UART2_TX_DMA_STREAM NULL
-#endif
-#ifndef UART2_RX_DMA_STREAM
-#define UART2_RX_DMA_STREAM NULL
-#endif
-#ifndef UART3_TX_DMA_STREAM
-#define UART3_TX_DMA_STREAM NULL
-#endif
-#ifndef UART3_RX_DMA_STREAM
-#define UART3_RX_DMA_STREAM NULL
-#endif
-#ifndef UART4_TX_DMA_STREAM
-#define UART4_TX_DMA_STREAM NULL
-#endif
-#ifndef UART4_RX_DMA_STREAM
-#define UART4_RX_DMA_STREAM NULL
-#endif
-#ifndef UART5_TX_DMA_STREAM
-#define UART5_TX_DMA_STREAM NULL
-#endif
-#ifndef UART5_RX_DMA_STREAM
-#define UART5_RX_DMA_STREAM NULL
-#endif
-#ifndef UART6_TX_DMA_STREAM
-#define UART6_TX_DMA_STREAM NULL
-#endif
-#ifndef UART6_RX_DMA_STREAM
-#define UART6_RX_DMA_STREAM NULL
-#endif
-#ifndef UART7_TX_DMA_STREAM
-#define UART7_TX_DMA_STREAM NULL
-#endif
-#ifndef UART7_RX_DMA_STREAM
-#define UART7_RX_DMA_STREAM NULL
-#endif
-#ifndef UART8_TX_DMA_STREAM
-#define UART8_TX_DMA_STREAM NULL
-#endif
-#ifndef UART8_RX_DMA_STREAM
-#define UART8_RX_DMA_STREAM NULL
-#endif
-#ifndef UART9_TX_DMA_STREAM
-#define UART9_TX_DMA_STREAM NULL
-#endif
-#ifndef UART9_RX_DMA_STREAM
-#define UART9_RX_DMA_STREAM NULL
-#endif
-#ifndef UART10_TX_DMA_STREAM
-#define UART10_TX_DMA_STREAM NULL
-#endif
-#ifndef UART10_RX_DMA_STREAM
-#define UART10_RX_DMA_STREAM NULL
-#endif
 
 const uartHardware_t uartHardware[UARTDEV_COUNT] = {
 #ifdef USE_UART1
     {
         .device = UARTDEV_1,
         .reg = USART1,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_USART1_RX,
-        .rxDMAResource = (dmaResource_t *)UART1_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_USART1_TX,
-        .txDMAResource = (dmaResource_t *)UART1_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PA10), GPIO_AF7_USART1 },
             { DEFIO_TAG_E(PB7),  GPIO_AF7_USART1 },
@@ -182,12 +119,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_2,
         .reg = USART2,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_USART2_RX,
-        .rxDMAResource = (dmaResource_t *)UART2_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_USART2_TX,
-        .txDMAResource = (dmaResource_t *)UART2_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PA3), GPIO_AF7_USART2 },
             { DEFIO_TAG_E(PD6), GPIO_AF7_USART2 }
@@ -211,12 +142,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_3,
         .reg = USART3,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_USART3_RX,
-        .rxDMAResource = (dmaResource_t *)UART3_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_USART3_TX,
-        .txDMAResource = (dmaResource_t *)UART3_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PB11), GPIO_AF7_USART3 },
             { DEFIO_TAG_E(PC11), GPIO_AF7_USART3 },
@@ -242,12 +167,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_4,
         .reg = UART4,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_UART4_RX,
-        .rxDMAResource = (dmaResource_t *)UART4_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_UART4_TX,
-        .txDMAResource = (dmaResource_t *)UART4_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PA1),  GPIO_AF8_UART4 },
             { DEFIO_TAG_E(PA11), GPIO_AF6_UART4 },
@@ -279,12 +198,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_5,
         .reg = UART5,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_UART5_RX,
-        .rxDMAResource = (dmaResource_t *)UART5_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_UART5_TX,
-        .txDMAResource = (dmaResource_t *)UART5_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PB5),  GPIO_AF14_UART5 },
             { DEFIO_TAG_E(PB12), GPIO_AF14_UART5 },
@@ -310,12 +223,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_6,
         .reg = USART6,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_USART6_RX,
-        .rxDMAResource = (dmaResource_t *)UART6_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_USART6_TX,
-        .txDMAResource = (dmaResource_t *)UART6_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PC7), GPIO_AF7_USART6  },
             { DEFIO_TAG_E(PG9), GPIO_AF7_USART6 }
@@ -339,12 +246,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_7,
         .reg = UART7,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_UART7_RX,
-        .rxDMAResource = (dmaResource_t *)UART7_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_UART7_TX,
-        .txDMAResource = (dmaResource_t *)UART7_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PA8), GPIO_AF11_UART7 },
             { DEFIO_TAG_E(PB3), GPIO_AF11_UART7 },
@@ -372,12 +273,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_8,
         .reg = UART8,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_UART8_RX,
-        .rxDMAResource = (dmaResource_t *)UART8_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_UART8_TX,
-        .txDMAResource = (dmaResource_t *)UART8_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PE0), GPIO_AF8_UART8 }
         },
@@ -399,12 +294,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_9,
         .reg = UART9,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_UART9_RX,
-        .rxDMAResource = (dmaResource_t *)UART9_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_UART9_TX,
-        .txDMAResource = (dmaResource_t *)UART9_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PD14), GPIO_AF11_UART9 }
         },
@@ -426,12 +315,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = UARTDEV_10,
         .reg = USART10,
-#ifdef USE_DMA
-        .rxDMAChannel = DMA_REQUEST_USART10_RX,
-        .rxDMAResource = (dmaResource_t *)UART10_RX_DMA_STREAM,
-        .txDMAChannel = DMA_REQUEST_USART10_TX,
-        .txDMAResource = (dmaResource_t *)UART10_TX_DMA_STREAM,
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PE2), GPIO_AF11_USART10 }
         },
@@ -453,12 +336,6 @@ const uartHardware_t uartHardware[UARTDEV_COUNT] = {
     {
         .device = LPUARTDEV_1,
         .reg = LPUART1,
-#ifdef USE_DMA
-        .rxDMAChannel = BDMA_REQUEST_LPUART1_RX,
-        .rxDMAResource = (dmaResource_t *)NULL, // No DMA support yet (Need BDMA support)
-        .txDMAChannel = BDMA_REQUEST_LPUART1_TX,
-        .txDMAResource = (dmaResource_t *)NULL, // No DMA support yet (Need BDMA support)
-#endif
         .rxPins = {
             { DEFIO_TAG_E(PA10), GPIO_AF3_LPUART },
             { DEFIO_TAG_E(PB7),  GPIO_AF8_LPUART }
@@ -563,24 +440,59 @@ uartPort_t *serialUART(UARTDevice_e device, uint32_t baudRate, portMode_e mode, 
     return s;
 }
 
-// DMA configuration: copies stream/channel from uartHardware_t into uartPort_t.
-// Full DMA IRQ wiring deferred — polled/IRQ UART is sufficient for initial bring-up.
+// uartOpen() re-invokes serialUART() on every reopen, so a stream already held by this same owner must be re-claimable.
+static bool uartDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex)
+{
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
+// Resolves DMA stream/channel from the configured dmaopt, same mechanism F4/F7 use.
 void uartConfigureDma(uartDevice_t *uartdev)
 {
     uartPort_t *s = &(uartdev->port);
-    const uartHardware_t *hardware = uartdev->hardware;
 #ifdef USE_DMA
-    if (hardware->rxDMAResource) {
-        s->rxDMAStream  = (DMA_Stream_TypeDef *)hardware->rxDMAResource;
-        s->rxDMAChannel = hardware->rxDMAChannel;
+    const uartHardware_t *hardware = uartdev->hardware;
+    const UARTDevice_e device = hardware->device;
+
+    const dmaChannelSpec_t *rxDmaSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, device, serialUartConfig(device)->rxDmaopt);
+    if (rxDmaSpec) {
+        const dmaIdentifier_e identifier = dmaGetIdentifier((DMA_Stream_TypeDef *)rxDmaSpec->ref);
+        if (uartDmaClaim(identifier, OWNER_SERIAL_RX, RESOURCE_INDEX(device))) {
+            dmaEnable(identifier);
+            s->rxDMAChannel = rxDmaSpec->channel;
+            s->rxDMAStream = (DMA_Stream_TypeDef *)rxDmaSpec->ref;
+        } else {
+            // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven RX.
+            s->rxDMAChannel = 0;
+            s->rxDMAStream = NULL;
+        }
+    } else {
+        s->rxDMAChannel = 0;
+        s->rxDMAStream = NULL;
     }
-    if (hardware->txDMAResource) {
-        s->txDMAStream  = (DMA_Stream_TypeDef *)hardware->txDMAResource;
-        s->txDMAChannel = hardware->txDMAChannel;
+
+    const dmaChannelSpec_t *txDmaSpec = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, device, serialUartConfig(device)->txDmaopt);
+    if (txDmaSpec) {
+        const dmaIdentifier_e identifier = dmaGetIdentifier((DMA_Stream_TypeDef *)txDmaSpec->ref);
+        if (uartDmaClaim(identifier, OWNER_SERIAL_TX, RESOURCE_INDEX(device))) {
+            dmaEnable(identifier);
+            s->txDMAChannel = txDmaSpec->channel;
+            s->txDMAStream = (DMA_Stream_TypeDef *)txDmaSpec->ref;
+            dmaSetHandler(identifier, uartDmaIrqHandler, hardware->txPriority, (uint32_t)uartdev);
+        } else {
+            // stream owned by another peripheral (e.g. SPI DMA): fall back to IRQ-driven TX.
+            s->txDMAChannel = 0;
+            s->txDMAStream = NULL;
+        }
+    } else {
+        s->txDMAChannel = 0;
+        s->txDMAStream = NULL;
     }
 #else
     UNUSED(s);
-    UNUSED(hardware);
 #endif
 }
 
@@ -599,7 +511,8 @@ void uartTxMonitor(uartPort_t *s)
 
 void uartDmaIrqHandler(dmaChannelDescriptor_t *descriptor)
 {
-    UNUSED(descriptor);
+    uartPort_t *s = &(((uartDevice_t *)(descriptor->userParam))->port);
+    HAL_DMA_IRQHandler(&s->txDMAHandle);
 }
 
 static void handleUsartTxDma(uartPort_t *s)

--- a/src/main/pg/serial_uart.c
+++ b/src/main/pg/serial_uart.c
@@ -39,11 +39,14 @@
 
 PG_REGISTER_ARRAY_WITH_RESET_FN(serialUartConfig_t, UARTDEV_COUNT_MAX, serialUartConfig, PG_SERIAL_UART_CONFIG, 0);
 
-// F4/F7 serialUART() resolves DMA via serialUartConfig()/dmaGetChannelSpecByPeripheral();
-// H7's serial_uart_stm32h7xx.c uses its own pre-existing UARTn_{TX,RX}_DMA_STREAM macros
-// and never reads this PG array for UART -- no per-UART default table exists for it here,
-// only the blanket DMA_OPT_UNUSED below. Neither F4 nor F7 wire up UARTDEV_9/10 in their
-// uartHardware[] tables, so those two are intentionally absent from this table.
+// F4/F7/H7 serialUART() all resolve DMA via serialUartConfig()/
+// dmaGetChannelSpecByPeripheral(). This override table supplies F4/F7's per-target
+// UARTn_TX/RX_DMA_OPT defaults; H7 has no override table of its own, so every H7 UART
+// gets the blanket DMA_OPT_UNUSED default below unconditionally -- setting one requires
+// a per-target macro or future CLI support (tracked in issue #1373), not a fleet
+// default, since H7's dmaopt selects among 16 DMAMUX-routable streams rather than a
+// small fixed set. Neither F4 nor F7 wire up UARTDEV_9/10 in their uartHardware[]
+// tables, so those two are intentionally absent from this table.
 #if defined(STM32F4) || defined(STM32F7)
 typedef struct uartDmaopt_s {
     UARTDevice_e device;

--- a/src/main/target/common_defaults_post.h
+++ b/src/main/target/common_defaults_post.h
@@ -228,10 +228,11 @@
 
 // pg/serial_uart
 //
-// F4/F7 only -- serialUART() is the only consumer of these macros (via
-// serialUartConfig()); H7 has its own separate, pre-existing UARTn_{TX,RX}_DMA_STREAM
-// mechanism in serial_uart_stm32h7xx.c and never reads this PG array for UART, so no
-// default macros are defined for it here.
+// F4/F7/H7 serialUART() all resolve DMA via serialUartConfig(); these UARTn_TX/RX_DMA_OPT
+// macros are the only default-value mechanism, so no per-target macro exists for H7 here
+// (unlike F4/F7's block below) -- every H7 UART gets the blanket DMA_OPT_UNUSED default
+// from pg/serial_uart.c's reset function unconditionally, since H7's dmaopt selects among
+// 16 DMAMUX-routable streams rather than a small fixed set (see issue #1373).
 //
 // Every UARTn_TX/RX_DMA_OPT below defaults to DMA_OPT_UNUSED (off) fleet-wide. A single
 // valid stream/channel per UART removes ambiguity about which option to try, but not


### PR DESCRIPTION
AI Generated pull-request

## Summary

- `serial_uart_stm32h7xx.c`'s `uartConfigureDma()` was an EF-original stub since
  PR #1194 (H7 bring-up): it only copied static `UARTn_TX/RX_DMA_STREAM`-macro-fed
  fields into the port struct. No H7 target ever defined those macros, so the path
  was provably inert on every target, always.
- Now resolves DMA via `dmaGetChannelSpecByPeripheral()` + `serialUartConfig()`'s
  per-UART dmaopt, mirroring EF's own already-ported F4/F7 implementation
  (PR #1370) — the same `uartDmaClaim()` ownership-check pattern, and
  `dmaSetHandler()` registration for the TX-DMA-complete IRQ.
- `uartDmaIrqHandler()` was a no-op stub, unreachable because `dmaSetHandler()` was
  never called to register it. Now calls `HAL_DMA_IRQHandler()`, matching F7's
  `dmaIRQHandler()`.
- Removed `uartHardware_t`'s now-dead `rxDMAResource`/`txDMAResource`/
  `rxDMAChannel`/`txDMAChannel` fields and their NULL-fallback macros, since
  `uartConfigureDma()` no longer reads them — same retired-static-table cleanup
  already done for F4/F7 in PR #1370.
- Fixed `serialUART()`'s NVIC-enable gate to check both RX and TX DMA fallback
  (`!s->rxDMAStream || !s->txDMAStream`), matching F4/F7's stricter gate. The
  single-condition gate this replaced is BF's own current, shipped H7 behavior too
  (verified directly against BF 4.5-maintenance) — a real latent bug shared with
  BF, not a misread of BF's architecture. Not reachable on any current H7 target
  (dmaopt stays `DMA_OPT_UNUSED` everywhere, so both sides of the new OR are
  already true today) — confirmed by inspection, no re-test needed.

## No default-behavior change

`serialUartConfig()`'s reset function only applies a non-`DMA_OPT_UNUSED` default
overlay under `#if defined(STM32F4) || defined(STM32F7)`. Every H7 UART's
`txDmaopt`/`rxDmaopt` stays at the blanket default (`DMA_OPT_UNUSED`), so
`dmaGetChannelSpecByPeripheral()` short-circuits to `NULL` before touching any
table, exactly as the old stub always resolved to `NULL`. This is an architecture
port only — no H7 UART's dmaopt defaults to active as part of this change (that
decision belongs to a separate follow-up, issue #1373).

## Verification

- `make clean && make STELLARH7DEV FOXEERF722V4 FOXEERF405 SITL`: 4/4 succeeded, 0
  warnings/errors (`CCACHE_DISABLE=1`).
- Full bench sweep (`HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7
  FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 SITL`): 9/9 succeeded, 0
  warnings/errors.
- `make clean_test && make test`: 42/42 binaries pass.
- **Hardware verified on STELLARH7DEV**: `dma`/`status`/`tasks`/`version`/`diff all`
  CLI output byte-identical vs. master (`0d05ac775`). MSP connectivity confirmed via
  the Configurator's Setup-tab-first connection flow on both builds. No flight test
  needed — the touched code path (`opt < 0` short-circuit) doesn't depend on
  RX/failsafe/serial-port configuration.
- Three independent review tools converged: local CodeRabbit (2 rounds — 1
  false-positive rejected, checked against this codebase's actual `dmaChannelSpec_t`
  struct), an independent `/code-review` pass, and opencode — found and fixed 3 real
  issues (the NVIC-gate bug above, and two stale comments claiming H7 doesn't read
  `serialUartConfig()`, now corrected).
- **CI fully green**: all 11 build-matrix groups, `test`×2, `sitl`, Codacy.

## Outstanding

- Found issue #1373's claim that the H7 reqmap table needs completing for
  `UARTDEV_1`-`9` is false (those entries have existed since PR #1194, just never
  consumed until this PR) — flagged separately, not corrected as part of this PR.
- The NVIC-gate bug fixed here is BF's own current, shipped H7 behavior too — worth
  a BF issue ticket, not filed as part of this PR.

Closes #1374.