### PR TITLE
fix(sdcard): migrate dmaInit() to ownership-checked dmaAllocate()

### DIFF
--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -473,6 +473,15 @@ static bool sdcard_checkInitDone(void) {
     return status == 0x00;
 }
 
+// sdcard_init() can be called from both boot init and the USB MSC passthrough path -- a
+// stream already held by this same owner must be re-claimable.
+static bool sdcardDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 /**
  * Begin the initialization process for the SD card. This must be called first before any other sdcard_ routine.
  */
@@ -489,11 +498,17 @@ void sdcard_init(const sdcardConfig_t *config) {
     sdcard.useDMAForTx = config->useDma;
 #endif
     if (sdcard.useDMAForTx) {
+        if (sdcardDmaClaim(config->dmaIdentifier, OWNER_SDCARD, 0)) {
 #if defined(STM32F4) || defined(STM32F7)
-        sdcard.dmaChannel = config->dmaChannel;
+            sdcard.dmaChannel = config->dmaChannel;
 #endif
-        sdcard.dma = dmaGetDescriptorByIdentifier(config->dmaIdentifier);
-        dmaInit(config->dmaIdentifier, OWNER_SDCARD, 0);
+            sdcard.dma = dmaGetDescriptorByIdentifier(config->dmaIdentifier);
+            dmaEnable(config->dmaIdentifier);
+        } else {
+            // Stream already owned by another peripheral -- fall back to polled SPI
+            // rather than losing the card (and blackbox logging) entirely.
+            sdcard.useDMAForTx = false;
+        }
     }
     if (config->chipSelectTag) {
         sdcard.chipSelectPin = IOGetByTag(config->chipSelectTag);

--- a/src/main/drivers/sdcard_sdio_baremetal.c
+++ b/src/main/drivers/sdcard_sdio_baremetal.c
@@ -286,10 +286,14 @@ void sdcard_init(const sdcardConfig_t *config) {
         sdcard.useCache = 0;
     }
 #if defined(STM32H7)
-    SD_Initialize_LL(NULL);
+    if (!SD_Initialize_LL(NULL)) {
 #else
-    SD_Initialize_LL(dmaGetRefByIdentifier(sdcard.dma));
+    if (!SD_Initialize_LL(dmaGetRefByIdentifier(sdcard.dma))) {
 #endif
+        sdcard.state = SDCARD_STATE_NOT_PRESENT;
+        sdcard.failureCount++;
+        return;
+    }
     if (SD_IsDetected()) {
         if (SD_Init() != 0) {
             sdcard.state = SDCARD_STATE_NOT_PRESENT;

--- a/src/main/drivers/sdio_f4xx.c
+++ b/src/main/drivers/sdio_f4xx.c
@@ -1305,11 +1305,24 @@ static SD_Error_t SD_IsCardProgramming(uint8_t *pStatus)
 }
 */
 
+// SD_Initialize_LL() can be called from both the sdcard driver's own init and the USB MSC
+// passthrough path -- a stream already held by this same owner must be re-claimable.
+static bool sdioDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 /** -----------------------------------------------------------------------------------------------------------------*/
 /**
   * @brief  Initialize the SDIO module, DMA, and IO
   */
-void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
+bool SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
+    if (!(dma == DMA2_Stream3 || dma == DMA2_Stream6) || !sdioDmaClaim(dmaGetIdentifier(dma), OWNER_SDCARD, 0)) {
+        return false;
+    }
+    dmaEnable(dmaGetIdentifier(dma));
     // Reset SDIO Module
     RCC->APB2RSTR |=  RCC_APB2RSTR_SDIORST;
     delay(1);
@@ -1362,7 +1375,6 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream3->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream3), OWNER_SDCARD, 0);
         dmaSetHandler(dmaGetIdentifier(DMA2_Stream3), SDIO_DMA_ST3_IRQHandler, 1, 0);
     } else {
         // Initialize DMA2 channel 6
@@ -1375,9 +1387,9 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream6->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream6), OWNER_SDCARD, 0);
         dmaSetHandler(dmaGetIdentifier(DMA2_Stream6), SDIO_DMA_ST6_IRQHandler, 1, 0);
     }
