### PR TITLE
test(blackbox): add GPS mask + motor byte-sync regression tests

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -758,6 +758,18 @@ STATIC_UNIT_TESTED void unitTestWriteInterframe(void) {
     unitTestResetHistory();
     writeInterframe();
 }
+
+// Counts "motor" entries in blackboxMainFields[] whose condition currently evaluates true —
+// the same header-visible field count sendFieldDefinition() would emit for that field name.
+STATIC_UNIT_TESTED int unitTestCountVisibleMotorHeaderFields(void) {
+    int count = 0;
+    for (size_t i = 0; i < ARRAYLEN(blackboxMainFields); i++) {
+        if (strcmp(blackboxMainFields[i].name, "motor") == 0 && testBlackboxCondition(blackboxMainFields[i].condition)) {
+            count++;
+        }
+    }
+    return count;
+}
 #endif
 
 /* Write the contents of the global "slowHistory" to the log as an "S" frame. Because this data is logged so

--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -413,7 +413,7 @@ static bool blackboxIsOnlyLoggingIntraframes(void) {
     return blackboxConfig()->p_ratio == 0;
 }
 
-static bool isFieldEnabled(FlightLogFieldSelect_e field) {
+STATIC_UNIT_TESTED bool isFieldEnabled(FlightLogFieldSelect_e field) {
     return (blackboxConfig()->fields_disabled_mask & (1 << field)) == 0;
 }
 
@@ -738,6 +738,27 @@ static void writeInterframe(void) {
     blackboxHistory[0] = ((blackboxHistory[0] - blackboxHistoryRing + 1) % 3) + blackboxHistoryRing;
     blackboxLoggedAnyFrames = true;
 }
+
+#ifdef UNIT_TEST
+// Points the history ring at zeroed state so a test can drive write*Frame() byte output
+// directly, without a full logging-session bring-up (blackboxStart()/blackboxDeviceOpen()).
+static void unitTestResetHistory(void) {
+    memset(blackboxHistoryRing, 0, sizeof(blackboxHistoryRing));
+    blackboxHistory[0] = &blackboxHistoryRing[0];
+    blackboxHistory[1] = &blackboxHistoryRing[1];
+    blackboxHistory[2] = &blackboxHistoryRing[2];
+}
+
+STATIC_UNIT_TESTED void unitTestWriteIntraframe(void) {
+    unitTestResetHistory();
+    writeIntraframe();
+}
+
+STATIC_UNIT_TESTED void unitTestWriteInterframe(void) {
+    unitTestResetHistory();
+    writeInterframe();
+}
+#endif
 
 /* Write the contents of the global "slowHistory" to the log as an "S" frame. Because this data is logged so
  * infrequently, delta updates are not reasonable, so we log independent frames. */

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -86,6 +86,7 @@ STATIC_UNIT_TESTED bool testBlackboxCondition(FlightLogFieldCondition condition)
 STATIC_UNIT_TESTED bool isFieldEnabled(FlightLogFieldSelect_e field);
 STATIC_UNIT_TESTED void unitTestWriteIntraframe(void);
 STATIC_UNIT_TESTED void unitTestWriteInterframe(void);
+STATIC_UNIT_TESTED int unitTestCountVisibleMotorHeaderFields(void);
 extern int32_t blackboxSInterval;
 extern int32_t blackboxSlowFrameIterationTimer;
 #endif

--- a/src/main/blackbox/blackbox.h
+++ b/src/main/blackbox/blackbox.h
@@ -83,6 +83,9 @@ STATIC_UNIT_TESTED bool writeSlowFrameIfNeeded(void);
 STATIC_UNIT_TESTED void blackboxAdvanceIterationTimers(void);
 STATIC_UNIT_TESTED void blackboxBuildConditionCache(void);
 STATIC_UNIT_TESTED bool testBlackboxCondition(FlightLogFieldCondition condition);
+STATIC_UNIT_TESTED bool isFieldEnabled(FlightLogFieldSelect_e field);
+STATIC_UNIT_TESTED void unitTestWriteIntraframe(void);
+STATIC_UNIT_TESTED void unitTestWriteInterframe(void);
 extern int32_t blackboxSInterval;
 extern int32_t blackboxSlowFrameIterationTimer;
 #endif

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -399,7 +399,11 @@ static bool stubSensorsPresent = false;
 static bool stubFeatureEnabled = false;
 static bool stubRssiConfigured = false;
 bool sensors(uint32_t) {return stubSensorsPresent;}
