### PR TITLE
fix(target/spi): fix STM32F7X2 generic target boot hang

### DIFF
--- a/src/main/drivers/bus_spi_ll.c
+++ b/src/main/drivers/bus_spi_ll.c
@@ -116,6 +116,10 @@ static uint32_t spiDivisorToBRbits(SPI_TypeDef *instance, uint16_t divisor)
 
 void spiInitDevice(SPIDevice device) {
     spiDevice_t *spi = &(spiDevice[device]);
+
+    if (!spi->dev) {
+        return;
+    }
 #ifdef SDCARD_SPI_INSTANCE
     if (spi->dev == SDCARD_SPI_INSTANCE) {
         spi->leadingEdge = true;

--- a/src/main/drivers/bus_spi_stdperiph.c
+++ b/src/main/drivers/bus_spi_stdperiph.c
@@ -39,6 +39,10 @@
 
 void spiInitDevice(SPIDevice device) {
     spiDevice_t *spi = &(spiDevice[device]);
+
+    if (!spi->dev) {
+        return;
+    }
 #ifdef SDCARD_SPI_INSTANCE
     if (spi->dev == SDCARD_SPI_INSTANCE) {
         spi->leadingEdge = true;

--- a/src/main/sensors/acceleration.c
+++ b/src/main/sensors/acceleration.c
@@ -141,6 +141,7 @@ void pgResetFn_accelerometerConfig(accelerometerConfig_t *instance) {
 }
 
 bool accDetect(accDev_t *dev, accelerationSensor_e accHardwareToUse) {
+    UNUSED(dev); // unused when no USE_ACC_* chip is compiled in (e.g. a bare GENERIC_TARGET)
     accelerationSensor_e accHardware = ACC_NONE;
 #ifdef USE_ACC_ADXL345
     drv_adxl345_config_t acc_params;

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -33,6 +33,7 @@
 #include "common/axis.h"
 #include "common/maths.h"
 #include "common/filter.h"
+#include "common/utils.h"
 
 #include "config/feature.h"
 
@@ -391,6 +392,7 @@ const mpuDetectionResult_t *gyroMpuDetectionResult(void) {
 }
 
 STATIC_UNIT_TESTED gyroSensor_e gyroDetect(gyroDev_t *dev) {
+    UNUSED(dev); // unused when no USE_*_GYRO_* chip is compiled in (e.g. a bare GENERIC_TARGET)
     gyroSensor_e gyroHardware = GYRO_DEFAULT;
     switch (gyroHardware) {
     case GYRO_DEFAULT:

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -30,25 +30,7 @@
 
 #define USE_BEEPER
 
-// MPU interrupt
 #define USE_EXTI
-#define USE_MPU_DATA_READY_SIGNAL
-//#define DEBUG_MPU_DATA_READY_INTERRUPT
-#define MPU_INT_EXTI PB15 // XXX Should be gone
-
-#define USE_ACC
-#define USE_GYRO
-
-#define USE_ACC_SPI_MPU6500
-#define USE_GYRO_SPI_MPU6500
-// Other USE_ACCs and USE_GYROs should follow
-
-// Should be gone
-#define MPU6500_CS_PIN          PC4  // XXX Should be gone
-#define MPU6500_SPI_BUS    SPIDEV_1 // XXX Should be gone
-#define ACC_MPU6500_ALIGN CW0_DEG
-#define GYRO_MPU6500_ALIGN CW0_DEG
-
 
 #define USE_MAG
 #define USE_MAG_HMC5883

--- a/src/main/target/STM32F7X2/target.h
+++ b/src/main/target/STM32F7X2/target.h
@@ -30,6 +30,11 @@
 
 #define USE_BEEPER
 
+// No IMU/gyro selected: this file carries no board-specific sensor wiring, and
+// EF has no CLI/resource path to add one at runtime (no OWNER_MPU_CS/OWNER_MPU_EXTI
+// resourceTable entries). To use this target with a real board's gyro, add its
+// USE_*_SPI_*/USE_*_I2C_* chip macro plus the matching *_CS_PIN/*_SPI_BUS/*_EXTI_PIN
+// (or GYRO_1_* equivalents) here, matching that board's actual wiring.
 #define USE_EXTI
 
 #define USE_MAG


### PR DESCRIPTION
AI Generated pull-request

## Summary

Fixes #1409: `STM32F7X2` (EF's `GENERIC_TARGET` catch-all F722-class build) failed to boot on
real hardware — zero USB enumeration, no DFU device either. Two fixes, found in sequence:

1. `target.h` hardcoded `MPU_INT_EXTI PB15`/`MPU6500_CS_PIN PC4`/`MPU6500_SPI_BUS SPIDEV_1`
   (each self-flagged `// XXX Should be gone`), colliding with real board wiring. Removed —
   matches BF 4.5-maintenance's real generic target, which defines zero acc/gyro chip
   selection at all.
2. **The actual root cause, found after fix (1) alone did not resolve the symptom**:
   `spiInitDevice()` (`drivers/bus_spi_ll.c`, `drivers/bus_spi_stdperiph.c`) dereferenced an
   unresolved (`NULL`) SPI bus pointer unconditionally. Fixed by porting BF's existing
   `if (!spi->dev) { return; }` guard, present in BF's reference but missing from EF's port.

## Root cause (2): unguarded NULL SPI bus pointer

`STM32F7X2` compiles `USE_SPI_DEVICE_1/2/3` with zero SCK/MISO/MOSI pins defined anywhere
(`SPI_FULL_RECONFIGURABILITY`, no per-board defaults — this is by design, a truly generic
target has no fixed SPI wiring to assume). `spiPinConfigure()` (`bus_spi_pinconfig.c`)
correctly leaves `spiDevice[n].dev` at its zero-initialized `NULL` when no pin combination in
the shared MCU-family pin table matches. `spiInitDevice()` then ran anyway — `LL_SPI_Disable()`/
`LL_SPI_DeInit()`/`LL_SPI_Init()` on the F7/LL path, `SPI_I2S_DeInit()`/`SPI_Init()` on the
F4/stdperiph path — each dereferencing that `NULL` `SPI_TypeDef*`. This is a hard fault during
`fc_init.c`'s `init()`, before `mspSerialInit()`/`cliInit()` (and USB) ever run.

Checked against BF 4.5-maintenance's own `spiInitDevice()` (both
`drivers/stm32/bus_spi_ll.c:113` and `drivers/stm32/bus_spi_stdperiph.c`): both start with
`if (!spi->dev) { return; }`. EF's port was missing this guard in both files — a genuine,
previously-latent divergence from BF, invisible until now because every one of EF's other 465
targets always defines real SPI pins for every SPI device it declares. `STM32F7X2` is the
first target to compile an SPI device with no matching pins at all, and the first ever flashed
to real silicon (per #1409). Ported BF's guard verbatim to both files.

**Confirmed via LED-bisection instrumentation** (temporary, not part of this diff): boot
progressed past `ledInit()`/`timerInit()`/`serialInit()`/`motorDevInit()` but never reached a
checkpoint placed after the SPI-init block — pinpointing the hang to exactly this code, before
any hardware-level theory was confirmed.

## Root cause (1): hardcoded MPU6500 pins (kept from the original fix, insufficient alone)

On `FOXEERF722V4`'s actual wiring, PC4 is the board's real gyro INT/EXTI line (sensor-driven
output) and PB15 is SPI2 MOSI wired to an external flash chip — neither matches an MPU6500
CS/EXTI pair `target.h` assumed. This alone did not explain the boot hang (root cause (2) does)
but is still a real electrical-conflict risk worth removing, and matches BF's actual generic
target having zero hardcoded sensor pins.

### Trade-off carried over from the first pass (still applies)

Removing `USE_ACC`/`USE_GYRO`/`USE_ACC_SPI_MPU6500`/`USE_GYRO_SPI_MPU6500` means this generic
target has no CLI path to add gyro support back at runtime: `resource.h` has
`OWNER_MPU_CS`/`OWNER_MPU_EXTI` enum values, but `cli.c`'s `resourceTable[]` has no entry for
either (unlike `OWNER_BARO_CS`/`OWNER_COMPASS_CS`/`OWNER_SDCARD_CS`/`OWNER_FLASH_CS`/
`OWNER_OSD_CS`, which all do). Not a defect in this fix — the only fix available given EF's
current architecture. Closing this gap for real needs new `resourceTable` entries, a separate,
larger piece of work.

## Verification

- Build: `STM32F7X2 NERO FOXEERF722V4 HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7
  FOXEERF405 APEXF7 TMOTORF7` — 10/10 succeeded, 0 warnings.
- `SITL` — 1/1 succeeded (only the benign `lto-wrapper: warning: using serial compilation of N
  LTRANS jobs`).
- Host unit tests: `make clean_test && make test` — 48/48 test binaries pass, 0 FAILED
  assertions.
- Local CodeRabbit (`coderabbit review --agent --base upstream/master -c AGENTS.md`): 0
  findings, both passes (target.h-only, then full diff including the SPI fix).
- **Hardware-verified on real `FOXEERF722V4`: USB enumerates, CLI responds.** Board boots to
  `EmuFlight / STM32F7X2 (S7X2) 0.4.3 ... MSP API: 1.54` and the CLI autocomplete cache builds
  successfully.

## Scope

Two-file driver fix (`bus_spi_ll.c`, `bus_spi_stdperiph.c`) + one target.h cleanup + two
`-Wunused-parameter` fixes (`sensors/gyro.c`, `sensors/acceleration.c`, surfaced only by the
target.h change — no other target compiles with zero gyro/acc chips selected). No MSP surface
touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented initialization attempts for unavailable SPI hardware, avoiding potential startup failures.
  * Improved compatibility when accelerometer or gyroscope support is not enabled.
* **Configuration**
  * Updated STM32F7X2 defaults to avoid assuming specific onboard sensor wiring.
  * Sensor and gyro support can now be configured explicitly for the target hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->