### PR TITLE
test(dma): add host unit tests for DMA/LL register-level logic

### DIFF
--- a/src/main/drivers/bus_spi.c
+++ b/src/main/drivers/bus_spi.c
@@ -271,9 +271,10 @@ FAST_CODE static void spiRxIrqHandler(dmaChannelDescriptor_t *descriptor)
 
 #if defined(STM32F7) || defined(STM32H7)
     if (bus->curSegment->u.buffers.rxData) {
+        // uintptr_t widening: host build has 64-bit pointers; identical on the 32-bit target.
         SCB_InvalidateDCache_by_Addr(
-            (uint32_t *)((uint32_t)bus->curSegment->u.buffers.rxData & ~CACHE_LINE_MASK),
-            (((uint32_t)bus->curSegment->u.buffers.rxData & CACHE_LINE_MASK) +
+            (uint32_t *)((uintptr_t)bus->curSegment->u.buffers.rxData & ~CACHE_LINE_MASK),
+            (((uintptr_t)bus->curSegment->u.buffers.rxData & CACHE_LINE_MASK) +
               bus->curSegment->len - 1 + CACHE_LINE_SIZE) & ~CACHE_LINE_MASK);
     }
 #endif

--- a/src/main/drivers/dma.h
+++ b/src/main/drivers/dma.h
@@ -174,3 +174,8 @@ void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callbac
 resourceOwner_e dmaGetOwner(dmaIdentifier_e identifier);
 uint8_t dmaGetResourceIndex(dmaIdentifier_e identifier);
 dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier);
+
+#ifdef UNIT_TEST
+// resets the file-static dmaDescriptors[] ownership state; host tests have no other access to it.
+void dmaResetAllocationsForTest(void);
+#endif

