### PR TITLE
fix(transponder): migrate dmaInit() to ownership-checked dmaAllocate()

### DIFF
--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -124,7 +124,10 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     uint16_t dmaIndex = timerDmaIndex(timerChannel);
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&TimHandle, hdma[dmaIndex], hdma_tim);
-    dmaInit(timerHardware->dmaIrqHandler, OWNER_TRANSPONDER, 0);
+    if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_TRANSPONDER, 0)) {
+        return;
+    }
+    dmaEnable(timerHardware->dmaIrqHandler);
     dmaSetHandler(timerHardware->dmaIrqHandler, TRANSPONDER_DMA_IRQHandler, NVIC_PRIO_TRANSPONDER_DMA, dmaIndex);
     /* Initialize TIMx DMA handle */
     if (HAL_DMA_Init(TimHandle.hdma[dmaIndex]) != HAL_OK) {

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -73,7 +73,10 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     transponderIO = IOGetByTag(ioTag);
     IOInit(transponderIO, OWNER_TRANSPONDER, 0);
     IOConfigGPIOAF(transponderIO, IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_DOWN), timerHardware->alternateFunction);
-    dmaInit(timerHardware->dmaIrqHandler, OWNER_TRANSPONDER, 0);
+    if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_TRANSPONDER, 0)) {
+        return;
+    }
+    dmaEnable(timerHardware->dmaIrqHandler);
     dmaSetHandler(timerHardware->dmaIrqHandler, TRANSPONDER_DMA_IRQHandler, NVIC_PRIO_TRANSPONDER_DMA, 0);
     RCC_ClockCmd(timerRCC(timer), ENABLE);
     uint16_t prescaler = timerGetPrescalerByDesiredMhz(timer, transponder->timer_hz);

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -42,6 +42,7 @@ volatile uint8_t transponderIrDataTransferInProgress = 0;
 
 static IO_t transponderIO = IO_NONE;
 static TIM_TypeDef *timer = NULL;
+static bool transponderInitialised = false;
 #if defined(STM32F4)
 static DMA_Stream_TypeDef *dmaRef = NULL;
 #else
@@ -59,6 +60,7 @@ static void TRANSPONDER_DMA_IRQHandler(dmaChannelDescriptor_t* descriptor) {
 }
 
 void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
+    transponderInitialised = false;
     if (!ioTag) {
         return;
     }
@@ -127,6 +129,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     DMA_Init(dmaRef, &DMA_InitStructure);
     TIM_DMACmd(timer, timerDmaSource(timerHardware->channel), ENABLE);
     DMA_ITConfig(dmaRef, DMA_IT_TC, ENABLE);
