### PR TITLE
fix(msp): correct USE_USE_BEESIGN typo in MSP_FC_VARIANT board-type byte

### DIFF
--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -453,7 +453,7 @@ bool mspCommonProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst, mspPostProcessFnPtr
 #else
         sbufWriteU16(dst, 0); // No other build targets currently have hardware revision detection.
 #endif
-#if defined(USE_OSD) && (defined(USE_MAX7456)  || defined(USE_USE_BEESIGN))
+#if defined(USE_OSD) && (defined(USE_MAX7456)  || defined(USE_OSD_BEESIGN))
         sbufWriteU8(dst, 2);  // 2 == FC with OSD
 #else
         sbufWriteU8(dst, 0);  // 0 == FC


### PR DESCRIPTION
AI Generated pull-request

## Summary

`USE_USE_BEESIGN` (double `USE_`) at `src/main/interface/msp.c:456` never matched any macro. The
intended check for BeeSign OSD support is `USE_OSD_BEESIGN`. Part of `MSP_FC_VARIANT`'s
board-type byte reported to the configurator.

## Behavior

Identical on all 3 current BeeSign targets (`HMBF4PRO_INTL`, `HMBF4PRO_US`, `NBDHMBF4PRO`) —
each also defines `USE_MAX7456`, satisfying the `||` either way. The typo would only cause a
misreport if EmuFlight ever ships a BeeSign-equipped board without a MAX7456 chip.

## Verification

- `make clean_test && make test`: 48/48 unit tests pass, no new warnings.
- Build clean on `HMBF4PRO_INTL`, `HMBF4PRO_US`, `NBDHMBF4PRO`, `FOXEERF722V4`.

Closes #1380.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected board capability reporting for targets with BEESIGN OSD hardware.
  - These targets are now correctly identified as flight controllers with OSD support instead of plain flight controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->