### PR TITLE
refactor: guard softserial RX IOInit in duplex shared-pin mode

### DIFF
--- a/src/main/drivers/serial_softserial.c
+++ b/src/main/drivers/serial_softserial.c
@@ -227,7 +227,10 @@ serialPort_t *openSoftSerial(softSerialPortIndex_e portIndex, serialReceiveCallb
             }
             softSerial->rxIO = rxIO;
             softSerial->timerHardware = timerRx;
-            IOInit(rxIO, OWNER_SERIAL_RX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
+            // TX-branch IOInit() below would otherwise overwrite this in duplex mode on a shared pin.
+            if (!((mode & MODE_TX) && rxIO == txIO)) {
+                IOInit(rxIO, OWNER_SERIAL_RX, RESOURCE_INDEX(portIndex + RESOURCE_SOFT_OFFSET));
+            }
         }
         if (mode & MODE_TX) {
             // Need a pin on TX


### PR DESCRIPTION
AI Generated pull-request

## Summary
`openSoftSerial()` calls `IOInit(rxIO, OWNER_SERIAL_RX, ...)` unconditionally in its `mode & MODE_RX` branch. BF 4.5-maintenance guards this call with `if (!((mode & MODE_TX) && rxIO == txIO))` when duplex mode shares one physical pin for RX and TX. This PR ports that same guard for source-level parity with BF.

**Correction after further analysis: this has no observable runtime effect.** Whenever the guard actually suppresses the RX `IOInit()` call (duplex mode, `rxIO == txIO`), the unconditional TX-branch `IOInit(txIO, OWNER_SERIAL_TX, ...)` a few lines later runs on the exact same pin regardless of the guard, and `IOInit()` has no side effect besides the two-field struct write (`ioRec->owner`, `ioRec->index`). The final ownership-table value for that pin is `OWNER_SERIAL_TX` in both the guarded and unguarded code, in every case — nothing reads the table between the two calls. IT#1407's original claim that this changes what the `resource` CLI command reports does not hold up; the CLI output is identical either way.

This PR is kept as a harmless BF-parity / redundant-write-elimination cleanup, not a functional bug fix. IT#1407 is closed as not a real bug — see comment there.

## Test plan
- [x] Unit tests: `make clean_test && make test` — PASS, no failures
- [x] Build: `make HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 STELLARH7DEV SITL` — 10/10 succeeded, no compiler warnings on the changed file
- [x] CI: all checks pass (test, sitl, Codacy, CodeRabbit, all 11 build-target groups)
- [ ] Hardware verified: n/a — no functional behavior change