+    return true;
 }
 
 

--- a/src/main/drivers/sdio_f7xx.c
+++ b/src/main/drivers/sdio_f7xx.c
@@ -1326,11 +1326,24 @@ static SD_Error_t SD_IsCardProgramming(uint8_t *pStatus)
 }
 */
 
+// SD_Initialize_LL() can be called from both the sdcard driver's own init and the USB MSC
+// passthrough path -- a stream already held by this same owner must be re-claimable.
+static bool sdioDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return dmaAllocate(identifier, owner, resourceIndex);
+}
+
 /** -----------------------------------------------------------------------------------------------------------------*/
 /**
   * @brief  Initialize the SDMMC1 module, DMA, and IO
   */
-void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
+bool SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
+    if (!(dma == DMA2_Stream3 || dma == DMA2_Stream6) || !sdioDmaClaim(dmaGetIdentifier(dma), OWNER_SDCARD, 0)) {
+        return false;
+    }
+    dmaEnable(dmaGetIdentifier(dma));
     // Reset SDMMC1 Module
     RCC->APB2RSTR |=  RCC_APB2RSTR_SDMMC1RST;
     delay(1);
@@ -1386,7 +1399,6 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream3->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream3), OWNER_SDCARD, 0);
         dmaSetHandler(dmaGetIdentifier(DMA2_Stream3), SDMMC_DMA_ST3_IRQHandler, 1, 0);
     } else {
         // Initialize DMA2 channel 6
@@ -1399,9 +1411,9 @@ void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
                               DMA_MBURST_INC4      | DMA_PBURST_INC4        |
                               DMA_MEMORY_TO_PERIPH);
         DMA2_Stream6->FCR  = (DMA_SxFCR_DMDIS | DMA_SxFCR_FTH);                 // Configuration FIFO control register
-        dmaInit(dmaGetIdentifier(DMA2_Stream6), OWNER_SDCARD, 0);
         dmaSetHandler(dmaGetIdentifier(DMA2_Stream6), SDMMC_DMA_ST6_IRQHandler, 1, 0);
     }
+    return true;
 }
 
 

--- a/src/main/drivers/sdio_h7xx.c
+++ b/src/main/drivers/sdio_h7xx.c
@@ -734,9 +734,10 @@ bool SD_IsDetected(void) {
     return status;
 }
 
-void SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
+bool SD_Initialize_LL(DMA_Stream_TypeDef *dma) {
     UNUSED(dma);
     // H7 uses SDMMC internal DMA (IDMA) — no external DMA stream configuration needed.
+    return true;
 }
 
 void SDMMC1_IRQHandler(void)