--- a/src/main/drivers/dma_stm32f4xx.c
+++ b/src/main/drivers/dma_stm32f4xx.c
@@ -189,3 +189,12 @@ dmaChannelDescriptor_t* dmaGetDescriptorByIdentifier(const dmaIdentifier_e ident
 uint32_t dmaGetChannel(const uint8_t channel) {
     return ((uint32_t)channel * 2) << 24;
 }
+
+#ifdef UNIT_TEST
+void dmaResetAllocationsForTest(void) {
+    for (int i = 0; i < DMA_LAST_HANDLER; i++) {
+        dmaDescriptors[i].owner = OWNER_FREE;
+        dmaDescriptors[i].resourceIndex = 0;
+    }
+}
+#endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -77,6 +77,18 @@ bus_spi_unittest_DEFINES := \
 		SystemCoreClock=1000000
 
 
+bus_spi_h7_unittest_SRC := \
+		$(USER_DIR)/drivers/bus_spi.c \
+		$(USER_DIR)/build/atomic.c
+
+bus_spi_h7_unittest_DEFINES := \
+		STM32H7 \
+		USE_SPI \
+		USE_SPI_DEVICE_1 \
+		SPI1=\(SPI_TypeDef*\)0x40013000 \
+		SystemCoreClock=1000000
+
+
 blackbox_unittest_SRC :=  \
 		$(USER_DIR)/blackbox/blackbox.c \
 		$(USER_DIR)/blackbox/blackbox_encoding.c \
@@ -128,6 +140,172 @@ common_filter_unittest_SRC := \
 
 dma_bounds_unittest_DEFINES := \
 		STM32F4
+
+
+dma_stm32f4xx_unittest_SRC := \
+		$(USER_DIR)/drivers/dma_stm32f4xx.c
+
+dma_stm32f4xx_unittest_DEFINES := \
+		STM32F4 \
+		UNIT_TEST_DMA_REGISTER_MOCKS \
+		DMA1=\(DMA_TypeDef*\)0x40026000 \
+		DMA2=\(DMA_TypeDef*\)0x40026400 \
+		DMA1_Stream0=\(DMA_Stream_TypeDef*\)0x40026010 \
+		DMA1_Stream1=\(DMA_Stream_TypeDef*\)0x40026028 \
+		DMA1_Stream2=\(DMA_Stream_TypeDef*\)0x40026040 \
+		DMA1_Stream3=\(DMA_Stream_TypeDef*\)0x40026058 \
+		DMA1_Stream4=\(DMA_Stream_TypeDef*\)0x40026070 \
+		DMA1_Stream5=\(DMA_Stream_TypeDef*\)0x40026088 \
+		DMA1_Stream6=\(DMA_Stream_TypeDef*\)0x400260A0 \
+		DMA1_Stream7=\(DMA_Stream_TypeDef*\)0x400260B8 \
+		DMA2_Stream0=\(DMA_Stream_TypeDef*\)0x40026410 \
+		DMA2_Stream1=\(DMA_Stream_TypeDef*\)0x40026428 \
+		DMA2_Stream2=\(DMA_Stream_TypeDef*\)0x40026440 \
+		DMA2_Stream3=\(DMA_Stream_TypeDef*\)0x40026458 \
+		DMA2_Stream4=\(DMA_Stream_TypeDef*\)0x40026470 \
+		DMA2_Stream5=\(DMA_Stream_TypeDef*\)0x40026488 \
+		DMA2_Stream6=\(DMA_Stream_TypeDef*\)0x400264A0 \
+		DMA2_Stream7=\(DMA_Stream_TypeDef*\)0x400264B8 \
+		DMA1_Stream0_IRQn=1 \
+		DMA1_Stream1_IRQn=2 \
+		DMA1_Stream2_IRQn=3 \
+		DMA1_Stream3_IRQn=4 \
+		DMA1_Stream4_IRQn=5 \
+		DMA1_Stream5_IRQn=6 \
+		DMA1_Stream6_IRQn=7 \
+		DMA1_Stream7_IRQn=8 \
+		DMA2_Stream0_IRQn=9 \
+		DMA2_Stream1_IRQn=10 \
+		DMA2_Stream2_IRQn=11 \
+		DMA2_Stream3_IRQn=12 \
+		DMA2_Stream4_IRQn=13 \
+		DMA2_Stream5_IRQn=14 \
+		DMA2_Stream6_IRQn=15 \
+		DMA2_Stream7_IRQn=16 \
+		DMA_IT_TCIF0=0x20 \
+		DMA_IT_TCIF1=0x800 \
+		DMA_IT_TCIF2=0x200000 \
+		DMA_IT_TCIF3=0x8000000 \
+		DMA_IT_TCIF4=0x20 \
+		DMA_IT_TCIF5=0x800 \
+		DMA_IT_TCIF6=0x200000 \
+		DMA_IT_TCIF7=0x8000000
+
+
+dma_reqmap_unittest_SRC := \
+		$(USER_DIR)/drivers/dma_reqmap_mcu.c
+
+dma_reqmap_unittest_DEFINES := \
+		STM32F4 \
+		USE_SPI \
+		DMA_Channel_0=0 \
+		DMA_Channel_3=3 \
+		DMA_Channel_4=4 \
+		DMA_Channel_5=5 \
+		DMA1_Stream0=\(void*\)0x40026010 \
+		DMA1_Stream1=\(void*\)0x40026028 \
+		DMA1_Stream2=\(void*\)0x40026040 \
+		DMA1_Stream3=\(void*\)0x40026058 \
+		DMA1_Stream4=\(void*\)0x40026070 \
+		DMA1_Stream5=\(void*\)0x40026088 \
+		DMA1_Stream6=\(void*\)0x400260A0 \
+		DMA1_Stream7=\(void*\)0x400260B8 \
+		DMA2_Stream0=\(void*\)0x40026410 \
+		DMA2_Stream1=\(void*\)0x40026428 \
+		DMA2_Stream2=\(void*\)0x40026440 \
+		DMA2_Stream3=\(void*\)0x40026458 \
+		DMA2_Stream4=\(void*\)0x40026470 \
+		DMA2_Stream5=\(void*\)0x40026488 \
+		DMA2_Stream6=\(void*\)0x400264A0 \
+		DMA2_Stream7=\(void*\)0x400264B8
+
+
+dma_reqmap_h7_unittest_SRC := \
+		$(USER_DIR)/drivers/dma_reqmap_mcu.c
+
+dma_reqmap_h7_unittest_DEFINES := \
+		STM32H7 \
+		USE_SPI \
+		DMA_HandleTypeDef=DMA_Channel_TypeDef \
+		DMA1_Stream0=\(void*\)0x40020000 \
+		DMA1_Stream1=\(void*\)0x40020018 \
+		DMA1_Stream2=\(void*\)0x40020030 \
+		DMA1_Stream3=\(void*\)0x40020048 \
+		DMA1_Stream4=\(void*\)0x40020060 \
+		DMA1_Stream5=\(void*\)0x40020078 \
+		DMA1_Stream6=\(void*\)0x40020090 \
+		DMA1_Stream7=\(void*\)0x400200A8 \
+		DMA2_Stream0=\(void*\)0x40020400 \
+		DMA2_Stream1=\(void*\)0x40020418 \
+		DMA2_Stream2=\(void*\)0x40020430 \
+		DMA2_Stream3=\(void*\)0x40020448 \
+		DMA2_Stream4=\(void*\)0x40020460 \
+		DMA2_Stream5=\(void*\)0x40020478 \
+		DMA2_Stream6=\(void*\)0x40020490 \
+		DMA2_Stream7=\(void*\)0x400204A8 \
+		DMA_REQUEST_SPI1_TX=1 \
+		DMA_REQUEST_SPI1_RX=2 \
+		DMA_REQUEST_SPI2_TX=3 \
+		DMA_REQUEST_SPI2_RX=4 \
+		DMA_REQUEST_SPI3_TX=5 \
+		DMA_REQUEST_SPI3_RX=6 \
+		DMA_REQUEST_SPI4_TX=7 \
+		DMA_REQUEST_SPI4_RX=8 \
+		DMA_REQUEST_USART1_TX=9 \
+		DMA_REQUEST_USART1_RX=10 \
+		DMA_REQUEST_USART2_TX=11 \
+		DMA_REQUEST_USART2_RX=12 \
+		DMA_REQUEST_USART3_TX=13 \
+		DMA_REQUEST_USART3_RX=14 \
+		DMA_REQUEST_UART4_TX=15 \
+		DMA_REQUEST_UART4_RX=16 \
+		DMA_REQUEST_UART5_TX=17 \
+		DMA_REQUEST_UART5_RX=18 \
+		DMA_REQUEST_USART6_TX=19 \
+		DMA_REQUEST_USART6_RX=20 \
+		DMA_REQUEST_UART7_TX=21 \
+		DMA_REQUEST_UART7_RX=22 \
+		DMA_REQUEST_UART8_TX=23 \
+		DMA_REQUEST_UART8_RX=24 \
+		TIM1=\(void*\)0x40010000 \
+		TIM2=\(void*\)0x40010400 \
+		TIM3=\(void*\)0x40010800 \
+		TIM4=\(void*\)0x40010C00 \
+		TIM5=\(void*\)0x40011000 \
+		TIM8=\(void*\)0x40011400 \
+		TIM15=\(void*\)0x40011800 \
+		TIM16=\(void*\)0x40011C00 \
+		TIM17=\(void*\)0x40012000 \
+		TIM_CHANNEL_1=1 \
+		TIM_CHANNEL_2=2 \
+		TIM_CHANNEL_3=3 \
+		TIM_CHANNEL_4=4 \
+		DMA_REQUEST_TIM1_CH1=25 \
+		DMA_REQUEST_TIM1_CH2=26 \
+		DMA_REQUEST_TIM1_CH3=27 \
+		DMA_REQUEST_TIM1_CH4=28 \
+		DMA_REQUEST_TIM2_CH1=29 \
+		DMA_REQUEST_TIM2_CH2=30 \
+		DMA_REQUEST_TIM2_CH3=31 \
+		DMA_REQUEST_TIM2_CH4=32 \
+		DMA_REQUEST_TIM3_CH1=33 \
+		DMA_REQUEST_TIM3_CH2=34 \
+		DMA_REQUEST_TIM3_CH3=35 \
+		DMA_REQUEST_TIM3_CH4=36 \
+		DMA_REQUEST_TIM4_CH1=37 \
+		DMA_REQUEST_TIM4_CH2=38 \
+		DMA_REQUEST_TIM4_CH3=39 \
+		DMA_REQUEST_TIM5_CH1=40 \
+		DMA_REQUEST_TIM5_CH2=41 \
+		DMA_REQUEST_TIM5_CH3=42 \
+		DMA_REQUEST_TIM5_CH4=43 \
+		DMA_REQUEST_TIM8_CH1=44 \
+		DMA_REQUEST_TIM8_CH2=45 \
+		DMA_REQUEST_TIM8_CH3=46 \
+		DMA_REQUEST_TIM8_CH4=47 \
+		DMA_REQUEST_TIM15_CH1=48 \
+		DMA_REQUEST_TIM16_CH1=49 \
+		DMA_REQUEST_TIM17_CH1=50
 
 
 encoding_unittest_SRC := \

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -220,6 +220,35 @@ dma_reqmap_unittest_DEFINES := \
 		DMA2_Stream7=\(void*\)0x400264B8
 
 
+dma_reqmap_f7_unittest_SRC := \
+		$(USER_DIR)/drivers/dma_reqmap_mcu.c
+
+dma_reqmap_f7_unittest_DEFINES := \
+		STM32F7 \
+		USE_SPI \
+		DMA_HandleTypeDef=DMA_Channel_TypeDef \
+		DMA_CHANNEL_0=0 \
+		DMA_CHANNEL_3=3 \
+		DMA_CHANNEL_4=4 \
+		DMA_CHANNEL_5=5 \
+		DMA1_Stream0=\(void*\)0x40026010 \
+		DMA1_Stream1=\(void*\)0x40026028 \
+		DMA1_Stream2=\(void*\)0x40026040 \
+		DMA1_Stream3=\(void*\)0x40026058 \
+		DMA1_Stream4=\(void*\)0x40026070 \
+		DMA1_Stream5=\(void*\)0x40026088 \
+		DMA1_Stream6=\(void*\)0x400260A0 \
+		DMA1_Stream7=\(void*\)0x400260B8 \
+		DMA2_Stream0=\(void*\)0x40026410 \
+		DMA2_Stream1=\(void*\)0x40026428 \
+		DMA2_Stream2=\(void*\)0x40026440 \
+		DMA2_Stream3=\(void*\)0x40026458 \
+		DMA2_Stream4=\(void*\)0x40026470 \
+		DMA2_Stream5=\(void*\)0x40026488 \
+		DMA2_Stream6=\(void*\)0x400264A0 \
+		DMA2_Stream7=\(void*\)0x400264B8
+
+
 dma_reqmap_h7_unittest_SRC := \
 		$(USER_DIR)/drivers/dma_reqmap_mcu.c
 

--- a/src/test/unit/bus_spi_h7_unittest.cc
+++ b/src/test/unit/bus_spi_h7_unittest.cc
@@ -1,0 +1,247 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// STM32H7 counterpart to bus_spi_unittest.cc, whose mocks only ever stood up an STM32F4
+// configuration (see that file's own gap note and fix/spi-dma-unittest-infra/CONTEXT).
+// H7's spiInitBusDMA() (bus_spi.c:306) shares the same source lines as F4/F7 -- but
+// USE_TX_IRQ_HANDLER (bus_spi.c:33-35) is only defined for STM32F4/STM32F7, so H7 has no
+// Tx-only-DMA fallback branch: a Tx-succeeds/Rx-fails allocation falls through to the
+// "neither" else-branch and discards the already-allocated Tx descriptor. That divergence
+// was previously unexercised by any test; ReconfirmsTxOnlyDoesNotEnableDma below covers it.
+
+extern "C" {
+
+#include "platform.h"
+
+#if !defined(UNUSED)
+#define UNUSED(x) (void)(x)
+#endif
+
+#include "drivers/bus.h"
+#include "drivers/bus_spi.h"
+#include "drivers/bus_spi_impl.h"
+#include "drivers/dma.h"
+#include "drivers/dma_reqmap.h"
+#include "drivers/nvic.h"
+
+static int dmaTxStreamMarker;
+static int dmaRxStreamMarker;
+
+static bool txSpecAvailable;
+static bool rxSpecAvailable;
+static bool txAllocSucceeds;
+static bool rxAllocSucceeds;
+static int dmaSetHandlerCallCount;
+static dmaIdentifier_e lastHandlerIdentifier;
+
+static dmaChannelSpec_t txSpec;
+static dmaChannelSpec_t rxSpec;
+static dmaChannelDescriptor_t txDescriptor;
+static dmaChannelDescriptor_t rxDescriptor;
+
+const dmaChannelSpec_t *dmaGetChannelSpecByPeripheral(dmaPeripheral_e device, uint8_t index, int8_t opt) {
+    UNUSED(index);
+    if (opt != 0) {
+        return NULL;
+    }
+    if (device == DMA_PERIPH_SPI_SDO) {
+        return txSpecAvailable ? &txSpec : NULL;
+    }
+    if (device == DMA_PERIPH_SPI_SDI) {
+        return rxSpecAvailable ? &rxSpec : NULL;
+    }
+    return NULL;
+}
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef *stream) {
+    if ((const void *)stream == (const void *)&dmaTxStreamMarker) {
+        return DMA1_ST0_HANDLER;
+    }
+    if ((const void *)stream == (const void *)&dmaRxStreamMarker) {
+        return DMA1_ST1_HANDLER;
+    }
+    return DMA_NONE;
+}
+
+bool dmaAllocate(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    UNUSED(owner);
+    UNUSED(resourceIndex);
+    if (identifier == DMA1_ST0_HANDLER) {
+        return txAllocSucceeds;
+    }
+    if (identifier == DMA1_ST1_HANDLER) {
+        return rxAllocSucceeds;
+    }
+    return false;
+}
+
+dmaChannelDescriptor_t *dmaGetDescriptorByIdentifier(const dmaIdentifier_e identifier) {
+    if (identifier == DMA1_ST0_HANDLER) {
+        return &txDescriptor;
+    }
+    if (identifier == DMA1_ST1_HANDLER) {
+        return &rxDescriptor;
+    }
+    return NULL;
+}
+
+void dmaEnable(dmaIdentifier_e identifier) {
+    UNUSED(identifier);
+}
+
+void dmaSetHandler(dmaIdentifier_e identifier, dmaCallbackHandlerFuncPtr callback, uint32_t priority, uintptr_t userParam) {
+    UNUSED(callback);
+    UNUSED(priority);
+    UNUSED(userParam);
+    dmaSetHandlerCallCount++;
+    lastHandlerIdentifier = identifier;
+}
+
+void spiInternalResetStream(dmaChannelDescriptor_t *descriptor) {
+    UNUSED(descriptor);
+}
+
+void spiInternalResetDescriptors(busDevice_t *bus) {
+    UNUSED(bus);
+}
+
+void spiInternalInitStream(const extDevice_t *dev, bool preInit) {
+    UNUSED(dev);
+    UNUSED(preInit);
+}
+
+void spiInternalStartDMA(const extDevice_t *dev) {
+    UNUSED(dev);
+}
+
+void spiInternalStopDMA(const extDevice_t *dev) {
+    UNUSED(dev);
+}
+
+void spiInitDevice(SPIDevice device) {
+    UNUSED(device);
+}
+
+void spiSequenceStart(const extDevice_t *dev) {
+    UNUSED(dev);
+}
+
+void IOHi(IO_t io) {
+    UNUSED(io);
+}
+
+void IOLo(IO_t io) {
+    UNUSED(io);
+}
+
+// spiRxIrqHandler()'s cache-invalidate call on F7/H7; never reached by the tests below
+// (none drive the real DMA IRQ handler), but must still resolve to satisfy the TU.
+void SCB_InvalidateDCache_by_Addr(uint32_t *addr, int32_t dsize) {
+    UNUSED(addr);
+    UNUSED(dsize);
+}
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+SPI_TypeDef fakeSpi1;
+
+void resetSpiTestState()
+{
+    memset(&fakeSpi1, 0, sizeof(fakeSpi1));
+
+    for (int device = 0; device < SPIDEV_COUNT; device++) {
+        busDevice_t *bus = spiBusByDevice(static_cast<SPIDevice>(device));
+        memset(bus, 0, sizeof(*bus));
+        memset(&spiDevice[device], 0, sizeof(spiDevice[device]));
+    }
+    spiDevice[SPIDEV_1].dev = &fakeSpi1;
+
+    txSpecAvailable = true;
+    rxSpecAvailable = true;
+    txAllocSucceeds = true;
+    rxAllocSucceeds = true;
+    dmaSetHandlerCallCount = 0;
+    lastHandlerIdentifier = DMA_NONE;
+
+    txSpec = { 0, (dmaResource_t *)&dmaTxStreamMarker, 0 };
+    rxSpec = { 0, (dmaResource_t *)&dmaRxStreamMarker, 0 };
+    memset(&txDescriptor, 0, sizeof(txDescriptor));
+    memset(&rxDescriptor, 0, sizeof(rxDescriptor));
+}
+
+} // namespace
+
+TEST(BusSpiH7Unittest, FullDuplexEnablesDmaSameAsF4)
+{
+    resetSpiTestState();
+    extDevice_t dev = {};
+    ASSERT_TRUE(spiSetBusInstance(&dev, SPI_DEV_TO_CFG(SPIDEV_1)));
+
+    spiInitBusDMA();
+
+    busDevice_t *bus = spiBusByDevice(SPIDEV_1);
+    EXPECT_TRUE(bus->useDMA);
+    EXPECT_EQ(bus->dmaTx, &txDescriptor);
+    EXPECT_EQ(bus->dmaRx, &rxDescriptor);
+    EXPECT_EQ(dmaSetHandlerCallCount, 1);
+    EXPECT_EQ(lastHandlerIdentifier, DMA1_ST1_HANDLER);
+}
+
+TEST(BusSpiH7Unittest, TxOnlySuccessDoesNotEnableDmaUnlikeF4F7)
+{
+    // H7 has no USE_TX_IRQ_HANDLER fallback (bus_spi.c:33-35): a Tx-only allocation success
+    // still leaves the bus fully polled, and the already-allocated Tx descriptor is discarded
+    // rather than retained -- the opposite of F4/F7's InitBusDmaFallsBackToTxOnlyWhenNoRxChannel.
+    resetSpiTestState();
+    rxSpecAvailable = false;
+    extDevice_t dev = {};
+    ASSERT_TRUE(spiSetBusInstance(&dev, SPI_DEV_TO_CFG(SPIDEV_1)));
+
+    spiInitBusDMA();
+
+    busDevice_t *bus = spiBusByDevice(SPIDEV_1);
+    EXPECT_FALSE(bus->useDMA);
+    EXPECT_EQ(bus->dmaTx, nullptr); // discarded, even though dmaAllocate() succeeded for Tx
+    EXPECT_EQ(bus->dmaRx, nullptr);
+    EXPECT_EQ(dmaSetHandlerCallCount, 0);
+}
+
+TEST(BusSpiH7Unittest, AllocationFailureLeavesBusPolled)
+{
+    // adversarial: both channels rejected by the DMA allocator.
+    resetSpiTestState();
+    txAllocSucceeds = false;
+    rxAllocSucceeds = false;
+    extDevice_t dev = {};
+    ASSERT_TRUE(spiSetBusInstance(&dev, SPI_DEV_TO_CFG(SPIDEV_1)));
+
+    spiInitBusDMA();
+
+    busDevice_t *bus = spiBusByDevice(SPIDEV_1);
+    EXPECT_FALSE(bus->useDMA);
+    EXPECT_EQ(bus->dmaTx, nullptr);
+    EXPECT_EQ(bus->dmaRx, nullptr);
+    EXPECT_EQ(dmaSetHandlerCallCount, 0);
+}

