### PR TITLE
test(cli): add host unit-test coverage for dmaopt claim-status diagnostic

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -3832,7 +3832,7 @@ static void printResource(uint8_t dumpMask) {
         }
         for (int index = 0; index < MAX_RESOURCE_INDEX(resourceTable[i].maxIndex); index++) {
             const ioTag_t ioTag = *(ioTag_t *)((const uint8_t *)currentConfig + resourceTable[i].stride * index + resourceTable[i].offset);
-            ioTag_t ioTagDefault = NULL;
+            ioTag_t ioTagDefault = 0;
             if (defaultConfig) {
                 ioTagDefault = *(ioTag_t *)((const uint8_t *)defaultConfig + resourceTable[i].stride * index + resourceTable[i].offset);
             }
@@ -4035,7 +4035,7 @@ static const char *dmaoptValueToString(dmaoptValue_t opt, char *buf) {
     return buf;
 }
 
-static const dmaoptEntry_t *findDmaoptEntry(const char *name) {
+STATIC_UNIT_TESTED const dmaoptEntry_t *findDmaoptEntry(const char *name) {
     for (unsigned i = 0; i < ARRAYLEN(dmaoptEntryTable); i++) {
         if (strcasecmp(name, dmaoptEntryTable[i].device) == 0) {
             return &dmaoptEntryTable[i];
@@ -4054,7 +4054,7 @@ static dmaoptValue_t *dmaoptAddr(const dmaoptEntry_t *entry, int index) {
 }
 
 // Surfaces serialUART()'s otherwise-silent IRQ-driven fallback via dmaAllocate()'s live ownership state.
-static void printDmaoptClaimStatus(const dmaoptEntry_t *entry, int index, const dmaChannelSpec_t *dmaChannelSpec) {
+STATIC_UNIT_TESTED void printDmaoptClaimStatus(const dmaoptEntry_t *entry, int index, const dmaChannelSpec_t *dmaChannelSpec) {
     const dmaIdentifier_e identifier = dmaGetIdentifier((DMA_Stream_TypeDef *)dmaChannelSpec->ref);
     if (identifier == DMA_NONE) {
         // reqmap table points at a stream absent from dmaDescriptors[] -- a map bug, not a live contention case.

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -109,6 +109,7 @@ cli_unittest_SRC := \
 		$(USER_DIR)/interface/cli.c \
 		$(USER_DIR)/config/feature.c \
 		$(USER_DIR)/pg/pg.c \
+		$(USER_DIR)/drivers/resource.c \
                 $(USER_DIR)/common/typeconversion.c
 
 cli_unittest_DEFINES := \
@@ -117,6 +118,8 @@ cli_unittest_DEFINES := \
 		USE_VTX_SMARTAUDIO \
 		USE_OSD \
 		USE_CLI \
+		USE_RESOURCE_MGMT \
+		STM32F4 \
 		SystemCoreClock=1000000
 
 beeper_dshot_beacon_unittest_SRC := \

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -264,8 +264,7 @@ TEST_F(DmaoptClaimStatusTest, OwnClaimPrintsNothing)
     printDmaoptClaimStatus(entry, 0, &spec);
     const std::string output = testing::internal::GetCapturedStdout();
 
-    EXPECT_EQ(std::string::npos, output.find("CLAIMED BY"));
-    EXPECT_EQ(std::string::npos, output.find("DMA MAP ERROR"));
+    EXPECT_TRUE(output.empty());
 }
 
 TEST_F(DmaoptClaimStatusTest, FreeOwnerPrintsNothing)
@@ -276,8 +275,7 @@ TEST_F(DmaoptClaimStatusTest, FreeOwnerPrintsNothing)
     printDmaoptClaimStatus(entry, 0, &spec);
     const std::string output = testing::internal::GetCapturedStdout();
 
-    EXPECT_EQ(std::string::npos, output.find("CLAIMED BY"));
-    EXPECT_EQ(std::string::npos, output.find("DMA MAP ERROR"));
+    EXPECT_TRUE(output.empty());
 }
 
 TEST_F(DmaoptClaimStatusTest, ConflictWithResourceIndexPrintsIndexSuffix)

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -33,6 +33,9 @@ extern "C" {
     #include "pg/pg_ids.h"
     #include "pg/rx.h"
     #include "drivers/buf_writer.h"
+    #include "drivers/dma.h"
+    #include "drivers/dma_reqmap.h"
+    #include "drivers/io_impl.h"
     #include "drivers/vtx_common.h"
     #include "fc/config.h"
     #include "fc/rc_adjustments.h"
@@ -59,6 +62,14 @@ extern "C" {
     void cliSet(char *cmdline);
     void cliGet(char *cmdline);
     void cliVtx(char *cmdline);
+
+    // dmaoptEntry_t stays opaque here -- its definition is private to cli.c; the test
+    // only ever forwards a pointer obtained from findDmaoptEntry() back into
+    // printDmaoptClaimStatus(), never dereferences a field directly.
+    struct dmaoptEntry_s;
+    typedef struct dmaoptEntry_s dmaoptEntry_t;
+    const dmaoptEntry_t *findDmaoptEntry(const char *name);
+    void printDmaoptClaimStatus(const dmaoptEntry_t *entry, int index, const dmaChannelSpec_t *dmaChannelSpec);
 
     static const int UNIT_TEST_DATA_LENGTH = 3;
 
@@ -219,8 +230,114 @@ TEST(CLIUnittest, TestCliVtxInvalidArgumentCount)
 
 #pragma GCC diagnostic pop
 
+// dmaGetIdentifier/dmaGetOwner/dmaGetResourceIndex are stubbed (below) as test-controllable
+// fakes; these globals select what each call returns for the current test case.
+static dmaIdentifier_e fakeDmaIdentifier;
+static resourceOwner_e fakeDmaOwner;
+static uint8_t fakeDmaResourceIndex;
+
+class DmaoptClaimStatusTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        cliMode = 1;
+        fakeDmaIdentifier = static_cast<dmaIdentifier_e>(1); // any identifier != DMA_NONE
+        fakeDmaOwner = OWNER_FREE;
+        fakeDmaResourceIndex = 0;
+        entry = findDmaoptEntry("UART_TX");
+    }
+
+    const dmaoptEntry_t *entry;
+    dmaChannelSpec_t spec = {};
+};
+
+TEST_F(DmaoptClaimStatusTest, FindsUartTxEntry)
+{
+    ASSERT_NE(nullptr, entry);
+}
+
+TEST_F(DmaoptClaimStatusTest, OwnClaimPrintsNothing)
+{
+    fakeDmaOwner = OWNER_SERIAL_TX;
+    fakeDmaResourceIndex = RESOURCE_INDEX(0);
+
+    testing::internal::CaptureStdout();
+    printDmaoptClaimStatus(entry, 0, &spec);
+    const std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_EQ(std::string::npos, output.find("CLAIMED BY"));
+    EXPECT_EQ(std::string::npos, output.find("DMA MAP ERROR"));
+}
+
+TEST_F(DmaoptClaimStatusTest, FreeOwnerPrintsNothing)
+{
+    fakeDmaOwner = OWNER_FREE;
+
+    testing::internal::CaptureStdout();
+    printDmaoptClaimStatus(entry, 0, &spec);
+    const std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_EQ(std::string::npos, output.find("CLAIMED BY"));
+    EXPECT_EQ(std::string::npos, output.find("DMA MAP ERROR"));
+}
+
+TEST_F(DmaoptClaimStatusTest, ConflictWithResourceIndexPrintsIndexSuffix)
+{
+    fakeDmaOwner = OWNER_SPI_SDI;
+    fakeDmaResourceIndex = 3;
+
+    testing::internal::CaptureStdout();
+    printDmaoptClaimStatus(entry, 0, &spec);
+    const std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_NE(std::string::npos, output.find("# UART_TX 1: CLAIMED BY SPI_SDI 3"));
+}
+
+TEST_F(DmaoptClaimStatusTest, ConflictWithoutResourceIndexOmitsSuffix)
+{
+    fakeDmaOwner = OWNER_ADC;
+    fakeDmaResourceIndex = 0;
+
+    testing::internal::CaptureStdout();
+    printDmaoptClaimStatus(entry, 0, &spec);
+    const std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_NE(std::string::npos, output.find("# UART_TX 1: CLAIMED BY ADC\r\n"));
+}
+
+TEST_F(DmaoptClaimStatusTest, InvalidIdentifierPrintsMapError)
+{
+    fakeDmaIdentifier = DMA_NONE;
+
+    testing::internal::CaptureStdout();
+    printDmaoptClaimStatus(entry, 0, &spec);
+    const std::string output = testing::internal::GetCapturedStdout();
+
+    EXPECT_NE(std::string::npos, output.find("# UART_TX 1: DMA MAP ERROR"));
+}
+
 // STUBS
 extern "C" {
+
+// USE_RESOURCE_MGMT (enabled for this test to reach cliDma/dmaopt) also compiles
+// cliResource()/printResource(), which this test suite does not exercise -- link-only stubs.
+ioRec_t ioRecs[1];
+int IO_GPIOPortIdx(IO_t) { return 0; }
+int IO_GPIOPinIdx(IO_t) { return 0; }
+IO_t IOGetByTag(ioTag_t) { return NULL; }
+ioRec_t *IO_Rec(IO_t) { return &ioRecs[0]; }
+
+int tfp_sprintf(char *s, const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    const int ret = vsprintf(s, fmt, args);
+    va_end(args);
+    return ret;
+}
+
+dmaIdentifier_e dmaGetIdentifier(const DMA_Stream_TypeDef *) { return fakeDmaIdentifier; }
+resourceOwner_e dmaGetOwner(dmaIdentifier_e) { return fakeDmaOwner; }
+uint8_t dmaGetResourceIndex(dmaIdentifier_e) { return fakeDmaResourceIndex; }
+const dmaChannelSpec_t *dmaGetChannelSpecByPeripheral(dmaPeripheral_e, uint8_t, int8_t) { return NULL; }
 
 float motor_disarmed[MAX_SUPPORTED_MOTORS];
 

--- a/src/test/unit/cli_unittest.cc
+++ b/src/test/unit/cli_unittest.cc
@@ -329,7 +329,7 @@ ioRec_t *IO_Rec(IO_t) { return &ioRecs[0]; }
 int tfp_sprintf(char *s, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    const int ret = vsprintf(s, fmt, args);
+    const int ret = vsnprintf(s, 16, fmt, args);
     va_end(args);
     return ret;
 }


### PR DESCRIPTION
AI Generated pull-request

## Summary
Closes #1401.

`printDmaoptClaimStatus()` (added in #1400) had zero host unit-test coverage: `cli_unittest_DEFINES` never set an MCU-family macro, so the `#if defined(STM32F4) || defined(STM32F7) || defined(STM32H7)` dmaopt subsystem in `src/main/interface/cli.c` was never compiled into the host `cli_unittest` binary.

- `src/test/Makefile`: add `STM32F4` + `USE_RESOURCE_MGMT` to `cli_unittest_DEFINES`, add `drivers/resource.c` to `cli_unittest_SRC` (real `ownerNames` table instead of a hand-rolled duplicate).
- `src/main/interface/cli.c`: mark `findDmaoptEntry()` and `printDmaoptClaimStatus()` `STATIC_UNIT_TESTED`; fix `ioTag_t ioTagDefault = NULL` in `printResource()` (a pointer-to-integer error under host clang once `USE_RESOURCE_MGMT` compiles on host for the first time — unreachable on any real target build).
- `src/test/unit/cli_unittest.cc`: 6 new test cases covering all 5 branches of `printDmaoptClaimStatus()` (own-claim, `OWNER_FREE`, conflict with/without a resourceIndex suffix, `DMA_NONE`/invalid identifier), plus link-only stubs for `dmaGetIdentifier`/`dmaGetOwner`/`dmaGetResourceIndex`/`dmaGetChannelSpecByPeripheral`/`tfp_sprintf`/IO accessors pulled in by enabling `USE_RESOURCE_MGMT`.

Verified by mutation testing: removing the `OWNER_FREE` early-return guard in `printDmaoptClaimStatus()` causes `FreeOwnerPrintsNothing` to fail, confirming the assertions are not vacuous.

## Test plan
- [x] `make clean_test && make test`: 47 suites pass, 0 failures, 0 new warnings (includes 9 `cli_unittest` tests: 3 pre-existing + 6 new).
- [x] Bench build: `HELIOSPRING TMOTORF7 APEXF7 FOXEERF722V4 SKYSTARSF405AIO TUNERCF405 FOXEERF405 PYRODRONEF7 STELLARH7DEV NBDHMBF4PRO SITL` all build clean.
- [x] Local CodeRabbit review (`coderabbit review --agent --base upstream/master`): 0 findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when displaying DMA resource ownership and claim status.
  * Corrected handling of default resource values to avoid misleading status output.
  * Improved reporting for free, self-owned, conflicting, indexed, and invalid DMA resources.

* **Tests**
  * Expanded validation for UART DMA lookups, resource availability, ownership conflicts, indexed resources, and invalid DMA identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->