### PR TITLE
fix(led-strip): migrate dmaInit() to ownership-checked dmaAllocate()

### DIFF
--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -53,7 +53,7 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
     const timerHardware_t *timerHardware = timerGetByTag(ioTag);
     TIM_TypeDef *timer = timerHardware->tim;
     timerChannel = timerHardware->channel;
-    if (timerHardware->dmaRef == NULL) {
+    if (timerHardware->dmaRef == NULL || !dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
         return;
     }
     TimHandle.Instance = timer;
@@ -99,9 +99,6 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
     uint16_t dmaIndex = timerDmaIndex(timerChannel);
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&TimHandle, hdma[dmaIndex], hdma_tim);
-    if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
-        return;
-    }
     dmaEnable(timerHardware->dmaIrqHandler);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, dmaIndex);
     /* Initialize TIMx DMA handle */

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -99,7 +99,10 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
     uint16_t dmaIndex = timerDmaIndex(timerChannel);
     /* Link hdma_tim to hdma[x] (channelx) */
     __HAL_LINKDMA(&TimHandle, hdma[dmaIndex], hdma_tim);
-    dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);
+    if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
+        return;
+    }
+    dmaEnable(timerHardware->dmaIrqHandler);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, dmaIndex);
     /* Initialize TIMx DMA handle */
     if (HAL_DMA_Init(TimHandle.hdma[dmaIndex]) != HAL_OK) {

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -62,7 +62,7 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
     DMA_InitTypeDef DMA_InitStructure;
     const timerHardware_t *timerHardware = timerGetByTag(ioTag);
     timer = timerHardware->tim;
-    if (timerHardware->dmaRef == NULL) {
+    if (timerHardware->dmaRef == NULL || !dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
         return;
     }
     ws2811IO = IOGetByTag(ioTag);
@@ -106,9 +106,6 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
         TIM_CCxCmd(timer, timerHardware->channel, TIM_CCx_Enable);
     }
     TIM_Cmd(timer, ENABLE);
-    if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
-        return;
-    }
     dmaEnable(timerHardware->dmaIrqHandler);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, 0);
     dmaRef = timerHardware->dmaRef;

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -106,7 +106,10 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
         TIM_CCxCmd(timer, timerHardware->channel, TIM_CCx_Enable);
     }
     TIM_Cmd(timer, ENABLE);
-    dmaInit(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0);
+    if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
+        return;
+    }
+    dmaEnable(timerHardware->dmaIrqHandler);
     dmaSetHandler(timerHardware->dmaIrqHandler, WS2811_DMA_IRQHandler, NVIC_PRIO_WS2811_DMA, 0);
     dmaRef = timerHardware->dmaRef;
     DMA_DeInit(dmaRef);


### PR DESCRIPTION
AI Generated pull-request

## Summary

Stage 3 of 5 in IT#1363's fleet-wide `dmaInit()` → `dmaAllocate()` migration (stage 1, ADC, merged as PR#1389; stage 2, transponder, merged as PR#1393). Converts `ws2811LedStripHardwareInit()` in both `light_ws2811strip_stdperiph.c` and `light_ws2811strip_hal.c` from unchecked `dmaInit()` to ownership-checked `dmaAllocate()` + `dmaEnable()`.

## Why this is safe

- `ws2811LedStripHardwareInit()` is `void` in EF (BF's equivalent returns `bool`, checked by its one caller) — but EF already gates the DMA-enable path on a file-scope `ws2811Initialised` flag, set `true` only at the end of a fully successful init and checked by `ws2811LedStripDMAEnable()` before it touches any DMA register. An early return on allocation failure happens before that assignment, so the existing flag closes the same reachability gap BF closes via its `bool` return — no signature change or caller update needed.
- Both variants already had a `dmaRef == NULL` early-return before this change; the `dmaAllocate()` check was combined into that same early-return, matching BF 4.5-maintenance's `stm32/light_ws2811strip_{hal,stdperiph}.c` structure exactly (allocate check first, before any GPIO/RCC/timer/DMA-clock setup).
- No coupling risk of the kind found in PR#1389's H7 ADC fix: everything after the DMA claim is this one function's own timer/DMA setup, not a separate subsystem.
- `dmaInit()` never fails (unconditional overwrite), so this claim cannot currently collide with anything on any existing target — boot-time, single call site per variant, defense-in-depth/BF-parity change, not a fix for an active bug.

## Review history

Local `coderabbit review --agent` (round 1) found one real issue: in the stdperiph variant, `TIM_Cmd(timer, ENABLE)` ran before the `dmaAllocate()` check, so a claim failure would leave the timer running with the output pin driving the LED data line. Fixed in `db2c44d0c` by moving the `dmaAllocate()` call to combine with the existing `dmaRef == NULL` early-return, before any hardware setup, in both variants (matching BF's ordering exactly). Local `coderabbit review --agent` (round 2) and an opencode second-opinion pass both came back clean — opencode additionally confirmed no DMA register access occurs between the allocation check and `dmaEnable()` in either variant, and that the change's only owner-leak-on-later-failure characteristic is a pre-existing pattern (no `dmaRelease()` API exists in EF or BF), not introduced here.

## Verification

- Build: 7/7 targets, no warnings — HELIOSPRING (F4), FOXEERF722V4 (F7), STELLARH7DEV (H7) (all 3 real aircraft compile `USE_LED_STRIP` via the `common_fc_pre.h` fleet default), plus CRAZYBEEF4FS (F4 stdperiph), MATEKF722HD (F7 HAL), SPRACINGH7EF (H7 HAL, the only H7 target with `USE_LED_STRIP` enabled), plus SITL.
- Host unit tests: `make test` — 33/33 test binaries pass (incl. `test_ledstrip_unittest`, `test_ws2811_unittest`), unchanged from the PR#1393 baseline.
- **No physical LED strip available for end-to-end verification.** DMA-claim behavior itself is checkable via the `dma`/`resource` CLI on real hardware without a strip attached, but only after enabling `feature LED_STRIP` + save + reboot on the target — compiling `USE_LED_STRIP` in alone does not trigger the DMA-claiming `ws2811LedStripHardwareInit()` call (`fc_init.c` only calls it via `ledStripEnable()`, gated on the feature flag). Not yet performed — build-only this session.

## Related

- Parent issue: #1363
- Prior stages: #1389 (ADC, merged), #1393 (transponder, merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WS2811 LED-strip DMA channel setup during hardware initialization.
  * Added handling for DMA allocation failures to prevent incomplete initialization.
  * Improved DMA activation reliability for LED-strip output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->