--- a/src/test/unit/bus_spi_h7_unittest.cc
+++ b/src/test/unit/bus_spi_h7_unittest.cc
@@ -18,13 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-// STM32H7 counterpart to bus_spi_unittest.cc, whose mocks only ever stood up an STM32F4
-// configuration (see that file's own gap note and fix/spi-dma-unittest-infra/CONTEXT).
-// H7's spiInitBusDMA() (bus_spi.c:306) shares the same source lines as F4/F7 -- but
-// USE_TX_IRQ_HANDLER (bus_spi.c:33-35) is only defined for STM32F4/STM32F7, so H7 has no
-// Tx-only-DMA fallback branch: a Tx-succeeds/Rx-fails allocation falls through to the
-// "neither" else-branch and discards the already-allocated Tx descriptor. That divergence
-// was previously unexercised by any test; ReconfirmsTxOnlyDoesNotEnableDma below covers it.
+// STM32H7 counterpart to bus_spi_unittest.cc, which only ever stood up STM32F4.
+// H7 has no USE_TX_IRQ_HANDLER (bus_spi.c:33-35), so Tx-only success discards dmaTx instead of falling back.
 
 extern "C" {
 
@@ -151,8 +146,7 @@ void IOLo(IO_t io) {
     UNUSED(io);
 }
 
-// spiRxIrqHandler()'s cache-invalidate call on F7/H7; never reached by the tests below
-// (none drive the real DMA IRQ handler), but must still resolve to satisfy the TU.
+// link-only: spiRxIrqHandler()'s F7/H7 cache-invalidate call, never reached by these tests.
 void SCB_InvalidateDCache_by_Addr(uint32_t *addr, int32_t dsize) {
     UNUSED(addr);
     UNUSED(dsize);
@@ -211,9 +205,7 @@ TEST(BusSpiH7Unittest, FullDuplexEnablesDmaSameAsF4)
 
 TEST(BusSpiH7Unittest, TxOnlySuccessDoesNotEnableDmaUnlikeF4F7)
 {
-    // H7 has no USE_TX_IRQ_HANDLER fallback (bus_spi.c:33-35): a Tx-only allocation success
-    // still leaves the bus fully polled, and the already-allocated Tx descriptor is discarded
-    // rather than retained -- the opposite of F4/F7's InitBusDmaFallsBackToTxOnlyWhenNoRxChannel.
+    // H7 has no Tx-only fallback: bus stays polled and dmaTx is discarded, unlike F4/F7.
     resetSpiTestState();
     rxSpecAvailable = false;
     extDevice_t dev = {};

--- a/src/test/unit/dma_reqmap_f7_unittest.cc
+++ b/src/test/unit/dma_reqmap_f7_unittest.cc
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Compiles the real dma_reqmap_mcu.c under -DSTM32F7. Covers what an F4-only compile
+// (dma_reqmap_unittest.cc) cannot exercise: the DMA_CHANNEL_x-macro variant of DMA()
+// (F4 uses DMA_Channel_x, a different macro entirely) and the UARTDEV_7/UARTDEV_8 table
+// rows that exist only under #if defined(STM32F7).
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma_reqmap.h"
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// --- F7-exclusive UART entries: no F4 equivalent, unreachable from the F4 test binary ---
+
+TEST(DmaReqmapF7Unittest, Uart7RxAndTxResolveToDistinctStreams)
+{
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_7, 0);
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_7, 0);
+
+    ASSERT_NE(rx, nullptr);
+    ASSERT_NE(tx, nullptr);
+    EXPECT_NE(rx->ref, tx->ref);
+}
+
+TEST(DmaReqmapF7Unittest, Uart8RxAndTxResolveToDistinctStreams)
+{
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_8, 0);
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_8, 0);
+
+    ASSERT_NE(rx, nullptr);
+    ASSERT_NE(tx, nullptr);
+    EXPECT_NE(rx->ref, tx->ref);
+}
+
+TEST(DmaReqmapF7Unittest, Uart7HasNoSecondAlternateOption)
+{
+    // UARTDEV_7/8 list exactly one silicon-valid option each -- unlike UARTDEV_1, opt 1 must fail closed.
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_7, 1), nullptr);
+}
+
+// --- Shared UART entries: confirm the same rows F4 covers also resolve under the F7 compile ---
+
+TEST(DmaReqmapF7Unittest, Uart1RxAndTxResolveToDistinctStreams)
+{
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_1, 0);
+
+    ASSERT_NE(rx, nullptr);
+    ASSERT_NE(tx, nullptr);
+    EXPECT_NE(rx->ref, tx->ref);
+}
+
+// --- Adversarial: same fail-closed contract must hold under the F7 macro variant too ---
+
+TEST(DmaReqmapF7Unittest, RejectsNegativeOptIndex)
+{
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_7, -1), nullptr);
+}
+
+TEST(DmaReqmapF7Unittest, RejectsOptIndexPastTableWidth)
+{
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_7, MAX_PERIPHERAL_DMA_OPTIONS), nullptr);
+}

