### PR TITLE
fix: correct W25N01GV flash geometry (sectors/pageSize swapped)

### DIFF
--- a/src/main/drivers/flash_w25n.c
+++ b/src/main/drivers/flash_w25n.c
@@ -126,9 +126,9 @@ struct {
     uint16_t        pagesPerSector;
     uint16_t        pageSize;
 } w25nFlashConfig[] = {
-    // Winbond W25N01GV
+    // Winbond W25N01GV: 1,024 blocks x 64 pages x 2,048-byte pages (datasheet General Descriptions)
     // Datasheet: https://www.winbond.com/resource-files/W25N01GV%20Rev%20R%20070323.pdf
-    { 0xEFAA21, 2048, 64, 1024 },
+    { 0xEFAA21, 1024, 64, 2048 },
     // Winbond W25N02KV
     // Datasheet: https://www.winbond.com/resource-files/W25N02KVxxIRU_Datasheet_RevM.pdf
     { 0xEFAA22, 2048, 64, 2048 },


### PR DESCRIPTION
AI Generated pull-request

## Summary
- `w25nFlashConfig[]` declared 2048 blocks x 64 pages x 1024-byte pages for the W25N01GV entry. Per the datasheet's General Descriptions section, the part is 1024 erasable blocks x 64 pages x 2048-byte pages. Both orderings multiply to the same 128MB `totalSize`, which is why `flash_info` never showed a wrong number.
- `W25N_LINEAR_TO_PAGE()`/`W25N_LINEAR_TO_COLUMN()` derive from `geometry.pageSize`, so the wrong 1024-byte value caused addresses past 64MB to alias onto pages already written earlier in the same fill, and only the lower half of every physical 2048-byte page was ever written.
- The bad-block-management partition start (`geometry.sectors - N`) was likewise placed outside the chip's real 1024 blocks.
- Port of betaflight/betaflight#15524 (merged into BF master, not yet backported to 4.5-maintenance).
- Changes the flashfs/BBMGMT partition boundaries. Existing blackbox data on affected boards is not readable after this change — run `flash_erase` after flashing.

## Test plan
- [x] `make clean && make test` — PASS, 0 failures
- [x] Bench build: STELLARH7DEV, KONEXH743, SITL — 3 succeeded, 0 failed, no warnings
- [ ] Hardware verified on a real W25N01GV/W25M02G board (STELLARH7DEV) — `flash_erase`, `flash_info`, `flash_scan`, write-then-read-back past the old 64MB alias point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Winbond W25N01GV flash geometry reporting.
  * Improved compatibility with the device’s documented block and page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->