--- a/src/main/drivers/sdmmc_sdio.h
+++ b/src/main/drivers/sdmmc_sdio.h
@@ -216,7 +216,7 @@ typedef struct {
 extern           SD_CardInfo_t               SD_CardInfo;
 extern           SD_CardType_t               SD_CardType;
 
-void             SD_Initialize_LL            (DMA_Stream_TypeDef *dma);
+bool             SD_Initialize_LL            (DMA_Stream_TypeDef *dma);
 SD_Error_t       SD_Init                     (void);
 bool             SD_IsDetected              (void);
 bool             SD_GetState                 (void);

--- a/src/main/msc/usbd_storage_sdio.c
+++ b/src/main/msc/usbd_storage_sdio.c
@@ -152,7 +152,7 @@ static int8_t STORAGE_Init (uint8_t lun) {
 #endif
     UNUSED(lun);
     LED0_OFF;
-    SD_Initialize_LL(SDIO_DMA);
+    if (!SD_Initialize_LL(SDIO_DMA)) return 1;
     if (SD_Init() != 0) return 1;
     LED0_ON;
     return 0;

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -348,6 +348,10 @@ serial_uart_dma_claim_unittest_DEFINES := \
 		STM32F4
 
 
+sdcard_dma_claim_unittest_DEFINES := \
+		STM32F4
+
+
 flight_failsafe_unittest_SRC := \
 		$(USER_DIR)/common/bitarray.c \
 		$(USER_DIR)/fc/rc_modes.c \

--- a/src/test/unit/sdcard_dma_claim_unittest.cc
+++ b/src/test/unit/sdcard_dma_claim_unittest.cc
@@ -1,0 +1,160 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+extern "C" {
+
+#include "platform.h"
+#include "drivers/dma.h"
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+// Mirrors sdcardDmaClaim() (drivers/sdcard.c) and sdioDmaClaim() (drivers/sdio_f4xx.c,
+// drivers/sdio_f7xx.c -- byte-identical body, confirmed by direct read) rather than compiling
+// those files. Real-compile was investigated, not assumed disproportionate: sdcard.c's
+// SDCARD_STATE_SENDING_WRITE completion path (STM32F4 branch) needs a real DMA_Stream_TypeDef
+// with ->ref/->completeFlag fields, a two-arg DMA_GetFlagStatus()/DMA_ClearFlag() pair distinct
+// from the one-arg mock already in test/unit/platform.h, DMA_Cmd(), SPI_I2S_GetFlagStatus(),
+// LL_SPI_DisableDMAReq_TX(), and direct ->DR register access -- none of which the file's own
+// DMA-claim logic uses, but all of which must still link since the whole .c compiles as one
+// translation unit. sdio_f4xx.c/f7xx.c need the same class of surface an order of magnitude
+// larger (118 direct SDIO->/RCC-> field accesses, real GPIO AF config, NVIC). Both are the
+// same disproportionate-mocking case bus_spi_ll.c/bus_spi_stdperiph.c already were in
+// feat/dma-ll-unittest-infra (20+ mocks needed for functions that weren't even the test
+// target). Follows the same mirror-with-fake-DMA-state convention already established for
+// uartDmaClaim() in serial_uart_dma_claim_unittest.cc.
+//
+// sdcard_init() (SPI mode) can be called from both fc_init.c (boot) and
+// usbd_storage_sd_spi.c (USB MSC passthrough). SD_Initialize_LL() (SDIO mode) can be called
+// from both sdcard_sdio_baremetal.c (boot) and usbd_storage_sdio.c (USB MSC passthrough). In
+// both cases the second call is a legitimate reopen of the same OWNER_SDCARD claim, not a
+// conflict, and must not be misidentified as one now that the caller-side return check exists.
+namespace {
+
+resourceOwner_e fakeOwner = OWNER_FREE;
+uint8_t fakeResourceIndex = 0;
+
+void resetFakeDmaState() {
+    fakeOwner = OWNER_FREE;
+    fakeResourceIndex = 0;
+}
+
+resourceOwner_e fakeDmaGetOwner(dmaIdentifier_e) {
+    return fakeOwner;
+}
+
+uint8_t fakeDmaGetResourceIndex(dmaIdentifier_e) {
+    return fakeResourceIndex;
+}
+
+bool fakeDmaAllocate(dmaIdentifier_e, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (fakeOwner != OWNER_FREE) {
+        return false;
+    }
+    fakeOwner = owner;
+    fakeResourceIndex = resourceIndex;
+    return true;
+}
+
+bool sdcardDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (fakeDmaGetOwner(identifier) == owner && fakeDmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return fakeDmaAllocate(identifier, owner, resourceIndex);
+}
+
+bool sdioDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
+    if (fakeDmaGetOwner(identifier) == owner && fakeDmaGetResourceIndex(identifier) == resourceIndex) {
+        return true;
+    }
+    return fakeDmaAllocate(identifier, owner, resourceIndex);
+}
+
+const dmaIdentifier_e kStream = DMA1_ST3_HANDLER;
+
+}  // namespace
+
+// sdcardDmaClaim() -- SPI-mode (drivers/sdcard.c), real callers always pass OWNER_SDCARD / index 0.
+
+TEST(SdcardDmaClaimUnittest, FirstClaimOnFreeStreamSucceeds) {
+    resetFakeDmaState();
+    EXPECT_TRUE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
+    EXPECT_EQ(fakeOwner, OWNER_SDCARD);
+}
+
+TEST(SdcardDmaClaimUnittest, UsbMscReopenBySameOwnerAndIndexSucceeds) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SDCARD;
+    fakeResourceIndex = 0;
+    // sdcard_init() called again from usbd_storage_sd_spi.c after fc_init.c already claimed it.
+    EXPECT_TRUE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
+}
+
+TEST(SdcardDmaClaimUnittest, ConflictWithForeignOwnerFails) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SPI_SDI;
+    fakeResourceIndex = 0;
+    EXPECT_FALSE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
+    // failed claim must not disturb the existing owner's bookkeeping.
+    EXPECT_EQ(fakeOwner, OWNER_SPI_SDI);
+}
+
+TEST(SdcardDmaClaimUnittest, SameOwnerDifferentResourceIndexFails) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SDCARD;
+    fakeResourceIndex = 1;
+    // spec-level guard: same owner enum alone is not sufficient, index must match too.
+    EXPECT_FALSE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
+}
+
+// sdioDmaClaim() -- SDIO-mode (drivers/sdio_f4xx.c, drivers/sdio_f7xx.c), same real callers
+// always pass OWNER_SDCARD / index 0.
+
+TEST(SdioDmaClaimUnittest, FirstClaimOnFreeStreamSucceeds) {
+    resetFakeDmaState();
+    EXPECT_TRUE(sdioDmaClaim(kStream, OWNER_SDCARD, 0));
+    EXPECT_EQ(fakeOwner, OWNER_SDCARD);
+}
+
+TEST(SdioDmaClaimUnittest, UsbMscReopenBySameOwnerAndIndexSucceeds) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SDCARD;
+    fakeResourceIndex = 0;
+    // SD_Initialize_LL() called again from usbd_storage_sdio.c after sdcard_sdio_baremetal.c
+    // already claimed it during boot.
+    EXPECT_TRUE(sdioDmaClaim(kStream, OWNER_SDCARD, 0));
+}
+
+TEST(SdioDmaClaimUnittest, ConflictWithForeignOwnerFails) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SPI_SDI;
+    fakeResourceIndex = 0;
+    EXPECT_FALSE(sdioDmaClaim(kStream, OWNER_SDCARD, 0));
+    EXPECT_EQ(fakeOwner, OWNER_SPI_SDI);
+}
+
+TEST(SdioDmaClaimUnittest, SameOwnerDifferentResourceIndexFails) {
+    resetFakeDmaState();
+    fakeOwner = OWNER_SDCARD;
+    fakeResourceIndex = 1;
+    EXPECT_FALSE(sdioDmaClaim(kStream, OWNER_SDCARD, 0));
+}