--- a/src/test/unit/dma_reqmap_h7_unittest.cc
+++ b/src/test/unit/dma_reqmap_h7_unittest.cc
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Compiles the real src/main/drivers/dma_reqmap_mcu.c's STM32H7 branch under UNIT_TEST --
+// a genuinely different code path from dma_reqmap_unittest.cc's F4/F7 branch (DMAMUX
+// request-code table vs. per-stream channelSpec arrays), added for PR #1383's H7
+// uartConfigureDma() port, which had no host coverage of its reqmap consumer before this.
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma_reqmap.h"
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// dmaGetChannelSpecByPeripheral()'s H7 branch writes each result into a shared,
+// opt-indexed scratch array (dmaChannelSpec_mcu.c's static dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS]),
+// not a stable per-peripheral value -- the returned pointer is only valid until the next
+// call using the same opt index. The real caller (spiInitBusDMA(), bus_spi.c:326-335) copies
+// ->channel/->ref out immediately and never holds two results live at once; tests here do
+// the same, and a dedicated test below documents the aliasing itself.
+TEST(DmaReqmapH7Unittest, Uart1RxAndTxResolveToDistinctRequestCodes)
+{
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
+    ASSERT_NE(rx, nullptr);
+    const uint32_t rxChannel = rx->channel;
+
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_1, 0);
+    ASSERT_NE(tx, nullptr);
+
+    EXPECT_NE(rxChannel, tx->channel); // DMA_REQUEST_USART1_RX != _TX
+}
+
+TEST(DmaReqmapH7Unittest, DifferentOptsResolveToDifferentStreamsButSameRequestCode)
+{
+    // H7's DMAMUX model: any of the 16 streams can carry any peripheral's request code,
+    // unlike F4/F7's fixed per-stream channelSpec table -- opt only selects the stream.
+    const dmaChannelSpec_t *opt0 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_3, 0);
+    ASSERT_NE(opt0, nullptr);
+    const dmaResource_t *opt0Ref = opt0->ref;
+    const uint32_t opt0Channel = opt0->channel;
+
+    const dmaChannelSpec_t *opt1 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_3, 1);
+    ASSERT_NE(opt1, nullptr);
+
+    EXPECT_NE(opt0Ref, opt1->ref);
+    EXPECT_EQ(opt0Channel, opt1->channel); // same peripheral request, different stream
+}
+
+TEST(DmaReqmapH7Unittest, ResultAliasesSharedPerOptSlotAcrossCalls)
+{
+    // adversarial: a caller that (incorrectly) holds two live pointers from the same
+    // opt index sees the first one mutate underneath it -- documents a real trap distinct
+    // from the F4/F7 branch, whose channelSpec entries are immutable static table rows.
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
+    ASSERT_NE(rx, nullptr);
+    ASSERT_EQ(rx->channel, static_cast<uint32_t>(DMA_REQUEST_USART1_RX));
+
+    dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_1, 0); // same opt index
+
+    EXPECT_EQ(rx->channel, static_cast<uint32_t>(DMA_REQUEST_USART1_TX)); // rx's slot was overwritten
+}
+
+TEST(DmaReqmapH7Unittest, RejectsNegativeOptIndex)
+{
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, -1), nullptr);
+}
+
+TEST(DmaReqmapH7Unittest, RejectsOptIndexPastTableWidth)
+{
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, MAX_PERIPHERAL_DMA_OPTIONS), nullptr);
+}
+
+TEST(DmaReqmapH7Unittest, RejectsUnmappedPeripheral)
+{
+    // adversarial: TIMUP entries require USE_TIMER, not defined for this test config --
+    // must fail closed (NULL), not read past dmaPeripheralMapping[]'s end.
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_TIMUP, 0, 0), nullptr);
+}