+    transponderInitialised = true;
 }
 
 bool transponderIrInit(const ioTag_t ioTag, const transponderProvider_e provider) {
@@ -147,7 +150,7 @@ bool transponderIrInit(const ioTag_t ioTag, const transponderProvider_e provider
         return false;
     }
     transponderIrHardwareInit(ioTag, &transponder);
-    return true;
+    return transponderInitialised;
 }
 
 bool isTransponderIrReady(void) {
@@ -169,6 +172,9 @@ void transponderIrUpdateData(const uint8_t* transponderData) {
 }
 
 void transponderIrDMAEnable(transponder_t *transponder) {
+    if (!transponderInitialised) {
+        return;
+    }
     DMA_SetCurrDataCounter(dmaRef, transponder->dma_buffer_size);  // load number of bytes to be transferred
     TIM_SetCounter(timer, 0);
     TIM_Cmd(timer, ENABLE);
@@ -176,6 +182,9 @@ void transponderIrDMAEnable(transponder_t *transponder) {
 }
 
 void transponderIrDisable(void) {
+    if (!transponderInitialised) {
+        return;
+    }
     DMA_Cmd(dmaRef, DISABLE);
     TIM_Cmd(timer, DISABLE);
     IOInit(transponderIO, OWNER_TRANSPONDER, 0);

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -73,6 +73,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     transponderIO = IOGetByTag(ioTag);
     IOInit(transponderIO, OWNER_TRANSPONDER, 0);
     IOConfigGPIOAF(transponderIO, IO_CONFIG(GPIO_Mode_AF, GPIO_Speed_50MHz, GPIO_OType_PP, GPIO_PuPd_DOWN), timerHardware->alternateFunction);
+    dmaRef = timerHardware->dmaRef;
     if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_TRANSPONDER, 0)) {
         return;
     }
@@ -105,7 +106,6 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     timerOCPreloadConfig(timer, timerHardware->channel, TIM_OCPreload_Enable);
     TIM_CtrlPWMOutputs(timer, ENABLE);
     /* configure DMA */
-    dmaRef = timerHardware->dmaRef;
     DMA_Cmd(dmaRef, DISABLE);
     DMA_DeInit(dmaRef);
     DMA_StructInit(&DMA_InitStructure);


### PR DESCRIPTION
AI Generated pull-request

## Summary

Stage 2 of 5 in IT#1363's fleet-wide `dmaInit()` → `dmaAllocate()` migration (stage 1, ADC, merged as PR#1389). Converts `transponderIrHardwareInit()` in both `transponder_ir_io_stdperiph.c` and `transponder_ir_io_hal.c` from unchecked `dmaInit()` to ownership-checked `dmaAllocate()` + `dmaEnable()`.

## Why this is safe

- `transponderIrHardwareInit()` is `void` in both EF and BF — matches BF 4.5-maintenance's `transponder_ir_io_stdperiph.c`/`transponder_ir_io_hal.c` exactly, one-line-shape swap, no signature or caller changes.
- No coupling risk of the kind found in PR#1389's H7 ADC fix: everything in this function after the DMA claim is part of the same timer/DMA setup, not a separate subsystem. An early return on allocation failure only skips the rest of this one function's own DMA/timer config, nothing else.
- `dmaInit()` never fails (unconditional overwrite), so this claim cannot currently collide with anything on any existing target — boot-time, single call site, defense-in-depth/BF-parity change, not a fix for an active bug.

## Review history

Two real issues were found and fixed during review, both in `transponder_ir_io_stdperiph.c`:

1. **NULL `dmaRef` dereference** on a DMA claim failure (the new early-return sat before the `dmaRef` assignment). Fixed in `07b60e50c` by reordering to match BF's assignment-before-check ordering.
2. **`transponderIrInit()` always returned `true`** regardless of hardware-init success, so a claim failure could still let `transponderIrTransmit()` write to a DMA stream `OWNER_TRANSPONDER` never actually got. Fixed in `116b45996` by adding a `transponderInitialised` flag matching the pattern already used in the HAL variant.

Both fixes independently verified by GitHub CodeRabbit (2 review rounds, latest Merge Risk: Low, no actionable findings) and a separate local `/code-review` pass. One Clang static-analysis note ("undeclared identifier 'dmaRef'") was investigated and confirmed a tooling false positive — `dmaRef` sits behind a pre-existing `#if defined(STM32F4)` guard, and real builds with `STM32F4` defined compile clean.

## Verification

- Build: 6/6 targets, no warnings — HELIOSPRING (F4), FOXEERF722V4 (F7), STELLARH7DEV (H7) (all 3 real aircraft; `transponder_ir_io_*.c` compiles unconditionally on F4/F7/H7 regardless of `USE_TRANSPONDER`), plus OMNIBUSF4 and SPRACINGF7DUAL (both define `USE_TRANSPONDER`, exercise the changed code path), plus SITL.
- Host unit tests: `make test` — 47/47 test binaries pass (incl. `test_transponder_ir_unittest`), unchanged from the PR#1389 baseline.
- Full CI (11 build-target groups, Codacy, SITL, host tests): all pass.
- **No real-hardware verification possible**: none of the user's 3 real aircraft (HELIOSPRING, STELLARH7DEV, FOXEERF722V4) define `USE_TRANSPONDER` — all three use onboard SPI flash for blackbox, no transponder hardware. Compile-gate + bench-target build coverage only, per the staging decision made during stage 1's planning pass.

## Related

- Parent issue: #1363
- Prior stage: #1389 (ADC, merged)