### PR DESCRIPTION
AI Generated pull-request

## Summary

Stage 5 of 5 in IT#1363's fleet-wide `dmaInit()` → `dmaAllocate()` migration (stage 1 ADC, stage 2 transponder, stage 3 LED strip all merged; stage 4 motors/DSHOT MERGED). Converts `sdcard.c` (SPI-mode) and `sdio_f4xx.c`/`sdio_f7xx.c` (SDIO-mode) from unchecked `dmaInit()` to ownership-checked `dmaAllocate()` + `dmaEnable()`.

## Why this needed more than a mechanical swap

- **`sdcard.c` (SPI-mode)**: falls back to polled SPI (clearing `useDMAForTx`) on claim failure instead of aborting card init entirely. `useDMAForTx` is already checked as a runtime gate at every transfer/completion site in this file — this is a supported, pre-existing fallback path, not new code. Losing DMA acceleration is preferable to losing the SD card (and blackbox logging) over an unrelated DMA conflict.
- **`sdio_f4xx.c`/`sdio_f7xx.c`**: `SD_Initialize_LL()` changed from `void` to `bool`, matching BF's actual return type, with the claim check moved to the very top of the function — before any RCC/GPIO/DMA register access. `sdio_h7xx.c`'s no-op stub (H7 uses internal IDMA, no external stream) is now `bool` too, matching BF exactly.
- **Deliberately not matching BF 4.5-maintenance's exact identifier-resolution logic**: BF's own `SD_Initialize_LL()` computes the DMA identifier from a file-scope static (`dmaStream`) that's only assigned *after* the ownership check — meaning `dmaAllocate()` always operates on an invalid/NULL-derived identifier and the function always returns `false` in 4.5-maintenance. This EF implementation resolves the identifier from the `dma` **parameter** instead, matching what BF's code clearly intended. That bug was independently confirmed fixed in current BF master (commit `b551d654a`, PR#14990, "Refactor DMA driver to abstract platform-specific types...", function renamed `SD_InitialiseHardware`) as a side effect of an unrelated, much larger DMA-API refactor — not a targeted fix. Per explicit instruction this is not filed upstream; tracked independently in `~/SYNC/nerdCopter-GIT/AI/EF/fix/dmainit-sdcard-migration/BF45-SDIO-DMASTREAM-BUG.md`.
- **Caller-side NULL-deref fix**: `usbd_storage_sdio.c` and `sdcard_sdio_baremetal.c` previously ignored `SD_Initialize_LL()`'s return value entirely. Since neither caller configures the DMA stream itself, a claim failure would leave the file-scope `dma_stream` pointer `NULL`, and the first real card transfer would dereference it in `SD_StartBlockTransfert()` — a hard fault, not a graceful failure. Both callers now check the return and bail to `SDCARD_STATE_NOT_PRESENT` (or an equivalent failure return) instead. Found via an opencode second-opinion pass, verified directly against source before fixing.
- **Double-init idempotency**: `sdcard_init()`/`SD_Initialize_LL()` can each be called twice per boot — once from `fc_init.c`, once from the USB MSC passthrough path — for the same logical `OWNER_SDCARD`. Added `sdcardDmaClaim()`/`sdioDmaClaim()`, matching the existing `uartDmaClaim()`/`dshotDmaClaim()` pattern already in this codebase: a stream already held by the same owner+resourceIndex is treated as an already-successful claim, so the second call isn't mistaken for a real conflict.

## Known architectural gap this PR does not close (tracked separately, not blocking)

`sdcard.c` (SPI-mode) still uses its own legacy per-driver DMA claim and the old raw-SPI polled API (`spiInstanceByDevice()`, `spiTransfer()`). BF 4.5-maintenance's equivalent (`sdcard_spi.c`) has no DMA-claim code of its own — it's fully migrated to the generic `extDevice_t`/`spiSequence()` bus-level mechanism (`spiInitBusDMA()` already claims DMA per-bus). This PR's `dmaAllocate()` fix is correct and safe for IT#1363's actual scope (ownership-check migration) but does not migrate `sdcard.c` onto that generic mechanism. Filed as #1399, sized comparable to the IMUF9001 legacy-DMA migration (#1143, closed) — a full driver rewrite, not part of this PR. SDIO mode (`sdio_f4xx.c`/`sdio_f7xx.c`) has no equivalent gap — BF's own SDIO driver also claims DMA per-driver (SDIO isn't part of the generic SPI-bus abstraction).

## BF-master verdict check

Per the corrected `/bf-gaps` process (4.5-maintenance is the reference, master checked as fallback for bugfixes/architecture direction, not the primary diff target): `git log 4.5-maintenance..master` confirms the `SD_Initialize_LL()` identifier bug above as `4.5-only` (fixed in master's `b551d654a`). A second verdict for the `sdcard.c` architectural gap (#1399): `not-comparable` — EF has no BF-equivalent file to diff against, since BF's `sdcard_spi.c` never had per-driver DMA-claim code to begin with. Full inventory: `fix/dmainit-sdcard-migration/dmainit-sdcard-migration-bf-gaps.md`; both verdicts logged in `MIGRATION.md` § BF-branch register.

## Review history

Local `coderabbit review --agent`: 0 findings, both rounds. An opencode second-opinion pass on the first round found two real issues (the NULL-deref and double-init cases above), both fixed and re-verified; a follow-up opencode pass on the fixed diff could not complete (infra instability, multiple models failing) and was not retried further, matching prior-session precedent for this tool. GitHub CodeRabbit's formal review: `APPROVED`, no actionable comments, all 7 changed files LGTM. A targeted analysis request (idempotent-reclaim logic + BF-bug avoidance) came back clean: confirmed both SPI-mode and SDIO-mode reclaim logic handle either boot-order permutation correctly, and confirmed no equivalent stale-static-before-assignment bug exists elsewhere in either file.

## Verification

- Build: 7/7 targets, no warnings — HELIOSPRING/FOXEERF722V4/STELLARH7DEV (3 real aircraft, all compile-gate only since none define `USE_SDCARD`), plus MLTYPHF4 (F4, SPI-mode + DMA), FLYSPARKF4 (F4, SDIO-mode), SPEEDYBEEF7V3 (F7, SDIO-mode), plus SITL.
- Host unit tests: `make test` — 48/48 test binaries pass (up from 43; added `sdcard_dma_claim_unittest.cc`, host coverage for `sdcardDmaClaim()`/`sdioDmaClaim()` — see PR comment for scope/rationale).
- **No real-hardware verification of a normally-configured target is possible** — none of the 3 real aircraft compile `USE_SDCARD`, and no `USE_SDCARD`-capable board (flight or bench) exists in inventory at all.
- **The ownership-check conflict mechanism itself was bench-verified on real silicon, both MCU families** (2026-08-24, not part of this PR's diff — local-only, uncommitted `target.h`/`target.mk` edits on two owned bench boards, SKYSTARSF405AIO/F4-STDPERIPH and TMOTORF7/F7-HAL, neither a real-aircraft target). `USE_SDCARD` was temporarily enabled sharing an existing SPI bus with a spare, verified-free CS pin, with the SD card's DMA stream deliberately pointed at the same stream the board's own ADC already owns (`DMA2_Stream3`/`DMA2_Stream4` respectively) — a real, physical ownership conflict, not simulated. On both boards, with `sdcard_dma` confirmed `ON` (`get sdcard_dma`), `dma` CLI output showed the ADC's stream unchanged after reboot: `sdcardDmaClaim()`'s ownership check correctly rejected the conflicting claim and fell back to polled SPI, no crash, no stolen stream. This does not test a real card's read/write path (none was present, none is needed to exercise the claim/conflict logic) and does not change the risk framing below for a normally-configured target — it confirms the specific new mechanism this PR adds actually works on hardware, across both MCU families.
- Compile-gate + bench-target build otherwise. Accepted as a documented, known risk for the remaining untested surface: this is a blackbox-logging peripheral, not a flight-control one — worst-case failure (SD card not detected, or SPI-mode fallback to polled transfer) is a logging/data-loss risk, not a flight-safety risk, unlike PR#1397 (motors). Marked DRAFT pending full hardware acquisition, not pending further code changes.

## Related

- Parent issue: #1363
- Prior stages: #1389 (ADC, merged), #1393 (transponder, merged), #1394 (LED strip, merged), #1397 (motors/DSHOT, merged) — all 4 prior stages now merged
- Follow-up: #1399 (sdcard.c SPI-mode architecture gap, not blocking)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SD card initialization reliability when DMA resources are unavailable or already in use.
  * Automatically falls back to polled transfers when DMA cannot be claimed.
  * SD card and USB storage initialization now stop cleanly when low-level setup fails.
  * Prevented invalid or conflicting DMA configurations from being used.
  * Improved handling when the same SD card transfer resource is initialized more than once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


