### PR TITLE
fix(motors): migrate dmaInit() to ownership-checked dmaAllocate()

### DIFF
--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -208,10 +208,18 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->timer = &dmaMotorTimers[timerIndex];
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
+        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaTimUPIrqHandler);
         motor->timer->dmaBurstRef = dmaRef;
     } else
 #endif
     {
+        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaIrqHandler);
         motor->timerDmaSource = timerDmaSource(timerHardware->channel);
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }
@@ -220,10 +228,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     DMA_StructInit(&DMA_InitStructure);
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaTimUPIrqHandler);
         dmaSetHandler(timerHardware->dmaTimUPIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
         DMA_InitStructure.DMA_Channel = timerHardware->dmaTimUPChannel;
         DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)motor->timer->dmaBurstBuffer;
@@ -243,10 +247,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     } else
 #endif
     {
-        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaIrqHandler);
         dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #if defined(STM32F4)
         DMA_InitStructure.DMA_Channel = timerHardware->dmaChannel;

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -156,6 +156,20 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     if (dmaRef == NULL) {
         return;
     }
+#ifdef USE_DSHOT_DMAR
+    if (useBurstDshot) {
+        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaTimUPIrqHandler);
+    } else
+#endif
+    {
+        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaIrqHandler);
+    }
     TIM_OCInitTypeDef TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
     motorDmaOutput_t * const motor = &dmaMotors[motorIndex];
@@ -208,18 +222,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->timer = &dmaMotorTimers[timerIndex];
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaTimUPIrqHandler);
         motor->timer->dmaBurstRef = dmaRef;
     } else
 #endif
     {
-        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaIrqHandler);
         motor->timerDmaSource = timerDmaSource(timerHardware->channel);
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }

--- a/src/main/drivers/pwm_output_dshot.c
+++ b/src/main/drivers/pwm_output_dshot.c
@@ -47,6 +47,16 @@ motorDmaOutput_t *getMotorDmaOutput(uint8_t index) {
     return &dmaMotors[index];
 }
 
+// configureTimer is true for every channel of a shared burst-DMA timer, not just the
+// first, so this claim is attempted once per channel; a stream already held by this
+// same owner must be re-claimable.
+static bool dshotDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 uint8_t getTimerIndex(TIM_TypeDef *timer) {
     for (int i = 0; i < dmaMotorTimerCount; i++) {
         if (dmaMotorTimers[i].timer == timer) {
@@ -210,7 +220,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     DMA_StructInit(&DMA_InitStructure);
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim));
+        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaTimUPIrqHandler);
         dmaSetHandler(timerHardware->dmaTimUPIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
         DMA_InitStructure.DMA_Channel = timerHardware->dmaTimUPChannel;
         DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)motor->timer->dmaBurstBuffer;
@@ -230,7 +243,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     } else
 #endif
     {
-        dmaInit(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaIrqHandler);
         dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #if defined(STM32F4)
         DMA_InitStructure.DMA_Channel = timerHardware->dmaChannel;

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -150,6 +150,20 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     if (dmaRef == NULL) {
         return;
     }
+#ifdef USE_DSHOT_DMAR
+    if (useBurstDshot) {
+        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaTimUPIrqHandler);
+    } else
+#endif
+    {
+        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaIrqHandler);
+    }
     LL_TIM_OC_InitTypeDef oc_init;
     LL_DMA_InitTypeDef dma_init;
     motorDmaOutput_t * const motor = &dmaMotors[motorIndex];
@@ -222,10 +236,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->timer = &dmaMotorTimers[timerIndex];
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaTimUPIrqHandler);
         motor->timer->dmaBurstRef = dmaRef;
         if (!configureTimer) {
             motor->configured = true;
@@ -234,10 +244,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     } else
 #endif
     {
-        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaIrqHandler);
         motor->timerDmaSource = timerDmaSource(timerHardware->channel);
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -234,6 +234,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     } else
 #endif
     {
+        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaIrqHandler);
         motor->timerDmaSource = timerDmaSource(timerHardware->channel);
         motor->timer->timerDmaSources &= ~motor->timerDmaSource;
     }
@@ -253,10 +257,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     } else
 #endif
     {
-        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
-            return;
-        }
-        dmaEnable(timerHardware->dmaIrqHandler);
         dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #if defined(STM32H7)
         dma_init.PeriphRequest = timerHardware->dmaChannel;

--- a/src/main/drivers/pwm_output_dshot_hal.c
+++ b/src/main/drivers/pwm_output_dshot_hal.c
@@ -42,6 +42,16 @@ motorDmaOutput_t *getMotorDmaOutput(uint8_t index) {
     return &dmaMotors[index];
 }
 
