### PR TITLE
fix(drivers): migrate timerGetByTag() to ownership-checked timerAllocate()

### DIFF
--- a/src/main/drivers/camera_control.c
+++ b/src/main/drivers/camera_control.c
@@ -121,7 +121,7 @@ void cameraControlInit(void) {
     IOInit(cameraControlRuntime.io, OWNER_CAMERA_CONTROL, 0);
     if (CAMERA_CONTROL_MODE_HARDWARE_PWM == cameraControlConfig()->mode) {
 #ifdef CAMERA_CONTROL_HARDWARE_PWM_AVAILABLE
-        const timerHardware_t *timerHardware = timerGetByTag(cameraControlConfig()->ioTag);
+        const timerHardware_t *timerHardware = timerAllocate(cameraControlConfig()->ioTag, OWNER_CAMERA_CONTROL, 0);
         if (!timerHardware) {
             return;
         }

--- a/src/main/drivers/light_ws2811strip_hal.c
+++ b/src/main/drivers/light_ws2811strip_hal.c
@@ -50,7 +50,10 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
     if (!ioTag) {
         return;
     }
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP, 0);
+    if (timerHardware == NULL) {
+        return;
+    }
     TIM_TypeDef *timer = timerHardware->tim;
     timerChannel = timerHardware->channel;
     if (timerHardware->dmaRef == NULL || !dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {

--- a/src/main/drivers/light_ws2811strip_stdperiph.c
+++ b/src/main/drivers/light_ws2811strip_stdperiph.c
@@ -60,7 +60,10 @@ void ws2811LedStripHardwareInit(ioTag_t ioTag) {
     TIM_TimeBaseInitTypeDef  TIM_TimeBaseStructure;
     TIM_OCInitTypeDef  TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_LED_STRIP, 0);
+    if (timerHardware == NULL) {
+        return;
+    }
     timer = timerHardware->tim;
     if (timerHardware->dmaRef == NULL || !dmaAllocate(timerHardware->dmaIrqHandler, OWNER_LED_STRIP, 0)) {
         return;

--- a/src/main/drivers/pwm_output.c
+++ b/src/main/drivers/pwm_output.c
@@ -273,7 +273,7 @@ void motorDevInit(const motorDevConfig_t *motorConfig, uint16_t idlePulse, uint8
     }
     for (int motorIndex = 0; motorIndex < MAX_SUPPORTED_MOTORS && motorIndex < motorCount; motorIndex++) {
         const ioTag_t tag = motorConfig->ioTags[motorIndex];
-        const timerHardware_t *timerHardware = timerGetByTag(tag);
+        const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, RESOURCE_INDEX(motorIndex));
         if (timerHardware == NULL) {
             /* not enough motors initialised for the mixer or a break in the motors */
             pwmWrite = &pwmWriteUnused;
@@ -492,7 +492,7 @@ void servoDevInit(const servoDevConfig_t *servoConfig) {
         }
         servos[servoIndex].io = IOGetByTag(tag);
         IOInit(servos[servoIndex].io, OWNER_SERVO, RESOURCE_INDEX(servoIndex));
-        const timerHardware_t *timer = timerGetByTag(tag);
+        const timerHardware_t *timer = timerAllocate(tag, OWNER_SERVO, RESOURCE_INDEX(servoIndex));
         if (timer == NULL) {
             /* flag failure and disable ability to arm */
             break;
@@ -524,7 +524,7 @@ void pwmToggleBeeper(void) {
 }
 
 void beeperPwmInit(const ioTag_t tag, uint16_t frequency) {
-    const timerHardware_t *timer = timerGetByTag(tag);
+    const timerHardware_t *timer = timerAllocate(tag, OWNER_BEEPER, 0);
     IO_t beeperIO = IOGetByTag(tag);
     if (beeperIO && timer) {
         beeperPwm.io = beeperIO;

--- a/src/main/drivers/rx/rx_pwm.c
+++ b/src/main/drivers/rx/rx_pwm.c
@@ -329,7 +329,7 @@ void pwmRxInit(const pwmConfig_t *pwmConfig) {
     inputFilteringMode = pwmConfig->inputFilteringMode;
     for (int channel = 0; channel < PWM_INPUT_PORT_COUNT; channel++) {
         pwmInputPort_t *port = &pwmInputPorts[channel];
-        const timerHardware_t *timer = timerGetByTag(pwmConfig->ioTags[channel]);
+        const timerHardware_t *timer = timerAllocate(pwmConfig->ioTags[channel], OWNER_PWMINPUT, RESOURCE_INDEX(channel));
         if (!timer) {
             /* TODO: maybe fail here if not enough channels? */
             continue;
@@ -370,7 +370,7 @@ void ppmAvoidPWMTimerClash(TIM_TypeDef *pwmTimer) {
 void ppmRxInit(const ppmConfig_t *ppmConfig) {
     ppmResetDevice();
     pwmInputPort_t *port = &pwmInputPorts[FIRST_PWM_PORT];
-    const timerHardware_t *timer = timerGetByTag(ppmConfig->ioTag);
+    const timerHardware_t *timer = timerAllocate(ppmConfig->ioTag, OWNER_PPMINPUT, 0);
     if (!timer) {
         /* TODO: fail here? */
         return;

--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -565,7 +565,10 @@ static serialPort_t *openEscSerial(escSerialPortIndex_e portIndex, serialReceive
 #endif
     }
     escSerial->mode = mode;
-    escSerial->txTimerHardware = timerGetByTag(escSerialConfig()->ioTag);
+    escSerial->txTimerHardware = timerAllocate(escSerialConfig()->ioTag, OWNER_MOTOR, 0);
+    if (escSerial->txTimerHardware == NULL) {
+        return NULL;
+    }
 #ifdef USE_HAL_DRIVER
     escSerial->txTimerHandle = timerFindTimerHandle(escSerial->txTimerHardware->tim);
 #endif

--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -203,8 +203,9 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
     int pinCfgIndex = portIndex + RESOURCE_SOFT_OFFSET;
     ioTag_t tagRx = serialPinConfig()->ioTagRx[pinCfgIndex];
     ioTag_t tagTx = serialPinConfig()->ioTagTx[pinCfgIndex];
-    const timerHardware_t *timerRx = timerGetByTag(tagRx);
-    const timerHardware_t *timerTx = timerGetByTag(tagTx);
+    const timerHardware_t *timerTx = timerAllocate(tagTx, OWNER_SERIAL_TX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
+    // Same tag claimed twice under different owners would falsely conflict in bidir/duplex mode.
+    const timerHardware_t *timerRx = (tagRx == tagTx) ? timerTx : timerAllocate(tagRx, OWNER_SERIAL_RX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
     IO_t rxIO = IOGetByTag(tagRx);
     IO_t txIO = IOGetByTag(tagTx);
     if (options & SERIAL_BIDIR) {

--- a/src/main/drivers/timer.h
+++ b/src/main/drivers/timer.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "drivers/io_types.h"
+#include "drivers/resource.h"
 #include "rcc_types.h"
 #include "drivers/timer_def.h"
 
@@ -183,6 +184,7 @@ rccPeriphTag_t timerRCC(TIM_TypeDef *tim);
 uint8_t timerInputIrq(TIM_TypeDef *tim);
 
 const timerHardware_t *timerGetByTag(ioTag_t ioTag);
+const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex);
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index);
 
 #if defined(USE_HAL_DRIVER)

--- a/src/main/drivers/timer_common.c
+++ b/src/main/drivers/timer_common.c
@@ -54,6 +54,37 @@ const timerHardware_t *timerGetByTag(ioTag_t ioTag) {
     return NULL;
 }
 
+#ifdef USE_TIMER_MGMT
+static resourceOwner_e timerOwners[MAX_TIMER_PINMAP_COUNT];
+
+const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex) {
+    UNUSED(resourceIndex); // tracked by BF's resourceOwner_t for its timerGetOwner() accessor; no equivalent consumer exists in EF yet
+    if (!ioTag) {
+        return NULL;
+    }
+    for (unsigned i = 0; i < MAX_TIMER_PINMAP_COUNT; i++) {
+        if (timerIOConfig(i)->ioTag == ioTag) {
+            if (timerOwners[i]) {
+                return NULL;
+            }
+            const timerHardware_t *timer = timerGetByTag(ioTag);
+            if (!timer) {
+                return NULL;
+            }
+            timerOwners[i] = owner;
+            return timer;
+        }
+    }
+    return NULL;
+}
+#else
+const timerHardware_t *timerAllocate(ioTag_t ioTag, resourceOwner_e owner, uint8_t resourceIndex) {
+    UNUSED(owner);
+    UNUSED(resourceIndex);
+    return timerGetByTag(ioTag);
+}
+#endif
+
 ioTag_t timerioTagGetByUsage(timerUsageFlag_e usageFlag, uint8_t index) {
     uint8_t currentIndex = 0;
     for (int i = 0; i < (int)USABLE_TIMER_CHANNEL_COUNT; i++) {

--- a/src/main/drivers/transponder_ir_io_hal.c
+++ b/src/main/drivers/transponder_ir_io_hal.c
@@ -69,7 +69,7 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     if (!ioTag) {
         return;
     }
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER, 0);
     if (!timerHardware) {
         return;
     }

--- a/src/main/drivers/transponder_ir_io_stdperiph.c
+++ b/src/main/drivers/transponder_ir_io_stdperiph.c
@@ -67,7 +67,10 @@ void transponderIrHardwareInit(ioTag_t ioTag, transponder_t *transponder) {
     TIM_TimeBaseInitTypeDef  TIM_TimeBaseStructure;
     TIM_OCInitTypeDef  TIM_OCInitStructure;
     DMA_InitTypeDef DMA_InitStructure;
-    const timerHardware_t *timerHardware = timerGetByTag(ioTag);
+    const timerHardware_t *timerHardware = timerAllocate(ioTag, OWNER_TRANSPONDER, 0);
+    if (timerHardware == NULL) {
+        return;
+    }
     timer = timerHardware->tim;
     if (timerHardware->dmaRef == NULL) {
         return;


### PR DESCRIPTION
AI Generated pull-request

## Summary

Ports BF 4.5-maintenance's `timerAllocate()`/`timerOwners[]` ownership-tracking mechanism into `src/main/drivers/timer_common.c`/`timer.h`, matching BF's `USE_TIMER_MGMT`-gated real-check / no-op-fallback structure exactly (not made unconditional). Converts 9 files / 12 call sites from unchecked `timerGetByTag()` to `timerAllocate(ioTag, OWNER_X, resourceIndex)`:

- `light_ws2811strip_stdperiph.c`, `light_ws2811strip_hal.c` — `OWNER_LED_STRIP`
- `transponder_ir_io_stdperiph.c`, `transponder_ir_io_hal.c` — `OWNER_TRANSPONDER`
- `camera_control.c` — `OWNER_CAMERA_CONTROL`
- `pwm_output.c` — motor/servo/beeper (3 sites)
- `rx/rx_pwm.c` — PWM/PPM (2 sites)
- `serial_softserial.c`, `serial_escserial.c` (`txTimerHardware` only)

Closes part of #1395.

## Scope correction on the linked issue

#1395 was corrected twice during this work. First correction: BF's real ownership check is gated behind `USE_TIMER_MGMT`, not unconditional. Second correction: that check is fleet-wide default on BF's real fleet — `drivers/stm32/platform_mcu.h` turns it on for all STM32/AT32, gated only by `USE_DMA_SPEC` (itself default for every STM32 family), and 616 of 629 real BF board configs define the `TIMER_PIN_MAPPING` the check needs. EF has neither piece of that architecture — only 2 targets (`NERO`, `STM32F7X2`) define `USE_TIMER_MGMT` at all, via a one-off per-board `#define`.

**This PR is necessary groundwork only — it does not yet deliver real ownership protection anywhere in nerdCopter's own hardware fleet.** No EF target he personally owns combines `USE_TIMER_MGMT` with a populated pinmap the way BF's real boards do. Closing that gap for real needs, as follow-up work not attempted here:
1. A platform-default header (matching `platform_mcu.h`) turning `USE_TIMER_MGMT` on for STM32/AT32 targets.
2. Per-board `TIMER_PIN_MAPPING`-equivalent tables — substantial per-target authoring.
3. Resolving #1396 (`dmaGetChannelSpecByTimer()` has a real H7 implementation but zero callers anywhere in the tree) — a prerequisite for H7 targets specifically; F4/F7 need a real implementation written first (documented decision, `extDevice_t/bf-deviations.md` DEV-002).

## Fixes required by the mechanical swap (not pre-existing bugs, found during this port)

Several call sites dereferenced the timer pointer immediately after the old `timerGetByTag()` call with no NULL check — safe when that call always succeeds, not once `timerAllocate()` can legitimately return `NULL` on a conflict. Added a NULL check immediately after the call, before any dereference, matching BF's exact position in each equivalent file: `light_ws2811strip_stdperiph.c`, `light_ws2811strip_hal.c`, `transponder_ir_io_stdperiph.c`, `serial_escserial.c`.

`serial_softserial.c`'s `openSoftSerial()` computes `timerRx`/`timerTx` unconditionally before branching on `SERIAL_BIDIR`. In bidir mode the same tag is used for both directions — a blind swap would claim the same physical timer twice under two different owners and falsely fail. Ported BF's exact guard: `timerRx = (tagRx == tagTx) ? timerTx : timerAllocate(tagRx, OWNER_SERIAL_RX, ...)`.

## Deferred, not fixed in this PR

`serial_escserial.c`'s `openEscSerial()` resolves `rxTimerHardware` via direct array index (`&(timerHardware[output])`), never calling any tag-based lookup — a structurally larger gap than an unchecked claim (zero resource tracking of any kind on that path). Only the `txTimerHardware` site is converted here. Filed as #1408.

`fc/config.c:315` is a boot-time existence check (clears the beeper feature if unconfigured), not a resource claim — left calling the plain `timerGetByTag()` form, not converted.

## Review

- Local `coderabbit review --agent`, 2 rounds during implementation: found and fixed a claim-ordering issue (register/GPIO writes before the ownership check in several sites — see NULL-deref fixes above) and 2 accidental worktree-symlink staging mistakes (unstaged, not part of the diff). 2 further findings checked directly against BF's own reference implementation and found not actionable — BF's real code does the same thing being flagged (no `timerRelease()`/`dmaRelease()` API exists anywhere in BF either; BF's own `openSoftSerial()` also allocates both timer claims unconditionally, no mode/options gating).
- `/code-review` (medium effort), independent second pass: 1 finding (`timerOwnerResourceIndex[]` tracked per-slot but never read by anything) — fixed by dropping the dead array; `resourceIndex` is accepted but not stored, matching BF's own non-`USE_TIMER_MGMT` fallback pattern of discarding it when nothing consumes it.
- Final local `coderabbit review --agent` re-run on the committed diff: 0 findings.
- opencode second-opinion pass: could not complete — 2 different models failed with different errors in the same session (model-not-found, auth error), consistent with an infra-side outage. Not retried further.

## Follow-up issues filed

- #1407 — `serial_softserial.c` unconditional RX `IOInit()` (missing BF's duplex-shared-pin suppression guard), confirmed pre-existing, predates this PR.
- #1408 — `serial_escserial.c`'s `rxTimerHardware` array-index bypass, deferred from this PR above.

## Test plan

- [x] Build: `HELIOSPRING FOXEERF722V4 STELLARH7DEV NERO STM32F7X2` — 5/5 succeeded, 0 warnings. `NERO`/`STM32F7X2` are the only 2 fleet targets that compile the `USE_TIMER_MGMT` real-check branch this port adds live behavior to.
- [x] Build: `SITL` — 1/1 succeeded, 0 warnings.
- [x] Host unit tests: `make clean_test && make test` — 47/47 test binaries pass, 0 failed assertions.
- [x] Hardware verification: **complete, 2026-08-25**, on real `FOXEERF722V4` via the generic `STM32F7X2` target (post #1409/#1410's boot fix). Configured `resource`/`timer` CLI entries matching this board's real motor pins — accept path confirmed (`resource show` lists all 4 motors claimed after reboot). Deliberately forced a collision (`LED_STRIP` onto an already-motor-owned pin) — reject path confirmed (`dma` output unchanged after reboot, no new stream for the second claimant, proving `timerAllocate()` rejected it rather than silently overwriting). Full detail: PR comment below. The no-op branch on the 3 owned real aircraft (HELIOSPRING/FOXEERF722V4/STELLARH7DEV) remains behaviorally identical to the prior `timerGetByTag()` by source inspection, as before.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when initializing camera controls, motor and servo outputs, beepers, LED strips, serial interfaces, receiver inputs, and transponders.
  * Timer resources are now explicitly reserved to prevent conflicting hardware assignments.
  * Components gracefully skip initialization when a required timer is unavailable.
  * Soft serial correctly handles shared transmit and receive timer resources without duplicate allocation attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->