--- a/src/test/unit/dma_reqmap_h7_unittest.cc
+++ b/src/test/unit/dma_reqmap_h7_unittest.cc
@@ -18,10 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Compiles the real src/main/drivers/dma_reqmap_mcu.c's STM32H7 branch under UNIT_TEST --
-// a genuinely different code path from dma_reqmap_unittest.cc's F4/F7 branch (DMAMUX
-// request-code table vs. per-stream channelSpec arrays), added for PR #1383's H7
-// uartConfigureDma() port, which had no host coverage of its reqmap consumer before this.
+// Compiles the real dma_reqmap_mcu.c's STM32H7 branch under UNIT_TEST -- a different
+// code path from the F4/F7 branch (DMAMUX request-code table vs. channelSpec arrays).
 
 extern "C" {
 
@@ -35,12 +33,8 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
-// dmaGetChannelSpecByPeripheral()'s H7 branch writes each result into a shared,
-// opt-indexed scratch array (dmaChannelSpec_mcu.c's static dmaChannelSpec[MAX_PERIPHERAL_DMA_OPTIONS]),
-// not a stable per-peripheral value -- the returned pointer is only valid until the next
-// call using the same opt index. The real caller (spiInitBusDMA(), bus_spi.c:326-335) copies
-// ->channel/->ref out immediately and never holds two results live at once; tests here do
-// the same, and a dedicated test below documents the aliasing itself.
+// H7's result aliases a shared opt-indexed scratch array; read fields out immediately,
+// matching spiInitBusDMA() (bus_spi.c:326-335) -- see ResultAliasesSharedPerOptSlotAcrossCalls below.
 TEST(DmaReqmapH7Unittest, Uart1RxAndTxResolveToDistinctRequestCodes)
 {
     const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
@@ -55,8 +49,7 @@ TEST(DmaReqmapH7Unittest, Uart1RxAndTxResolveToDistinctRequestCodes)
 
 TEST(DmaReqmapH7Unittest, DifferentOptsResolveToDifferentStreamsButSameRequestCode)
 {
-    // H7's DMAMUX model: any of the 16 streams can carry any peripheral's request code,
-    // unlike F4/F7's fixed per-stream channelSpec table -- opt only selects the stream.
+    // H7's DMAMUX: opt only selects the stream, unlike F4/F7's fixed per-stream table.
     const dmaChannelSpec_t *opt0 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_3, 0);
     ASSERT_NE(opt0, nullptr);
     const dmaResource_t *opt0Ref = opt0->ref;
@@ -71,9 +64,7 @@ TEST(DmaReqmapH7Unittest, DifferentOptsResolveToDifferentStreamsButSameRequestCo
 
 TEST(DmaReqmapH7Unittest, ResultAliasesSharedPerOptSlotAcrossCalls)
 {
-    // adversarial: a caller that (incorrectly) holds two live pointers from the same
-    // opt index sees the first one mutate underneath it -- documents a real trap distinct
-    // from the F4/F7 branch, whose channelSpec entries are immutable static table rows.
+    // adversarial: a live pointer from an earlier call mutates once a later call reuses its opt index.
     const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
     ASSERT_NE(rx, nullptr);
     ASSERT_EQ(rx->channel, static_cast<uint32_t>(DMA_REQUEST_USART1_RX));
@@ -95,7 +86,6 @@ TEST(DmaReqmapH7Unittest, RejectsOptIndexPastTableWidth)
 
 TEST(DmaReqmapH7Unittest, RejectsUnmappedPeripheral)
 {
-    // adversarial: TIMUP entries require USE_TIMER, not defined for this test config --
-    // must fail closed (NULL), not read past dmaPeripheralMapping[]'s end.
+    // adversarial: TIMUP requires USE_TIMER (undefined here); must fail closed, not read past the table.
     EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_TIMUP, 0, 0), nullptr);
 }

--- a/src/test/unit/dma_reqmap_unittest.cc
+++ b/src/test/unit/dma_reqmap_unittest.cc
@@ -1,0 +1,103 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Compiles the real src/main/drivers/dma_reqmap_mcu.c (F4/F7 branch) under UNIT_TEST.
+// dmaGetChannelSpecByPeripheral() is a pure static-table lookup here -- no CMSIS register
+// access at all -- so it needs no register mocking, only fake DMAx_Streamy pointer/channel
+// literals to stand in for the real stream identities the table is built from.
+// F7 shares this exact source branch (`(STM32F4 || STM32F7) && USE_SPI`), so an F4 compile
+// exercises the same logic F7 would; see the analogous reasoning already recorded for
+// serial_uart_dma_claim_unittest.cc in fix/dmainit-ownership-check/CONTEXT.
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma_reqmap.h"
+#include "drivers/serial.h"
+#include "drivers/serial_uart.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// --- SPI entries: sanity that the real table still resolves the primary bus ---
+
+TEST(DmaReqmapUnittest, SpiSdoAndSdiResolveToDifferentStreamsOnSpiDev2)
+{
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_SDO, 1, 0);
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_SPI_SDI, 1, 0);
+
+    ASSERT_NE(tx, nullptr);
+    ASSERT_NE(rx, nullptr);
+    EXPECT_NE(tx->ref, rx->ref);
+}
+
+// --- UART entries: PR #1370/#1383's new reqmap consumers, previously untested ---
+
+TEST(DmaReqmapUnittest, Uart1RxAndTxResolveToDistinctStreams)
+{
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_1, 0);
+
+    ASSERT_NE(rx, nullptr);
+    ASSERT_NE(tx, nullptr);
+    EXPECT_NE(rx->ref, tx->ref);
+}
+
+TEST(DmaReqmapUnittest, Uart1RxHasASecondAlternateOption)
+{
+    // UARTDEV_1 RX has two known-valid streams (see dma_reqmap_mcu.c); opt 1 must resolve
+    // to a stream distinct from opt 0, giving serialUART() a real fallback to try.
+    const dmaChannelSpec_t *opt0 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
+    const dmaChannelSpec_t *opt1 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 1);
+
+    ASSERT_NE(opt0, nullptr);
+    ASSERT_NE(opt1, nullptr);
+    EXPECT_NE(opt0->ref, opt1->ref);
+}
+
+TEST(DmaReqmapUnittest, Uart6RxAndTxResolveToDistinctStreams)
+{
+    const dmaChannelSpec_t *rx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_6, 0);
+    const dmaChannelSpec_t *tx = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_TX, UARTDEV_6, 0);
+
+    ASSERT_NE(rx, nullptr);
+    ASSERT_NE(tx, nullptr);
+    EXPECT_NE(rx->ref, tx->ref);
+}
+
+// --- Adversarial: invalid opt / unknown device must fail closed, not crash or alias ---
+
+TEST(DmaReqmapUnittest, RejectsNegativeOptIndex)
+{
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, -1), nullptr);
+}
+
+TEST(DmaReqmapUnittest, RejectsOptIndexPastTableWidth)
+{
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, MAX_PERIPHERAL_DMA_OPTIONS), nullptr);
+}
+
+TEST(DmaReqmapUnittest, RejectsUartDeviceWithNoTableEntry)
+{
+    // UARTDEV_9/10 have no F4/F7 table rows at all (H7-only entries) -- must return NULL, not a stale/wrong row.
+    EXPECT_EQ(dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_9, 0), nullptr);
+}

