### PR TITLE
fix(build): stamp-file dependency for version.o REVISION staleness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,8 +304,14 @@ CLEAN_ARTIFACTS += $(TARGET_HEX)
 CLEAN_ARTIFACTS += $(TARGET_ELF) $(TARGET_OBJS) $(TARGET_MAP)
 CLEAN_ARTIFACTS += $(TARGET_LST)
 
-# Rebuild version.o whenever any source changes so the embedded timestamp stays current
-$(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC)
+# Rebuild version.o whenever any source changes, or REVISION itself changes (e.g. a dirty-tree
+# build followed by a clean-tree build with no source diff) so REVISION never goes stale in the
+# embedded firmware string. REVISION_STAMP's mtime only updates when its content actually changes,
+# so a same-REVISION incremental build still skips the recompile.
+REVISION_STAMP  := $(OBJECT_DIR)/$(TARGET)/build/.revision_stamp
+$(shell mkdir -p $(dir $(REVISION_STAMP)))
+$(shell [ "$$(cat $(REVISION_STAMP) 2>/dev/null)" = "$(REVISION)" ] || echo "$(REVISION)" > $(REVISION_STAMP))
+$(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC) $(REVISION_STAMP)
 
 # All known non-board phony targets.  Used as the single source of truth
 # for both .PHONY and _SUMMARY_SKIP_GOALS — add new phony targets here only.

--- a/Makefile
+++ b/Makefile
@@ -306,12 +306,19 @@ CLEAN_ARTIFACTS += $(TARGET_LST)
 
 # Rebuild version.o whenever any source changes, or REVISION itself changes (e.g. a dirty-tree
 # build followed by a clean-tree build with no source diff) so REVISION never goes stale in the
-# embedded firmware string. REVISION_STAMP's mtime only updates when its content actually changes,
-# so a same-REVISION incremental build still skips the recompile.
+# embedded firmware string. REVISION_STAMP's mtime only advances when its content actually
+# changes, so a same-REVISION incremental build still skips the recompile. check_revision_stamp
+# is phony so the recipe always runs when REVISION_STAMP is pulled in as a prerequisite, but only
+# then -- non-build goals like 'make help' never touch it.
 REVISION_STAMP  := $(OBJECT_DIR)/$(TARGET)/build/.revision_stamp
-$(shell mkdir -p $(dir $(REVISION_STAMP)))
-$(shell [ "$$(cat $(REVISION_STAMP) 2>/dev/null)" = "$(REVISION)" ] || echo "$(REVISION)" > $(REVISION_STAMP))
 $(OBJECT_DIR)/$(TARGET)/build/version.o : $(SRC) $(REVISION_STAMP)
+
+$(REVISION_STAMP): check_revision_stamp
+	$(V1) mkdir -p $(dir $@)
+	$(V1) [ "$$(cat $@ 2>/dev/null)" = "$(REVISION)" ] || echo "$(REVISION)" > $@
+
+.PHONY: check_revision_stamp
+check_revision_stamp:
 
 # All known non-board phony targets.  Used as the single source of truth
 # for both .PHONY and _SUMMARY_SKIP_GOALS — add new phony targets here only.


### PR DESCRIPTION
AI Generated pull-request

## Summary
`version.o`'s build rule only depends on `$(SRC)`, not on the `REVISION` value itself. A
dirty-tree build (`REVISION=uncommitted_<timestamp>`) followed by a clean-tree build with no
source-file changes leaves that stale object untouched by Make's own dependency graph, so the
firmware keeps reporting `uncommitted` in CLI `version` even though `HEAD` is clean and
`REVISION` now resolves to the real 7-char commit hash.

This is a regression: #1125 (`e8d439d26`) originally fixed this exact bug by making `version.o`
depend on a `FORCE` phony target. #1238 (`ae9a736d8`) reverted that back to `$(SRC)`, explicitly
to restore no-op incremental-build behavior for parallel builds — a legitimate goal, but it
reintroduced the staleness bug because `$(SRC)` cannot express "REVISION's value changed."

Fix: add `REVISION_STAMP`, a per-target file containing the current `REVISION` string. `version.o`
now depends on both `$(SRC)` and `REVISION_STAMP`, so:
- same `REVISION`, no source change → stamp untouched → no rebuild (preserves #1238's no-op
  incremental-build behavior)
- `REVISION` changes (dirty→clean transition, or a new commit landing with no other source diff)
  → stamp rewritten → `version.o` rebuilds with the correct value

`REVISION_STAMP`'s mkdir/compare logic is an explicit recipe rule (`check_revision_stamp` phony
trigger), not a parse-time `$(shell ...)` call, so it only runs when actually pulled into a build
goal — non-build goals like `make help` never touch it.

## Test plan
- [x] Reproduced the exact regression: clean build → SHA embedded; dirty a tracked non-`$(SRC)`
      file → rebuild → `uncommitted_<timestamp>` embedded; revert to clean, zero further changes →
      rebuild → `version.o` correctly recompiles with the real SHA (this transition was previously
      silently skipped)
- [x] Confirmed no-op case unaffected: rebuild again with zero changes → `version.o` mtime
      unchanged, no unnecessary recompile
- [x] Confirmed non-build goals don't touch the stamp: `make help` leaves `.revision_stamp` absent
- [x] Hardware bench check: flashed HELIOSPRING, TUNERCF405, and PYRODRONEF7, all report `(7da81fa)` — the
      real commit hash, not `uncommitted` — in CLI `version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build accuracy by detecting revision changes and recompiling affected components when needed.
  * Preserved incremental build performance when the revision remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->