### PR TITLE
feat(cli): warn when a UART's configured dmaopt loses its DMA claim

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -4053,6 +4053,28 @@ static dmaoptValue_t *dmaoptAddr(const dmaoptEntry_t *entry, int index) {
     return (dmaoptValue_t *)(base + entry->stride * index + entry->offset);
 }
 
+// Surfaces serialUART()'s otherwise-silent IRQ-driven fallback via dmaAllocate()'s live ownership state.
+static void printDmaoptClaimStatus(const dmaoptEntry_t *entry, int index, const dmaChannelSpec_t *dmaChannelSpec) {
+    const dmaIdentifier_e identifier = dmaGetIdentifier((DMA_Stream_TypeDef *)dmaChannelSpec->ref);
+    const resourceOwner_e expectedOwner = (entry->peripheral == DMA_PERIPH_UART_TX) ? OWNER_SERIAL_TX : OWNER_SERIAL_RX;
+    const resourceOwner_e actualOwner = dmaGetOwner(identifier);
+    const uint8_t actualIndex = dmaGetResourceIndex(identifier);
+    if (actualOwner == expectedOwner && actualIndex == RESOURCE_INDEX(index)) {
+        return;
+    }
+    // OWNER_FREE is indistinguishable from "this UART not opened this boot" (unassigned serial function) -- skip to avoid false positives on every unused UART slot.
+    if (actualOwner == OWNER_FREE) {
+        return;
+    }
+    if (actualIndex > 0) {
+        cliPrintLinef("# %s %d: WARNING stream held by %s %d, not this UART -- expect IRQ-driven fallback",
+                      entry->device, index + 1, ownerNames[actualOwner], actualIndex);
+    } else {
+        cliPrintLinef("# %s %d: WARNING stream held by %s, not this UART -- expect IRQ-driven fallback",
+                      entry->device, index + 1, ownerNames[actualOwner]);
+    }
+}
+
 static void printDmaoptEntry(const dmaoptEntry_t *entry, int index) {
     const dmaoptValue_t *addr = dmaoptAddr(entry, index);
     if (!addr) {
@@ -4066,6 +4088,7 @@ static void printDmaoptEntry(const dmaoptEntry_t *entry, int index) {
         if (dmaChannelSpec) {
             cliPrintLinef("# %s %d: " DMASPEC_FORMAT_STRING, entry->device, index + 1,
                           DMA_CODE_CONTROLLER(dmaChannelSpec->code), DMA_CODE_STREAM(dmaChannelSpec->code), DMA_CODE_CHANNEL(dmaChannelSpec->code));
+            printDmaoptClaimStatus(entry, index, dmaChannelSpec);
         }
     } else {
         cliPrintLinef("dma %s %d NONE", entry->device, index + 1);
@@ -4161,6 +4184,13 @@ static void cliDmaopt(char *cmdline) {
         cliPrintLinef("# dma %s %d: changed from %s to %s", entry->device, index + 1, orgvalString, optvalString);
     } else {
         cliPrintLinef("# dma %s %d: no change: %s", entry->device, index + 1, orgvalString);
+    }
+
+    if (optval != DMA_OPT_UNUSED) {
+        const dmaChannelSpec_t *dmaChannelSpec = dmaGetChannelSpecByPeripheral(entry->peripheral, index, optval);
+        if (dmaChannelSpec) {
+            printDmaoptClaimStatus(entry, index, dmaChannelSpec);
+        }
     }
 }
 #endif // STM32F4 || STM32F7 || STM32H7

--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -4056,6 +4056,11 @@ static dmaoptValue_t *dmaoptAddr(const dmaoptEntry_t *entry, int index) {
 // Surfaces serialUART()'s otherwise-silent IRQ-driven fallback via dmaAllocate()'s live ownership state.
 static void printDmaoptClaimStatus(const dmaoptEntry_t *entry, int index, const dmaChannelSpec_t *dmaChannelSpec) {
     const dmaIdentifier_e identifier = dmaGetIdentifier((DMA_Stream_TypeDef *)dmaChannelSpec->ref);
+    if (identifier == DMA_NONE) {
+        // reqmap table points at a stream absent from dmaDescriptors[] -- a map bug, not a live contention case.
+        cliPrintLinef("# %s %d: DMA MAP ERROR", entry->device, index + 1);
+        return;
+    }
     const resourceOwner_e expectedOwner = (entry->peripheral == DMA_PERIPH_UART_TX) ? OWNER_SERIAL_TX : OWNER_SERIAL_RX;
     const resourceOwner_e actualOwner = dmaGetOwner(identifier);
     const uint8_t actualIndex = dmaGetResourceIndex(identifier);
@@ -4066,13 +4071,11 @@ static void printDmaoptClaimStatus(const dmaoptEntry_t *entry, int index, const 
     if (actualOwner == OWNER_FREE) {
         return;
     }
+    char idxSuffix[DMA_OPT_STRING_BUFSIZE] = "";
     if (actualIndex > 0) {
-        cliPrintLinef("# %s %d: WARNING stream held by %s %d, not this UART -- expect IRQ-driven fallback",
-                      entry->device, index + 1, ownerNames[actualOwner], actualIndex);
-    } else {
-        cliPrintLinef("# %s %d: WARNING stream held by %s, not this UART -- expect IRQ-driven fallback",
-                      entry->device, index + 1, ownerNames[actualOwner]);
+        tfp_sprintf(idxSuffix, " %d", actualIndex);
     }
+    cliPrintLinef("# %s %d: CLAIMED BY %s%s", entry->device, index + 1, ownerNames[actualOwner], idxSuffix);
 }
 
 static void printDmaoptEntry(const dmaoptEntry_t *entry, int index) {


### PR DESCRIPTION
AI Generated pull-request

## Summary

`serialUART()` silently falls back to IRQ-driven mode when its DMA claim
(`uartDmaClaim()`/`dmaAllocate()`) loses a stream/channel to another peripheral at boot — no CLI
message, log entry, or other diagnostic exists anywhere (EF or BF, inherited design). PR #1384's
new `dma` CLI setter increased real user exposure to this by making it easy to configure a
`dmaopt` value that collides with another peripheral's claim.

Adds `printDmaoptClaimStatus()` in `src/main/interface/cli.c`, which cross-checks a resolved
`dmaopt` stream against `dmaGetOwner()`/`dmaGetResourceIndex()` — the same live bookkeeping
`dmaAllocate()`/`uartDmaClaim()` already populate — and prints a `# ... WARNING ...` line on
mismatch. Wired into both:
- `printDmaoptEntry()` — the `dma <device> <index>` get path and `dma <device> list` / bare
  `dma list` display path
- `cliDmaopt()` — the set path, so a `dma UART_TX 1 <n>` set gets an immediate proactive warning
  if the target stream is already held by something else

`OWNER_FREE` (stream never claimed by anyone) is treated as a no-op rather than a warning, since
it's indistinguishable from "this UART slot isn't opened as a serial port this boot" — the
overwhelmingly common state for any board with unused UART indices.

Closes #1388.

## Test plan

- [x] `make test` (unit tests) — 47 suites, 0 failures
- [x] `make HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 STELLARH7DEV SITL` — all succeed, 0 new warnings
- [x] Reviewed via local CodeRabbit CLI (0 findings) and opencode second opinion (1 finding
      investigated, confirmed false positive — cited a SITL-only file never compiled where this
      feature runs)
- [x] Hardware-verified on TMOTORF7 (build `dd9d2b8`, EmuFlight 0.4.3, MSP API 1.54), all three
      code paths through `printDmaoptClaimStatus()` exercised live via CLI:
  - Real conflict: `dma UART_TX 3 0` (only option, resolves to DMA1 Stream 3, already held by
    `SPI_SDI 2`) → `# UART_TX 3: WARNING stream held by SPI_SDI 2, not this UART -- expect
    IRQ-driven fallback` on both set and get
  - `OWNER_FREE` (non-`NONE` value resolving to a genuinely-unclaimed stream): `dma UART_TX 2 0`
    (resolves to DMA1 Stream 6, `FREE`) → no warning
  - Explicit `NONE`: `dma UART_TX 3 none` → no warning
  - No `save` run at any point; flash-persisted defaults untouched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added diagnostics for UART DMA configuration mismatches.
  * The CLI now identifies when a selected DMA stream is assigned to an unexpected resource and warns that operation may fall back to interrupt-driven transfers.
  * Free DMA streams no longer generate unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->