--- a/src/test/unit/dma_reqmap_unittest.cc
+++ b/src/test/unit/dma_reqmap_unittest.cc
@@ -18,13 +18,9 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Compiles the real src/main/drivers/dma_reqmap_mcu.c (F4/F7 branch) under UNIT_TEST.
-// dmaGetChannelSpecByPeripheral() is a pure static-table lookup here -- no CMSIS register
-// access at all -- so it needs no register mocking, only fake DMAx_Streamy pointer/channel
-// literals to stand in for the real stream identities the table is built from.
-// F7 shares this exact source branch (`(STM32F4 || STM32F7) && USE_SPI`), so an F4 compile
-// exercises the same logic F7 would; see the analogous reasoning already recorded for
-// serial_uart_dma_claim_unittest.cc in fix/dmainit-ownership-check/CONTEXT.
+// Compiles the real dma_reqmap_mcu.c (F4/F7 branch) under UNIT_TEST; pure table lookup,
+// no register access, so only fake DMAx_Streamy/channel literals are needed. F7 shares
+// this exact source branch, so an F4 compile exercises F7's logic too.
 
 extern "C" {
 
@@ -64,8 +60,7 @@ TEST(DmaReqmapUnittest, Uart1RxAndTxResolveToDistinctStreams)
 
 TEST(DmaReqmapUnittest, Uart1RxHasASecondAlternateOption)
 {
-    // UARTDEV_1 RX has two known-valid streams (see dma_reqmap_mcu.c); opt 1 must resolve
-    // to a stream distinct from opt 0, giving serialUART() a real fallback to try.
+    // UARTDEV_1 RX opt 1 must resolve to a different stream, giving serialUART() a real fallback.
     const dmaChannelSpec_t *opt0 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 0);
     const dmaChannelSpec_t *opt1 = dmaGetChannelSpecByPeripheral(DMA_PERIPH_UART_RX, UARTDEV_1, 1);
 

--- a/src/test/unit/dma_reqmap_unittest.cc
+++ b/src/test/unit/dma_reqmap_unittest.cc
@@ -19,8 +19,10 @@
  */
 
 // Compiles the real dma_reqmap_mcu.c (F4/F7 branch) under UNIT_TEST; pure table lookup,
-// no register access, so only fake DMAx_Streamy/channel literals are needed. F7 shares
-// this exact source branch, so an F4 compile exercises F7's logic too.
+// no register access, so only fake DMAx_Streamy/channel literals are needed. This file
+// covers the F4 compile only: F4 and F7 share the outer #elif guard but diverge inside it
+// -- the DMA() macro itself differs (DMA_Channel_x vs DMA_CHANNEL_x) and UARTDEV_7/8 exist
+// only under #if defined(STM32F7). See dma_reqmap_f7_unittest.cc for that coverage.
 
 extern "C" {
 

--- a/src/test/unit/dma_stm32f4xx_unittest.cc
+++ b/src/test/unit/dma_stm32f4xx_unittest.cc
@@ -18,12 +18,8 @@
  * If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Compiles the real src/main/drivers/dma_stm32f4xx.c under UNIT_TEST, mocking only the
-// register-level surface it touches (RCC_AHB1PeriphClockCmd, NVIC_Init) -- unlike
-// dma_bounds_unittest.cc, which mirrors dmaIdentifierIsValid() locally rather than linking
-// the production file. dmaDescriptors[] is file-static inside the real .c file (no reset
-// hook exists), so each TEST() below claims its own dedicated, never-reused DMA identifier
-// instead of resetting shared state between cases.
+// Compiles the real dma_stm32f4xx.c under UNIT_TEST, mocking only its register surface.
+// resetDmaTestState() clears dmaDescriptors[] via a UNIT_TEST-only hook added for this file.
 
 extern "C" {
 
@@ -51,7 +47,8 @@ void RCC_AHB1PeriphClockCmd(uint32_t periph, FunctionalState state) {
 #include "gtest/gtest.h"
 
 namespace {
-void resetRegisterMockCounters() {
+void resetDmaTestState() {
+    dmaResetAllocationsForTest();
     nvicInitCallCount = 0;
     rccClockCmdCallCount = 0;
     lastRccPeriph = 0;
@@ -62,6 +59,7 @@ void resetRegisterMockCounters() {
 
 TEST(DmaStm32F4xxUnittest, AllocateOnFreeStreamSucceedsAndRecordsOwner)
 {
+    resetDmaTestState();
     const dmaIdentifier_e id = DMA1_ST2_HANDLER;
     ASSERT_EQ(dmaGetOwner(id), OWNER_FREE);
 
@@ -72,6 +70,7 @@ TEST(DmaStm32F4xxUnittest, AllocateOnFreeStreamSucceedsAndRecordsOwner)
 
 TEST(DmaStm32F4xxUnittest, DoubleAllocateSameStreamByDifferentOwnerFails)
 {
+    resetDmaTestState();
     const dmaIdentifier_e id = DMA1_ST3_HANDLER;
     ASSERT_TRUE(dmaAllocate(id, OWNER_SPI_SDI, 1));
 
@@ -83,6 +82,7 @@ TEST(DmaStm32F4xxUnittest, DoubleAllocateSameStreamByDifferentOwnerFails)
 
 TEST(DmaStm32F4xxUnittest, AllocateRejectsInvalidIdentifier)
 {
+    resetDmaTestState();
     // adversarial: DMA_NONE and past-the-end identifiers must not index dmaDescriptors[].
     EXPECT_FALSE(dmaAllocate(DMA_NONE, OWNER_SPI_SDO, 0));
     EXPECT_FALSE(dmaAllocate(static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1), OWNER_SPI_SDO, 0));
@@ -92,24 +92,28 @@ TEST(DmaStm32F4xxUnittest, AllocateRejectsInvalidIdentifier)
 
 TEST(DmaStm32F4xxUnittest, GetIdentifierResolvesRealStreamPointer)
 {
+    resetDmaTestState();
     EXPECT_EQ(dmaGetIdentifier(DMA1_Stream4), DMA1_ST4_HANDLER);
     EXPECT_EQ(dmaGetIdentifier(DMA2_Stream6), DMA2_ST6_HANDLER);
 }
 
 TEST(DmaStm32F4xxUnittest, GetIdentifierRejectsUnknownStreamPointer)
 {
-    DMA_Stream_TypeDef unknownStream;
+    resetDmaTestState();
+    DMA_Stream_TypeDef unknownStream = {};
     EXPECT_EQ(dmaGetIdentifier(&unknownStream), DMA_NONE);
 }
 
 TEST(DmaStm32F4xxUnittest, GetDescriptorByIdentifierRejectsInvalidIdentifier)
 {
+    resetDmaTestState();
     EXPECT_EQ(dmaGetDescriptorByIdentifier(DMA_NONE), nullptr);
     EXPECT_EQ(dmaGetDescriptorByIdentifier(static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1)), nullptr);
 }
 
 TEST(DmaStm32F4xxUnittest, GetDescriptorByIdentifierReturnsMatchingStream)
 {
+    resetDmaTestState();
     dmaChannelDescriptor_t *descriptor = dmaGetDescriptorByIdentifier(DMA1_ST5_HANDLER);
     ASSERT_NE(descriptor, nullptr);
     EXPECT_EQ(descriptor->ref, DMA1_Stream5);
@@ -120,7 +124,7 @@ TEST(DmaStm32F4xxUnittest, GetDescriptorByIdentifierReturnsMatchingStream)
 
 TEST(DmaStm32F4xxUnittest, EnableOnValidIdentifierClocksTheControllerOnce)
 {
-    resetRegisterMockCounters();
+    resetDmaTestState();
     dmaEnable(DMA1_ST6_HANDLER);
     EXPECT_EQ(rccClockCmdCallCount, 1);
     EXPECT_EQ(lastRccPeriph, RCC_AHB1Periph_DMA1);
@@ -129,7 +133,7 @@ TEST(DmaStm32F4xxUnittest, EnableOnValidIdentifierClocksTheControllerOnce)
 TEST(DmaStm32F4xxUnittest, EnableOnInvalidIdentifierNeverTouchesRegisters)
 {
     // adversarial: guard must reject before the register write, not after.
-    resetRegisterMockCounters();
+    resetDmaTestState();
     dmaEnable(DMA_NONE);
     dmaEnable(static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1));
     EXPECT_EQ(rccClockCmdCallCount, 0);
@@ -137,7 +141,7 @@ TEST(DmaStm32F4xxUnittest, EnableOnInvalidIdentifierNeverTouchesRegisters)
 
 TEST(DmaStm32F4xxUnittest, SetHandlerRegistersCallbackAndEnablesInterrupt)
 {
-    resetRegisterMockCounters();
+    resetDmaTestState();
     const dmaIdentifier_e id = DMA2_ST0_HANDLER;
     dmaChannelDescriptor_t *descriptor = dmaGetDescriptorByIdentifier(id);
     ASSERT_NE(descriptor, nullptr);
@@ -153,7 +157,7 @@ TEST(DmaStm32F4xxUnittest, SetHandlerRegistersCallbackAndEnablesInterrupt)
 TEST(DmaStm32F4xxUnittest, SetHandlerOnInvalidIdentifierNeverTouchesRegisters)
 {
     // adversarial: same guard as dmaEnable(), exercised via the other register-touching entry point.
-    resetRegisterMockCounters();
+    resetDmaTestState();
     dmaSetHandler(DMA_NONE, nullptr, 0, 0);
     EXPECT_EQ(nvicInitCallCount, 0);
     EXPECT_EQ(rccClockCmdCallCount, 0);
@@ -163,6 +167,7 @@ TEST(DmaStm32F4xxUnittest, SetHandlerOnInvalidIdentifierNeverTouchesRegisters)
 
 TEST(DmaStm32F4xxUnittest, InitOverwritesExistingOwnerWithNoOwnershipCheck)
 {
+    resetDmaTestState();
     const dmaIdentifier_e id = DMA1_ST7_HANDLER;
     ASSERT_TRUE(dmaAllocate(id, OWNER_SPI_SDO, 1));
 

--- a/src/test/unit/dma_stm32f4xx_unittest.cc
+++ b/src/test/unit/dma_stm32f4xx_unittest.cc
@@ -1,0 +1,173 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Compiles the real src/main/drivers/dma_stm32f4xx.c under UNIT_TEST, mocking only the
+// register-level surface it touches (RCC_AHB1PeriphClockCmd, NVIC_Init) -- unlike
+// dma_bounds_unittest.cc, which mirrors dmaIdentifierIsValid() locally rather than linking
+// the production file. dmaDescriptors[] is file-static inside the real .c file (no reset
+// hook exists), so each TEST() below claims its own dedicated, never-reused DMA identifier
+// instead of resetting shared state between cases.
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma.h"
+
+static int nvicInitCallCount;
+static int rccClockCmdCallCount;
+static uint32_t lastRccPeriph;
+
+void NVIC_Init(NVIC_InitTypeDef *initStruct) {
+    (void)initStruct;
+    nvicInitCallCount++;
+}
+
+void RCC_AHB1PeriphClockCmd(uint32_t periph, FunctionalState state) {
+    (void)state;
+    rccClockCmdCallCount++;
+    lastRccPeriph = periph;
+}
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+namespace {
+void resetRegisterMockCounters() {
+    nvicInitCallCount = 0;
+    rccClockCmdCallCount = 0;
+    lastRccPeriph = 0;
+}
+} // namespace
+
+// --- dmaAllocate(): real ownership-check logic from the production file ---
+
+TEST(DmaStm32F4xxUnittest, AllocateOnFreeStreamSucceedsAndRecordsOwner)
+{
+    const dmaIdentifier_e id = DMA1_ST2_HANDLER;
+    ASSERT_EQ(dmaGetOwner(id), OWNER_FREE);
+
+    EXPECT_TRUE(dmaAllocate(id, OWNER_SPI_SDO, 3));
+    EXPECT_EQ(dmaGetOwner(id), OWNER_SPI_SDO);
+    EXPECT_EQ(dmaGetResourceIndex(id), 3);
+}
+
+TEST(DmaStm32F4xxUnittest, DoubleAllocateSameStreamByDifferentOwnerFails)
+{
+    const dmaIdentifier_e id = DMA1_ST3_HANDLER;
+    ASSERT_TRUE(dmaAllocate(id, OWNER_SPI_SDI, 1));
+
+    // adversarial: a second, different owner must not steal an already-claimed stream.
+    EXPECT_FALSE(dmaAllocate(id, OWNER_SERIAL_RX, 2));
+    EXPECT_EQ(dmaGetOwner(id), OWNER_SPI_SDI); // original claim untouched
+    EXPECT_EQ(dmaGetResourceIndex(id), 1);
+}
+
+TEST(DmaStm32F4xxUnittest, AllocateRejectsInvalidIdentifier)
+{
+    // adversarial: DMA_NONE and past-the-end identifiers must not index dmaDescriptors[].
+    EXPECT_FALSE(dmaAllocate(DMA_NONE, OWNER_SPI_SDO, 0));
+    EXPECT_FALSE(dmaAllocate(static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1), OWNER_SPI_SDO, 0));
+}
+
+// --- dmaGetIdentifier() / dmaGetDescriptorByIdentifier(): real stream-table lookup ---
+
+TEST(DmaStm32F4xxUnittest, GetIdentifierResolvesRealStreamPointer)
+{
+    EXPECT_EQ(dmaGetIdentifier(DMA1_Stream4), DMA1_ST4_HANDLER);
+    EXPECT_EQ(dmaGetIdentifier(DMA2_Stream6), DMA2_ST6_HANDLER);
+}
+
+TEST(DmaStm32F4xxUnittest, GetIdentifierRejectsUnknownStreamPointer)
+{
+    DMA_Stream_TypeDef unknownStream;
+    EXPECT_EQ(dmaGetIdentifier(&unknownStream), DMA_NONE);
+}
+
+TEST(DmaStm32F4xxUnittest, GetDescriptorByIdentifierRejectsInvalidIdentifier)
+{
+    EXPECT_EQ(dmaGetDescriptorByIdentifier(DMA_NONE), nullptr);
+    EXPECT_EQ(dmaGetDescriptorByIdentifier(static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1)), nullptr);
+}
+
+TEST(DmaStm32F4xxUnittest, GetDescriptorByIdentifierReturnsMatchingStream)
+{
+    dmaChannelDescriptor_t *descriptor = dmaGetDescriptorByIdentifier(DMA1_ST5_HANDLER);
+    ASSERT_NE(descriptor, nullptr);
+    EXPECT_EQ(descriptor->ref, DMA1_Stream5);
+    EXPECT_EQ(descriptor->dma, DMA1);
+}
+
+// --- dmaEnable() / dmaSetHandler(): real functions must reach the mocked registers ---
+
+TEST(DmaStm32F4xxUnittest, EnableOnValidIdentifierClocksTheControllerOnce)
+{
+    resetRegisterMockCounters();
+    dmaEnable(DMA1_ST6_HANDLER);
+    EXPECT_EQ(rccClockCmdCallCount, 1);
+    EXPECT_EQ(lastRccPeriph, RCC_AHB1Periph_DMA1);
+}
+
+TEST(DmaStm32F4xxUnittest, EnableOnInvalidIdentifierNeverTouchesRegisters)
+{
+    // adversarial: guard must reject before the register write, not after.
+    resetRegisterMockCounters();
+    dmaEnable(DMA_NONE);
+    dmaEnable(static_cast<dmaIdentifier_e>(DMA_LAST_HANDLER + 1));
+    EXPECT_EQ(rccClockCmdCallCount, 0);
+}
+
+TEST(DmaStm32F4xxUnittest, SetHandlerRegistersCallbackAndEnablesInterrupt)
+{
+    resetRegisterMockCounters();
+    const dmaIdentifier_e id = DMA2_ST0_HANDLER;
+    dmaChannelDescriptor_t *descriptor = dmaGetDescriptorByIdentifier(id);
+    ASSERT_NE(descriptor, nullptr);
+
+    dmaSetHandler(id, nullptr, 0, 0x1234);
+
+    EXPECT_EQ(nvicInitCallCount, 1);
+    EXPECT_EQ(rccClockCmdCallCount, 1);
+    EXPECT_EQ(lastRccPeriph, RCC_AHB1Periph_DMA2);
+    EXPECT_EQ(descriptor->userParam, (uintptr_t)0x1234);
+}
+
+TEST(DmaStm32F4xxUnittest, SetHandlerOnInvalidIdentifierNeverTouchesRegisters)
+{
+    // adversarial: same guard as dmaEnable(), exercised via the other register-touching entry point.
+    resetRegisterMockCounters();
+    dmaSetHandler(DMA_NONE, nullptr, 0, 0);
+    EXPECT_EQ(nvicInitCallCount, 0);
+    EXPECT_EQ(rccClockCmdCallCount, 0);
+}
+
+// --- dmaInit(): documents its real, unchecked overwrite -- unlike dmaAllocate() above ---
+
+TEST(DmaStm32F4xxUnittest, InitOverwritesExistingOwnerWithNoOwnershipCheck)
+{
+    const dmaIdentifier_e id = DMA1_ST7_HANDLER;
+    ASSERT_TRUE(dmaAllocate(id, OWNER_SPI_SDO, 1));
+
+    dmaInit(id, OWNER_SERIAL_TX, 4); // no ownership check, unlike dmaAllocate() above
+
+    EXPECT_EQ(dmaGetOwner(id), OWNER_SERIAL_TX);
+    EXPECT_EQ(dmaGetResourceIndex(id), 4);
+}

--- a/src/test/unit/platform.h
+++ b/src/test/unit/platform.h
@@ -30,6 +30,7 @@
 #define GCC_OPTIMIZE_SIZE
 #define FAST_CODE
 #define FAST_CODE_NOINLINE
+#define FAST_IRQ_HANDLER
 #define FAST_RAM_ZERO_INIT
 #define FAST_RAM
 #define DMA_DATA_ZERO_INIT
@@ -86,6 +87,7 @@ typedef struct {
 uint8_t DMA_GetFlagStatus(void *);
 void DMA_Cmd(DMA_Channel_TypeDef*, FunctionalState );
 void DMA_ClearFlag(uint32_t);
+void SCB_InvalidateDCache_by_Addr(uint32_t *addr, int32_t dsize);
 
 typedef struct {
     void* test;
@@ -106,6 +108,23 @@ typedef struct {
 #define WS2811_DMA_TC_FLAG (void *)1
 #define WS2811_DMA_HANDLER_IDENTIFER 0
 #define NVIC_PriorityGroup_2 0x500
+
+// StdPeriph register-level surface for compiling a real dma_stm32f4xx.c under UNIT_TEST.
+// Opt-in only (see dma_stm32f4xx_unittest_DEFINES) so other tests are unaffected.
+#ifdef UNIT_TEST_DMA_REGISTER_MOCKS
+typedef struct {
+    IRQn_Type       NVIC_IRQChannel;
+    uint8_t         NVIC_IRQChannelPreemptionPriority;
+    uint8_t         NVIC_IRQChannelSubPriority;
+    FunctionalState NVIC_IRQChannelCmd;
+} NVIC_InitTypeDef;
+
+void NVIC_Init(NVIC_InitTypeDef *initStruct);
+void RCC_AHB1PeriphClockCmd(uint32_t periph, FunctionalState state);
+
+#define RCC_AHB1Periph_DMA1 ((uint32_t)0x00000001)
+#define RCC_AHB1Periph_DMA2 ((uint32_t)0x00000002)
+#endif
 
 #include "target.h"
 


### PR DESCRIPTION
AI Generated pull-request

## Summary

Closes #1360. `dma_stm32f4xx.c`, `dma_reqmap_mcu.c`, and `bus_spi.c`'s H7-adjacent branches touched CMSIS/RCC/NVIC registers or MCU-specific code paths with zero host-test coverage — PR #1357 mocked only the narrow boundary `bus_spi.c` calls into, not these files' own internal logic.

Compiles the **real** production files under `-DUNIT_TEST`, mocking the register-level surface (`RCC_AHB1PeriphClockCmd`, `NVIC_Init`, DMA stream/channel pointer literals) rather than mirroring logic locally:
- `dma_stm32f4xx_unittest.cc` (12 tests) — `dmaAllocate()`/`dmaInit()`/`dmaEnable()`/ownership-check logic, including adversarial double-allocate and invalid-identifier cases
- `dma_reqmap_unittest.cc` (7 tests) — F4 reqmap table lookups incl. PR #1370's UART entries
- `dma_reqmap_f7_unittest.cc` (6 tests) — F7's reqmap branch, added after CodeRabbit's review found F4 and F7 diverge inside their shared `#elif` guard (different `DMA()` macro, F7-exclusive `UARTDEV_7`/`UARTDEV_8` rows) — an F4-only compile never exercised either
- `dma_reqmap_h7_unittest.cc` (6 tests) — H7's DMAMUX branch; **found and documented** a real API contract gotcha: `dmaGetChannelSpecByPeripheral()`'s H7 implementation returns a pointer into a shared, opt-indexed scratch array that a later call with the same opt silently overwrites. The real caller (`spiInitBusDMA()`) never holds two results live simultaneously, so this isn't a live bug, but it's now pinned by a dedicated test rather than left as an undocumented trap
- `bus_spi_h7_unittest.cc` (3 tests) — H7's `spiInitBusDMA()` branch, previously unexercised (PR #1357/#1358's mocks were F4-shaped only)

One production fix: `bus_spi.c`'s F7/H7 cache-invalidate call truncated a pointer to `uint32_t`, surfaced only by compiling that branch under `UNIT_TEST` for the first time. Widened through `uintptr_t` — same defect class and fix as PR #1357's `userParam` widening, no-op on the 32-bit target (confirmed via clean STELLARH7DEV/F7 bench builds with identical FLASH/RAM usage, plus real-hardware confirmation below).

**Explicitly out of scope** (documented in the CONTEXT doc as candidate follow-ups): `bus_spi_ll.c`/`bus_spi_stdperiph.c` still aren't host-testable — they'd need ~20+ additional LL/StdPeriph register mocks, matching the issue's own "larger effort" framing.

**Host-test-only limitation**: the new unit tests verify logic and that real functions reach mocked register call sites — they do not and cannot verify real DMA timing, NVIC interrupt/preemption behavior, or ISR-context execution on actual silicon.

## Review

Local CodeRabbit (`coderabbit review --agent`) found 6 issues: 4 dismissed as an already-established false positive (EmuFlight-specific license header — no such convention exists in this repo, checked against every existing test file), 1 major (missing reset hook for `dmaDescriptors[]`'s static state between tests — fixed via a new `UNIT_TEST`-only `dmaResetAllocationsForTest()`) and 1 minor (un-zeroed test struct) both fixed in a follow-up commit.

CodeRabbit's automated PR review then found a real, confirmed gap: `dma_reqmap_unittest.cc` only compiled `dma_reqmap_mcu.c` under `-DSTM32F4`, missing F7-specific coverage (this PR's own earlier claim that "F7 shares this exact source branch" with F4 was wrong). Fixed by adding `dma_reqmap_f7_unittest.cc` — see Summary above. CodeRabbit's formal review: **APPROVED**.

## Test plan
- [x] `make clean_test && make test` — 47/47 binaries pass (up from 46), 284 individual test cases, 0 failures
- [x] Bench build incl. SITL: `HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 SITL` — 9/9 clean, 0 warnings
- [x] Additional H7 compile check (`STELLARH7DEV`) — clean, identical FLASH/RAM usage before/after
- [x] Real-hardware bench check on FOXEERF722V4 (F7): `dma`/`resource`/`status`/`tasks` CLI output captured on master (`6d774e6`) and on this branch's build — `dma`/`resource` sections byte-identical, `status`/`tasks` differ only in expected runtime jitter. Confirms the `uintptr_t` widening is a true no-op on real hardware, not just a clean compile.
- Flight test not performed — not needed: this PR touches only host-test infra plus a pointer-width cast fix, not runtime DMA/SPI logic itself.