+// configureTimer stays true for every consecutive channel of the same shared timer
+// (see comment in pwmDshotMotorHardwareConfig), so a burst-mode TIM_UP claim is
+// attempted once per channel; a stream already held by this same owner must be re-claimable.
+static bool dshotDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 uint8_t getTimerIndex(TIM_TypeDef *timer) {
     for (int i = 0; i < dmaMotorTimerCount; i++) {
         if (dmaMotorTimers[i].timer == timer) {
@@ -147,6 +157,9 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     TIM_TypeDef *timer = timerHardware->tim;
     const IO_t motorIO = IOGetByTag(timerHardware->tag);
     const uint8_t timerIndex = getTimerIndex(timer);
+    // configureTimer is true for every channel of a timer processed consecutively,
+    // not just the first -- dmaMotorTimerCount only advances when a different, new
+    // timer is registered in between (see getTimerIndex above).
     const bool configureTimer = (timerIndex == dmaMotorTimerCount - 1);
 #if defined(STM32H7)
     // H7 GPIO driver is significantly stronger than F4/F7; VERY_HIGH causes ringing on DShot lines
@@ -209,6 +222,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     motor->timer = &dmaMotorTimers[timerIndex];
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
+        if (!dshotDmaClaim(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaTimUPIrqHandler);
         motor->timer->dmaBurstRef = dmaRef;
         if (!configureTimer) {
             motor->configured = true;
@@ -224,7 +241,6 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     LL_DMA_StructInit(&dma_init);
 #ifdef USE_DSHOT_DMAR
     if (useBurstDshot) {
-        dmaInit(timerHardware->dmaTimUPIrqHandler, OWNER_TIMUP, timerGetTIMNumber(timerHardware->tim));
         dmaSetHandler(timerHardware->dmaTimUPIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #if defined(STM32H7)
         dma_init.PeriphRequest = timerHardware->dmaTimUPChannel;
@@ -237,7 +253,10 @@ void pwmDshotMotorHardwareConfig(const timerHardware_t *timerHardware, uint8_t m
     } else
 #endif
     {
-        dmaInit(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
+        if (!dmaAllocate(timerHardware->dmaIrqHandler, OWNER_MOTOR, RESOURCE_INDEX(motorIndex))) {
+            return;
+        }
+        dmaEnable(timerHardware->dmaIrqHandler);
         dmaSetHandler(timerHardware->dmaIrqHandler, motor_DMA_IRQHandler, NVIC_BUILD_PRIORITY(1, 2), motorIndex);
 #if defined(STM32H7)
         dma_init.PeriphRequest = timerHardware->dmaChannel;


### PR DESCRIPTION
AI Generated pull-request

## Summary

Stage 4 of 5 in IT#1363's fleet-wide `dmaInit()` → `dmaAllocate()` migration (stage 1, ADC, merged as PR#1389; stage 2, transponder, merged as PR#1393; stage 3, LED strip, merged as PR#1394). Converts `pwmDshotMotorHardwareConfig()` in both `pwm_output_dshot.c` (F4) and `pwm_output_dshot_hal.c` (F7/H7) from unchecked `dmaInit()` to ownership-checked `dmaAllocate()` + `dmaEnable()`.

## Why this needed more than a mechanical swap

Burst DShot (`USE_DSHOT_DMAR`, active by default fleet-wide, confirmed live on HELIOSPRING: all 4 motors share TIM8) has multiple motor channels legitimately sharing **one** DMA stream (`OWNER_TIMUP`, keyed by timer number, not per-motor). `configureTimer` — the existing flag gating redundant per-timer setup — is true for **every** channel of a timer processed consecutively, not just the first (confirmed by tracing `getTimerIndex()`: `dmaMotorTimerCount` only advances when a genuinely new timer is registered). A mechanical `if (!dmaAllocate(...)) return;` swap would make the 2nd, 3rd, and 4th motor's claim on an already-owned stream fail outright — a flight-critical regression on any board with more than one motor per timer, not a defense-in-depth no-op like stages 1-3.

Added `dshotDmaClaim()`, matching an existing pattern already in this codebase (`uartDmaClaim()` in `serial_uart_stm32f4xx.c`, added for UART reconnect-safety): a stream already held by the same owner+resourceIndex is treated as an already-successful claim instead of a conflict, using the existing `dmaGetOwner()`/`dmaGetResourceIndex()` accessors (no new DMA API needed).

## Review history

Local `coderabbit review --agent` (round 1) found a real issue: `LL_EX_DMA_DeInit()`/`DMA_DeInit()` (resets the DMA stream's registers) ran before the ownership-check in both the `OWNER_MOTOR` path (both files) and the `OWNER_TIMUP` burst path (`pwm_output_dshot.c` only). A failed claim on a stream already owned by something else would have deinitialized it out from under that owner instead of leaving it untouched. Fixed in `7504035e4` by moving both claim checks ahead of any DMA register access, matching the ordering already established for LED strip and transponder. Round 2: 0 findings. opencode second-opinion pass could not complete — 4 different models failed with different errors (timeout, auth, server error) in the same session, consistent with an infra-side outage rather than a model-selection issue; not retried further.

GitHub CodeRabbit analysis (requested independently of the local review above) found a further real issue: GPIO AF configuration and full timer setup (clock enable, prescaler/period, output compare, channel enable) still ran before the DMA ownership check in both files. A claim failure returned with `motor->configured` unset and the DMA stream untouched, but had already reconfigured that motor channel's GPIO pin and timer state. Fixed in `82d475ca6` by moving both claim checks to immediately after the existing `dmaRef == NULL` check, before any GPIO or timer register access — matching BF 4.5-maintenance's actual structure, where the equivalent claim happens before `timerHardware`/`motor` state is even read. Re-verified: build 7/7, host tests 43/43, local `coderabbit review --agent` 0 findings.

## BF-master verdict check

Per the corrected `/bf-gaps` process (was diffing against BF master, now uses 4.5-maintenance as reference with master checked as fallback for bugfixes/architecture direction): `git log 4.5-maintenance..master` for `pwm_output_dshot.c`/`_hal.c` shows the shared-timer claim-bypass algorithm (`dmaGetOwner()`+`dmaIsConfigured`) is unchanged on master — only retyped by an unrelated opaque-resource refactor (PR#14990). Verdict: `not-comparable` (type-system divergence only, no gap to adopt or avoid). Full inventory: `fix/dmainit-dshot-migration/dmainit-dshot-migration-bf-gaps.md`; verdict logged in `MIGRATION.md` § BF-branch register.

## Verification

- Build: 7/7 targets, no warnings — HELIOSPRING (F4), FOXEERF722V4 (F7), STELLARH7DEV (H7, all 3 real aircraft), plus CRAZYBEEF4FS, MATEKF722HD, SPRACINGH7EF, plus SITL. Re-verified after each review-driven fix.
- Host unit tests: `make test` — 43/43 test binaries pass, unchanged from PR#1394's baseline. No test binary directly exercises `pwm_output_dshot*.c` (same DMA/LL host-test limitation as prior stages).
- Manually traced the shared-timer claim path against HELIOSPRING's real target config (`TIM8` CH1-4, all 4 motors, processed consecutively) to confirm `dshotDmaClaim()`'s bypass fires correctly for motors 2-4 and the real allocation only happens once, for motor 1.
- **DShot beacon bench-confirmed on real hardware**: heard the beacon tone through the motor, confirmed real (not coincidental) by toggling the feature off (silence) then on (tone returned). This exercises the same DMA-driven signal path this PR modifies. This is a bench tone test, not a flight test.
- **Required hardware verification, on each of the 3 real aircraft (HELIOSPRING, FOXEERF722V4, STELLARH7DEV):**
  1. `dma`/`resource` CLI output, branch vs. historical baseline, byte-for-byte — **DONE, PASSED, 2026-08-23.** Confirms the claim mechanism directly: `DMA2 Stream 1: TIMUP 8` (all 3 boards) and `DMA2 Stream 5: TIMUP 1` (FOXEERF722V4, second timer) unchanged versus historical captures spanning ~7 weeks (FOXEERF722V4), ~8 days (STELLARH7DEV, byte-for-byte identical), and the LED-strip-stage capture (HELIOSPRING). One explained, unrelated difference on HELIOSPRING (`DMA2 Stream 6`, a LED_STRIP feature-toggle difference between test sessions, not a DMA regression). Full comparison: `fix/dmainit-dshot-migration/compare-01.txt` in the AI docs tree.
  2. Arm + confirm all motors idle-spin evenly — **pending, to be reported separately.** A full flight is not required. This PR changes only the one-time boot-time DMA claim in `pwmDshotMotorHardwareConfig()` — it does not touch the per-loop DMA-refresh/write path that sends throttle values every PID iteration, which is unchanged. The only new failure mode is binary and resolves at boot: a motor's claim either succeeds (everything else behaves exactly as before this PR) or it doesn't (that motor gets no DShot signal at all, from the very first spin-up). Arming spins motors by default in EF (no `MOTOR_STOP` feature active by default), so arm + idle-spin already exercises and confirms every motor channel's claim succeeded behaviorally, complementing the direct mechanism check in (1).

  APEXF7 excluded (runs BF, not an EF test target).

## Related

- Parent issue: #1363
- Prior stages: #1389 (ADC, merged), #1393 (transponder, merged), #1394 (LED strip, merged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DShot motor output setup to reliably initialize DMA resources.
  - Fixed repeated DMA configuration scenarios, including shared-timer and burst-update modes.
  - Prevented resource ownership conflicts that could interfere with motor output initialization.
  - Improved consistency when configuring multiple motors using shared hardware resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