-void serialWrite(serialPort_t *, uint8_t) {}
+// TestMotorFieldByteSync resets this before each capture window; no other test writes.
+static int capturedSerialByteCount = 0;
+void serialWrite(serialPort_t *, uint8_t) {
+    capturedSerialByteCount++;
+}
 uint32_t serialTxBytesFree(const serialPort_t *) {return 0;}
 bool isSerialTransmitBufferEmpty(const serialPort_t *) {return false;}
 bool feature(uint32_t) {return stubFeatureEnabled;}
@@ -546,6 +550,13 @@ TEST(BlackboxTest, TestFieldMasking)
     EXPECT_EQ(false, testBlackboxCondition(FLIGHT_LOG_FIELD_CONDITION_AT_LEAST_MOTORS_1));
     EXPECT_EQ(true, testBlackboxCondition(FLIGHT_LOG_FIELD_CONDITION_DEBUG));
 
+    // GPS has no FLIGHT_LOG_FIELD_CONDITION_* wrapper; call sites check isFieldEnabled() directly
+    blackboxConfigMutable()->fields_disabled_mask = 0;
+    EXPECT_EQ(true, isFieldEnabled(FLIGHT_LOG_FIELD_SELECT_GPS));
+    blackboxConfigMutable()->fields_disabled_mask = (1 << FLIGHT_LOG_FIELD_SELECT_GPS);
+    EXPECT_EQ(false, isFieldEnabled(FLIGHT_LOG_FIELD_SELECT_GPS));
+    EXPECT_EQ(true, isFieldEnabled(FLIGHT_LOG_FIELD_SELECT_DEBUG));
+
     // Reset all global stub state so no later test observes this fixture
     blackboxConfigMutable()->fields_disabled_mask = 0;
     blackboxBuildConditionCache();
@@ -556,4 +567,45 @@ TEST(BlackboxTest, TestFieldMasking)
     stubFeatureEnabled = false;
     stubRssiConfigured = false;
     debugMode = 0;
+}
+
+TEST(BlackboxTest, TestMotorFieldByteSync)
+{
+    // Regression test for a header/data-write desync class: a mask that hides a field's
+    // header must also stop write*Frame() emitting that field's bytes, not just flip the
+    // condition-cache bit.
+    static pidProfile_t testPidProfile = {};
+    testPidProfile.pid[PID_ROLL].D = 1;
+    testPidProfile.pid[PID_PITCH].D = 1;
+    testPidProfile.pid[PID_YAW].D = 1;
+    currentPidProfile = &testPidProfile;
+
+    blackboxConfigMutable()->fields_disabled_mask = 0;
+    blackboxBuildConditionCache();
+    capturedSerialByteCount = 0;
+    unitTestWriteIntraframe();
+    const int intraBytesWithMotor = capturedSerialByteCount;
+
+    capturedSerialByteCount = 0;
+    unitTestWriteInterframe();
+    const int interBytesWithMotor = capturedSerialByteCount;
+
+    blackboxConfigMutable()->fields_disabled_mask = (1 << FLIGHT_LOG_FIELD_SELECT_MOTOR);
+    blackboxBuildConditionCache();
+    capturedSerialByteCount = 0;
+    unitTestWriteIntraframe();
+    const int intraBytesWithoutMotor = capturedSerialByteCount;
+
+    capturedSerialByteCount = 0;
+    unitTestWriteInterframe();
+    const int interBytesWithoutMotor = capturedSerialByteCount;
+
+    // getMotorCount() stub returns 4: motor[0] (1 VB byte) + 3 deltas (1 VB byte each) = 4 bytes,
+    // for both intraframe's raw encoding and interframe's average-predictor encoding.
+    EXPECT_EQ(4, intraBytesWithMotor - intraBytesWithoutMotor);
+    EXPECT_EQ(4, interBytesWithMotor - interBytesWithoutMotor);
+
+    blackboxConfigMutable()->fields_disabled_mask = 0;
+    blackboxBuildConditionCache();
+    currentPidProfile = NULL;
 }

--- a/src/test/unit/blackbox_unittest.cc
+++ b/src/test/unit/blackbox_unittest.cc
@@ -574,6 +574,15 @@ TEST(BlackboxTest, TestMotorFieldByteSync)
     // Regression test for a header/data-write desync class: a mask that hides a field's
     // header must also stop write*Frame() emitting that field's bytes, not just flip the
     // condition-cache bit.
