### PR TITLE
fix(scheduler): SERIAL task avg/max stats corrupted by unflagged USB TX waits

### DIFF
--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -344,9 +344,9 @@ FAST_CODE GCC_OPTIMIZE_SIZE void scheduler(void) {
             const timeUs_t currentTimeBeforeTaskCall = micros();
             selectedTask->taskFunc(currentTimeBeforeTaskCall);
             const timeUs_t taskExecutionTime = micros() - currentTimeBeforeTaskCall;
-            selectedTask->movingSumExecutionTime += taskExecutionTime - selectedTask->movingSumExecutionTime / MOVING_SUM_COUNT;
             selectedTask->totalExecutionTime += taskExecutionTime;   // time consumed by scheduler + task
             if (!ignoreCurrentTaskExecTime) {
+                selectedTask->movingSumExecutionTime += taskExecutionTime - selectedTask->movingSumExecutionTime / MOVING_SUM_COUNT;
                 selectedTask->maxExecutionTime = MAX(selectedTask->maxExecutionTime, taskExecutionTime);
             }
         } else {

--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -48,6 +48,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "drivers/serial_usb_vcp.h"
 #include "drivers/time.h"
+#include "scheduler/scheduler.h"
 
 #if defined(STM32H7)
 #include "stm32h7xx_hal.h"
@@ -372,6 +373,12 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength) {
     uint32_t deadline = millis() + 2;
     for (uint32_t i = 0; i < sendLength; i++) {
         while (CDC_Send_FreeBytes() == 0) {
+            // Host not draining yet (e.g. just after connect): this wait can
+            // clear within the deadline and return a full count below, so the
+            // caller's partial-count check never sees it. Exclude it here too,
+            // otherwise many small sub-deadline waits during one task tick sum
+            // to a large, uncounted execution time.
+            schedulerIgnoreTaskExecTime();
             if (millis() >= deadline) {
                 return i;
             }

--- a/src/main/vcpf4/usbd_cdc_vcp.c
+++ b/src/main/vcpf4/usbd_cdc_vcp.c
@@ -30,6 +30,7 @@
 #include "drivers/nvic.h"
 #include "drivers/time.h"
 #include "build/atomic.h"
+#include "scheduler/scheduler.h"
 
 __ALIGN_BEGIN USB_OTG_CORE_HANDLE  USB_OTG_dev __ALIGN_END;
 
@@ -167,6 +168,10 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength) {
     // Wait up to 2 ms for any in-flight USB packet to finish; bail early on timeout.
     uint32_t txStateDeadline = millis() + 2;
     while (USB_Tx_State != 0) {
+        // See CDC_Send_FreeBytes wait below: a sub-deadline wait here still
+        // returns a full/expected result, so the partial-count gate never
+        // sees it unless we flag it directly.
+        schedulerIgnoreTaskExecTime();
         if (millis() >= txStateDeadline) {
             return 0;
         }
@@ -174,6 +179,12 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength) {
     uint32_t deadline = millis() + 2;
     for (uint32_t i = 0; i < sendLength; i++) {
         while (CDC_Send_FreeBytes() == 0) {
+            // Host not draining yet (e.g. just after connect): this wait can
+            // clear within the deadline and return a full count below, so the
+            // caller's partial-count check never sees it. Exclude it here too,
+            // otherwise many small sub-deadline waits during one task tick sum
+            // to a large, uncounted execution time.
+            schedulerIgnoreTaskExecTime();
             if (millis() >= deadline) {
                 return i;
             }

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -47,9 +47,16 @@ extern "C" {
     uint32_t micros(void) { return simulatedTime; }
 
     // set up tasks to take a simulated representative time to execute
+    bool triggerIgnoreTaskExecTime = false;
     void taskMainPidLoop(timeUs_t) { simulatedTime += TEST_PID_LOOP_TIME; }
     void taskUpdateAccelerometer(timeUs_t) { simulatedTime += TEST_UPDATE_ACCEL_TIME; }
-    void taskHandleSerial(timeUs_t) { simulatedTime += TEST_HANDLE_SERIAL_TIME; }
+    void taskHandleSerial(timeUs_t) {
+        simulatedTime += TEST_HANDLE_SERIAL_TIME;
+        if (triggerIgnoreTaskExecTime) {
+            // simulates serial_usb_vcp.c flagging a CDC-backpressure stall mid-task
+            schedulerIgnoreTaskExecTime();
+        }
+    }
     void taskUpdateBatteryVoltage(timeUs_t) { simulatedTime += TEST_UPDATE_BATTERY_TIME; }
     bool rxUpdateCheck(timeUs_t, timeDelta_t) { simulatedTime += TEST_UPDATE_RX_CHECK_TIME; return false; }
     void taskUpdateRxMain(timeUs_t) { simulatedTime += TEST_UPDATE_RX_MAIN_TIME; }
@@ -485,4 +492,38 @@ TEST(SchedulerUnittest, TestTwoTasks)
     // and finally TASK_ACCEL should now run
     scheduler();
     EXPECT_EQ(&cfTasks[TASK_ACCEL], unittest_scheduler_selectedTask);
+}
+
+TEST(SchedulerUnittest, TestIgnoredExecutionTimeExcludedFromMovingSumAndMax)
+{
+    schedulerInit();
+    for (int taskId = 0; taskId < TASK_COUNT; ++taskId) {
+        setTaskEnabled(static_cast<cfTaskId_e>(taskId), false);
+    }
+    setTaskEnabled(TASK_SERIAL, true);
+
+    // Baseline run: normal execution establishes a moving sum and max.
+    // desiredPeriod (10000us, 100Hz) must fully elapse for taskAgeCycles to be nonzero.
+    triggerIgnoreTaskExecTime = false;
+    cfTasks[TASK_SERIAL].lastExecutedAt = 1000;
+    simulatedTime = cfTasks[TASK_SERIAL].lastExecutedAt + cfTasks[TASK_SERIAL].desiredPeriod;
+    scheduler();
+    EXPECT_EQ(&cfTasks[TASK_SERIAL], unittest_scheduler_selectedTask);
+    const uint32_t movingSumBaseline = cfTasks[TASK_SERIAL].movingSumExecutionTime;
+    const uint32_t maxBaseline = cfTasks[TASK_SERIAL].maxExecutionTime;
+    const uint32_t totalBaseline = cfTasks[TASK_SERIAL].totalExecutionTime;
+    EXPECT_EQ(static_cast<uint32_t>(TEST_HANDLE_SERIAL_TIME), maxBaseline);
+
+    // Second run: task itself flags ignoreCurrentTaskExecTime mid-execution, as
+    // serial_usb_vcp.c does on CDC-backpressure. movingSum/max must not absorb this
+    // run; totalExecutionTime is a genuine cumulative counter and must still grow.
+    triggerIgnoreTaskExecTime = true;
+    simulatedTime = cfTasks[TASK_SERIAL].lastExecutedAt + cfTasks[TASK_SERIAL].desiredPeriod;
+    scheduler();
+    EXPECT_EQ(&cfTasks[TASK_SERIAL], unittest_scheduler_selectedTask);
+    EXPECT_EQ(movingSumBaseline, cfTasks[TASK_SERIAL].movingSumExecutionTime);
+    EXPECT_EQ(maxBaseline, cfTasks[TASK_SERIAL].maxExecutionTime);
+    EXPECT_EQ(totalBaseline + TEST_HANDLE_SERIAL_TIME, cfTasks[TASK_SERIAL].totalExecutionTime);
+
+    triggerIgnoreTaskExecTime = false;
 }

--- a/src/test/unit/scheduler_unittest.cc
+++ b/src/test/unit/scheduler_unittest.cc
@@ -51,7 +51,10 @@ extern "C" {
     void taskMainPidLoop(timeUs_t) { simulatedTime += TEST_PID_LOOP_TIME; }
     void taskUpdateAccelerometer(timeUs_t) { simulatedTime += TEST_UPDATE_ACCEL_TIME; }
     void taskHandleSerial(timeUs_t) {
-        simulatedTime += TEST_HANDLE_SERIAL_TIME;
+        // Ignored run must differ from baseline, or a regression that drops the
+        // gate entirely would still pass by coincidence (max/movingSum would
+        // equal the baseline value either way).
+        simulatedTime += triggerIgnoreTaskExecTime ? TEST_HANDLE_SERIAL_TIME * 2 : TEST_HANDLE_SERIAL_TIME;
         if (triggerIgnoreTaskExecTime) {
             // simulates serial_usb_vcp.c flagging a CDC-backpressure stall mid-task
             schedulerIgnoreTaskExecTime();
@@ -523,7 +526,7 @@ TEST(SchedulerUnittest, TestIgnoredExecutionTimeExcludedFromMovingSumAndMax)
     EXPECT_EQ(&cfTasks[TASK_SERIAL], unittest_scheduler_selectedTask);
     EXPECT_EQ(movingSumBaseline, cfTasks[TASK_SERIAL].movingSumExecutionTime);
     EXPECT_EQ(maxBaseline, cfTasks[TASK_SERIAL].maxExecutionTime);
-    EXPECT_EQ(totalBaseline + TEST_HANDLE_SERIAL_TIME, cfTasks[TASK_SERIAL].totalExecutionTime);
+    EXPECT_EQ(totalBaseline + TEST_HANDLE_SERIAL_TIME * 2, cfTasks[TASK_SERIAL].totalExecutionTime);
 
     triggerIgnoreTaskExecTime = false;
 }


### PR DESCRIPTION
AI Generated pull-request

## Summary

Closes #1382.

Two independent bugs in `TASK_SERIAL`'s scheduler stats, both stemming from gaps in how
USB VCP TX-backpressure waits are excluded from task execution time accounting.

### 1. `avg/us` could exceed `max/us`

`scheduler()` (`src/main/scheduler/scheduler.c`) updated `movingSumExecutionTime`
(feeds the `tasks` CLI command's `avg/us`) unconditionally, while only
`maxExecutionTime` was gated behind the `ignoreCurrentTaskExecTime` flag. A USB
connect-time CDC backpressure burst could inflate `avg` while being excluded from `max`,
producing the logically-impossible `avg > max`.

Fix: move the `movingSumExecutionTime` update inside the same guard as
`maxExecutionTime`. `totalExecutionTime` stays unconditional — it's a genuine cumulative
wall-clock counter, unlike the moving average.

Added `SchedulerUnittest.TestIgnoredExecutionTimeExcludedFromMovingSumAndMax`, verified
to fail without the fix (movingSum absorbed a gated run, 30→60) and pass with it.

### 2. `max/us`/`maxload` still showing 400-940% right after connect

Found via live hardware iteration this session, after confirming bug 1's fix alone
didn't fully resolve the symptom on H7/F7 hardware.

`usbVcpWriteBuf()`/`usbVcpFlush()` (`src/main/drivers/serial_usb_vcp.c`) only call
`schedulerIgnoreTaskExecTime()` when `CDC_Send_DATA()` returns a partial count. But
`CDC_Send_DATA()` — both the F7/H7 HAL backend (`vcp_hal/usbd_cdc_interface.c`) and the
F4 STDPERIPH backend (`vcpf4/usbd_cdc_vcp.c`) — can wait on `CDC_Send_FreeBytes() == 0`
and still return a **full** count if the wait clears within its own per-byte deadline.
When that happens the caller's partial-count check never fires, so the wait is never
flagged, despite real wall-clock time having been spent.

A large CLI/MSP response right after USB connect (host not yet polling the CDC IN
endpoint at full speed) triggers many small buffered flushes. None register as
backpressure individually, but the sum inflates `TASK_SERIAL`'s `maxExecutionTime`/
`maxload` with real, uncounted wait time.

Fix: call `schedulerIgnoreTaskExecTime()` directly inside `CDC_Send_DATA`'s own wait
loop, on every iteration a wait occurs — not only on final timeout/partial-return.

## Hardware verification

Fresh-boot → connect → `tasks` (first read), repeated across multiple boot cycles:

| Board | Before (first read post-connect) | After |
|---|---|---|
| STELLARH7DEV (H7) | `SERIAL` max/us ~40000-41300, ~400-412% maxload | double/triple-digit us, normal |
| TMOTORF7 (F7) | up to ~940% maxload in one capture | double/triple-digit us, normal |
| TUNERCF405 (F4) | smaller magnitude, same pattern | normal |

Diagnostic `micros()`-based instrumentation was used to isolate the exact call site
during this session, then fully removed before committing — not part of this PR.

## Notes

- BF 4.5-maintenance's `scheduler.c` has the identical unconditional/gated asymmetry as
  bug 1, but BF's own USB VCP driver never calls `schedulerIgnoreTaskExecTime()`
  anywhere, so BF's version of that gap is unreachable dead code. EF's own
  `serial_usb_vcp.c` (from a prior PR) is what makes it reachable — bug 1's fix is an
  intentional EF-only divergence from BF's `scheduler.c` to fix a real, reachable bug.
- Bug 2's gap exists identically in Betaflight's current master
  (`src/platform/STM32/serial_usb_vcp.c` + `vcp_hal/usbd_cdc_interface.c` +
  `vcpf4/usbd_cdc_vcp.c`'s `VCP_DataTx`) — confirmed by code analysis, not BF-hardware-
  tested. Filed as betaflight/betaflight#15577.

## Test plan

- [x] `make clean_test && make test` — 47/47 test binaries clean, including the new
      scheduler unit test
- [x] Bench compile: HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7,
      FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7, STELLARH7DEV, SITL — 10/10 succeeded,
      0 failed, no warnings
- [x] Hardware-verified on STELLARH7DEV, TMOTORF7, TUNERCF405 (table above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task execution-time statistics for greater accuracy.
  * USB transmission wait time is no longer counted as active task execution time.
  * Cumulative execution totals remain accurate, while moving averages and maximums exclude intentionally ignored periods.

* **Tests**
  * Added coverage verifying execution statistics behave correctly when portions of task execution are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->