+
+    // Reset shared global stub state before use, not just at teardown — matches TestFieldMasking.
+    batteryConfigMutable()->voltageMeterSource = VOLTAGE_METER_NONE;
+    batteryConfigMutable()->currentMeterSource = CURRENT_METER_NONE;
+    stubSensorsPresent = false;
+    stubFeatureEnabled = false;
+    stubRssiConfigured = false;
+    debugMode = 0;
+
     static pidProfile_t testPidProfile = {};
     testPidProfile.pid[PID_ROLL].D = 1;
     testPidProfile.pid[PID_PITCH].D = 1;
@@ -582,6 +591,7 @@ TEST(BlackboxTest, TestMotorFieldByteSync)
 
     blackboxConfigMutable()->fields_disabled_mask = 0;
     blackboxBuildConditionCache();
+    const int headerFieldsWithMotor = unitTestCountVisibleMotorHeaderFields();
     capturedSerialByteCount = 0;
     unitTestWriteIntraframe();
     const int intraBytesWithMotor = capturedSerialByteCount;
@@ -592,6 +602,7 @@ TEST(BlackboxTest, TestMotorFieldByteSync)
 
     blackboxConfigMutable()->fields_disabled_mask = (1 << FLIGHT_LOG_FIELD_SELECT_MOTOR);
     blackboxBuildConditionCache();
+    const int headerFieldsWithoutMotor = unitTestCountVisibleMotorHeaderFields();
     capturedSerialByteCount = 0;
     unitTestWriteIntraframe();
     const int intraBytesWithoutMotor = capturedSerialByteCount;
@@ -604,6 +615,12 @@ TEST(BlackboxTest, TestMotorFieldByteSync)
     // for both intraframe's raw encoding and interframe's average-predictor encoding.
     EXPECT_EQ(4, intraBytesWithMotor - intraBytesWithoutMotor);
     EXPECT_EQ(4, interBytesWithMotor - interBytesWithoutMotor);
+
+    // Header field count (blackboxMainFields[], same table sendFieldDefinition() emits from)
+    // must drop in lockstep with the serialized byte count, not just the byte count alone.
+    EXPECT_EQ(4, headerFieldsWithMotor);
+    EXPECT_EQ(0, headerFieldsWithoutMotor);
+    EXPECT_EQ(headerFieldsWithMotor - headerFieldsWithoutMotor, intraBytesWithMotor - intraBytesWithoutMotor);
 
     blackboxConfigMutable()->fields_disabled_mask = 0;
     blackboxBuildConditionCache();


### PR DESCRIPTION
AI Generated pull-request

## Summary

Closes emuflight/EmuFlight#1347's two deferred test-coverage gaps from PR #1332 (blackbox field masking).

- `isFieldEnabled()` marked `STATIC_UNIT_TESTED`; `TestFieldMasking` now covers the GPS mask bit directly, since GPS has no `FLIGHT_LOG_FIELD_CONDITION_*` wrapper and is checked at the call site instead of the condition cache.
- New `unitTestWriteIntraframe()`/`unitTestWriteInterframe()` `UNIT_TEST`-only hooks drive `write*Frame()` from a zeroed history ring without a full logging-session bring-up (`blackboxStart()`/`blackboxDeviceOpen()`).
- New `TestMotorFieldByteSync` captures actual `serialWrite()` byte counts with the motor field masked vs. unmasked, asserting the header-visible field count and the frame's byte output stay in sync — the exact bug class fixed by PR #1332 (header omitted motor fields when masked, `writeIntraframe()`/`writeInterframe()` still wrote them unconditionally).

## Test plan

- [x] `make clean_test && make test` — all suites pass, including the new `BlackboxTest.TestMotorFieldByteSync` and the extended `TestFieldMasking`.
- [x] Verified `TestMotorFieldByteSync` actually catches the historical regression: temporarily reintroduced the unconditional motor write (dropped the `AT_LEAST_MOTORS_1` gate), confirmed the test fails with `Actual: 0, Expected: 4`, then reverted and confirmed a clean pass.
- [x] `make HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 SITL` — all 9 targets build clean, no warnings introduced.
- [ ] No hardware verification needed — test-only change, no firmware runtime behavior modified outside `UNIT_TEST` builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Blackbox logging when fields are disabled by masks.
  * Ensured removing the motor field consistently reduces recorded data in both intra-frame and inter-frame logs.
  * Improved accuracy of captured Blackbox output for masked telemetry fields.
  * Kept Blackbox headers synchronized with the fields included in recorded frames.

* **Tests**
  * Added regression coverage for field masking, motor-field data synchronization, and header accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->