### PR TITLE
refactor(drivers): migrate sdcard.c (SPI mode) to spiSequence()/extDevice_t

### DIFF
--- a/src/main/drivers/bus.h
+++ b/src/main/drivers/bus.h
@@ -139,8 +139,8 @@ typedef struct extDevice_s {
  * negateCS controls whether CS is deasserted between segments.
  * callback (if non-NULL) is called after each segment completes; its return value
  * may request BUS_BUSY (repeat), BUS_ABORT (skip remaining), or BUS_READY (advance).
- * Stage M.1 sync path advances unconditionally; BUS_ABORT/BUS_BUSY only honored
- * by the async DMA path (Stage M.3).
+ * Both the polled path (bus_spi_ll.c) and the async DMA path (bus_spi.c) honor all
+ * three return values.
  */
 typedef struct busSegment_s {
     union {

--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -27,7 +27,6 @@
 
 #include "drivers/nvic.h"
 #include "drivers/io.h"
-#include "dma.h"
 
 #include "drivers/bus_spi.h"
 #include "drivers/time.h"
@@ -38,9 +37,6 @@
 #ifdef AFATFS_USE_INTROSPECTIVE_LOGGING
 #define SDCARD_PROFILING
 #endif
-
-#define SET_CS_HIGH                                 IOHi(sdcard.chipSelectPin)
-#define SET_CS_LOW                                  IOLo(sdcard.chipSelectPin)
 
 #define SDCARD_INIT_NUM_DUMMY_BYTES                 10
 #define SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY     8
@@ -103,14 +99,11 @@ typedef struct sdcard_t {
 #ifdef SDCARD_PROFILING
     sdcard_profilerCallback_c profiler;
 #endif
-    SPI_TypeDef *instance;
+    extDevice_t dev;
+    int8_t idleCount;
     bool enabled;
     bool detectionInverted;
-    bool useDMAForTx;
     IO_t cardDetectPin;
-    IO_t chipSelectPin;
-    dmaChannelDescriptor_t * dma;
-    uint8_t dmaChannel;
 } sdcard_t;
 
 static sdcard_t sdcard;
@@ -153,16 +146,12 @@ bool sdcard_isFunctional(void) {
     return sdcard.state != SDCARD_STATE_NOT_PRESENT;
 }
 
-static void sdcard_select(void) {
-    SET_CS_LOW;
-}
-
 static void sdcard_deselect(void) {
     // As per the SD-card spec, give the card 8 dummy clocks so it can finish its operation
-    //spiTransferByte(sdcard.instance, 0xFF);
-    while (spiIsBusBusy(sdcard.instance)) {
-    }
-    SET_CS_HIGH;
+    spiWait(&sdcard.dev);
+    delayMicroseconds(10);
+    // Negate CS
+    spiRelease(&sdcard.dev);
 }
 
 /**
@@ -177,7 +166,7 @@ static void sdcard_reset(void) {
         return;
     }
     if (sdcard.state >= SDCARD_STATE_READY) {
-        spiSetDivisor(sdcard.instance, SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER);
+        spiSetClkDivisor(&sdcard.dev, SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER);
     }
     sdcard.failureCount++;
     if (sdcard.failureCount >= SDCARD_MAX_CONSECUTIVE_FAILURES) {
@@ -188,35 +177,93 @@ static void sdcard_reset(void) {
     }
 }
 
+// Called in ISR context
+// Wait until idle indicated by a read value of SDCARD_IDLE_TOKEN
+busStatus_e sdcard_callbackIdle(uint32_t arg) {
+    sdcard_t *sdcard = (sdcard_t *)arg;
+    extDevice_t *dev = &sdcard->dev;
+
+    uint8_t idleByte = dev->bus->curSegment->u.buffers.rxData[0];
+
+    if (idleByte == SDCARD_IDLE_TOKEN) {
+        // Default for next call to sdcard_callbackNotIdle()
+        sdcard->idleCount = SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY;
+        return BUS_READY;
+    }
+
+    if (--sdcard->idleCount <= 0) {
+        dev->bus->curSegment->u.buffers.rxData[0] = 0x00;
+        return BUS_ABORT;
+    }
+
+    return BUS_BUSY;
+}
+
+// Called in ISR context
+// Wait until idle is no longer indicated by a read value of SDCARD_IDLE_TOKEN
+busStatus_e sdcard_callbackNotIdle(uint32_t arg) {
+    sdcard_t *sdcard = (sdcard_t *)arg;
+    extDevice_t *dev = &sdcard->dev;
+
+    uint8_t idleByte = dev->bus->curSegment->u.buffers.rxData[0];
+
+    if (idleByte != SDCARD_IDLE_TOKEN) {
+        return BUS_READY;
+    }
+
+    if (sdcard->idleCount-- <= 0) {
+        return BUS_ABORT;
+    }
+
+    return BUS_BUSY;
+}
+
 /**
  * The SD card spec requires 8 clock cycles to be sent by us on the bus after most commands so it can finish its
  * processing of that command. The easiest way for us to do this is to just wait for the bus to become idle before
  * we transmit a command, sending at least 8-bits onto the bus when we do so.
  */
 static bool sdcard_waitForIdle(int maxBytesToWait) {
-    while (maxBytesToWait > 0) {
-        uint8_t b = spiTransferByte(sdcard.instance, 0xFF);
-        if (b == 0xFF) {
-            return true;
-        }
-        maxBytesToWait--;
-    }
-    return false;
+    uint8_t idleByte;
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, &idleByte}, sizeof(idleByte), false, sdcard_callbackIdle},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    sdcard.idleCount = maxBytesToWait;
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
+    return (idleByte == SDCARD_IDLE_TOKEN);
 }
 
 /**
- * Wait for up to maxDelay 0xFF idle bytes to arrive from the card, returning the first non-idle byte found.
+ * Wait for up to maxDelay SDCARD_IDLE_TOKEN idle bytes to arrive from the card, returning the first non-idle byte found.
  *
- * Returns 0xFF on failure.
+ * Returns SDCARD_IDLE_TOKEN on failure.
  */
 static uint8_t sdcard_waitForNonIdleByte(int maxDelay) {
-    for (int i = 0; i < maxDelay + 1; i++) { // + 1 so we can wait for maxDelay '0xFF' bytes before reading a response byte afterwards
-        uint8_t response = spiTransferByte(sdcard.instance, 0xFF);
-        if (response != 0xFF) {
-            return response;
-        }
-    }
-    return 0xFF;
+    uint8_t idleByte;
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, &idleByte}, sizeof(idleByte), false, sdcard_callbackNotIdle},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    sdcard.idleCount = maxDelay;
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
+    return idleByte;
 }
 
 /**
@@ -224,12 +271,10 @@ static uint8_t sdcard_waitForNonIdleByte(int maxDelay) {
  * with the given argument, waits up to SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY bytes for a reply, and returns the
  * first non-0xFF byte of the reply.
  *
- * You must select the card first with sdcard_select() and deselect it afterwards with sdcard_deselect().
- *
- * Upon failure, 0xFF is returned.
+ * Upon failure, SDCARD_IDLE_TOKEN is returned.
  */
 static uint8_t sdcard_sendCommand(uint8_t commandCode, uint32_t commandArgument) {
-    const uint8_t command[6] = {
+    uint8_t command[6] = {
         0x40 | commandCode,
         commandArgument >> 24,
                         commandArgument >> 16,
@@ -238,15 +283,31 @@ static uint8_t sdcard_sendCommand(uint8_t commandCode, uint32_t commandArgument)
                         0x95 /* Static CRC. This CRC is valid for CMD0 with a 0 argument, and CMD8 with 0x1AB argument, which are the only
         commands that require a CRC */
     };
+
+    uint8_t idleByte;
+    uint8_t cmdResponse;
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, &idleByte}, sizeof(idleByte), false, sdcard_callbackIdle},
+        {.u.buffers = {command, NULL}, sizeof(command), false, NULL},
+        {.u.buffers = {NULL, &cmdResponse}, sizeof(cmdResponse), false, sdcard_callbackNotIdle},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    sdcard.idleCount = SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY;
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
     // Go ahead and send the command even if the card isn't idle if this is the reset command
-    if (!sdcard_waitForIdle(SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY) && commandCode != SDCARD_COMMAND_GO_IDLE_STATE)
-        return 0xFF;
-    spiTransfer(sdcard.instance, command, NULL, sizeof(command));
-    /*
-     * The card can take up to SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY bytes to send the response, in the meantime
-     * it'll transmit 0xFF filler bytes.
-     */
-    return sdcard_waitForNonIdleByte(SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY);
+    if ((idleByte != SDCARD_IDLE_TOKEN) && commandCode != SDCARD_COMMAND_GO_IDLE_STATE) {
+        return SDCARD_IDLE_TOKEN;
+    }
+
+    return cmdResponse;
 }
 
 static uint8_t sdcard_sendAppCommand(uint8_t commandCode, uint32_t commandArgument) {
@@ -261,14 +322,23 @@ static uint8_t sdcard_sendAppCommand(uint8_t commandCode, uint32_t commandArgume
 static bool sdcard_validateInterfaceCondition(void) {
     uint8_t ifCondReply[4];
     sdcard.version = 0;
-    sdcard_select();
     uint8_t status = sdcard_sendCommand(SDCARD_COMMAND_SEND_IF_COND, (SDCARD_VOLTAGE_ACCEPTED_2_7_to_3_6 << 8) | SDCARD_IF_COND_CHECK_PATTERN);
     // Don't deselect the card right away, because we'll want to read the rest of its reply if it's a V2 card
     if (status == (SDCARD_R1_STATUS_BIT_ILLEGAL_COMMAND | SDCARD_R1_STATUS_BIT_IDLE)) {
         // V1 cards don't support this command
         sdcard.version = 1;
     } else if (status == SDCARD_R1_STATUS_BIT_IDLE) {
-        spiTransfer(sdcard.instance, NULL, ifCondReply, sizeof(ifCondReply));
+        // Note that this does not release the CS at the end of the transaction
+        busSegment_t segments[] = {
+            {.u.buffers = {NULL, ifCondReply}, sizeof(ifCondReply), false, NULL},
+            {.u.link = {NULL, NULL}, 0, true, NULL},
+        };
+
+        spiSequence(&sdcard.dev, &segments[0]);
+
+        // Block pending completion of SPI access
+        spiWait(&sdcard.dev);
+
         /*
          * We don't bother to validate the SDCard's operating voltage range since the spec requires it to accept our
          * 3.3V, but do check that it echoed back our check pattern properly.
@@ -282,10 +352,20 @@ static bool sdcard_validateInterfaceCondition(void) {
 }
 
 static bool sdcard_readOCRRegister(uint32_t *result) {
-    sdcard_select();
     uint8_t status = sdcard_sendCommand(SDCARD_COMMAND_READ_OCR, 0);
     uint8_t response[4];
-    spiTransfer(sdcard.instance, NULL, response, sizeof(response));
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, response}, sizeof(response), false, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
     if (status == 0) {
         sdcard_deselect();
         *result = (response[0] << 24) | (response[1] << 16) | (response[2] << 8) | response[3];
@@ -302,38 +382,79 @@ typedef enum {
     SDCARD_RECEIVE_ERROR
 } sdcardReceiveBlockStatus_e;
 
+// Called in ISR context
+// Wait until the arrival of the SDCARD_SINGLE_BLOCK_READ_START_TOKEN token
+busStatus_e sdcard_callbackNotIdleDataBlock(uint32_t arg) {
+    sdcard_t *sdcard = (sdcard_t *)arg;
+    extDevice_t *dev = &sdcard->dev;
+
+    uint8_t idleByte = dev->bus->curSegment->u.buffers.rxData[0];
+
+    if (idleByte == SDCARD_SINGLE_BLOCK_READ_START_TOKEN) {
+        return BUS_READY;
+    }
+
+    if (idleByte != SDCARD_IDLE_TOKEN) {
+        return BUS_ABORT;
+    }
+
+    if (sdcard->idleCount-- <= 0) {
+        return BUS_ABORT;
+    }
+
+    return BUS_BUSY;
+}
+
 /**
  * Attempt to receive a data block from the SD card.
  *
  * Return true on success, otherwise the card has not responded yet and you should retry later.
  */
 static sdcardReceiveBlockStatus_e sdcard_receiveDataBlock(uint8_t *buffer, int count) {
-    uint8_t dataToken = sdcard_waitForNonIdleByte(8);
-    if (dataToken == 0xFF) {
+    uint8_t dataToken;
+
+    sdcard.idleCount = SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY;
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, &dataToken}, sizeof(dataToken), false, sdcard_callbackNotIdleDataBlock},
+        {.u.buffers = {NULL, buffer}, count, false, NULL},
+        // Discard trailing CRC, we don't care
+        {.u.buffers = {NULL, NULL}, 2, false, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
+    switch (dataToken) {
+    case SDCARD_IDLE_TOKEN:
         return SDCARD_RECEIVE_BLOCK_IN_PROGRESS;
-    }
-    if (dataToken != SDCARD_SINGLE_BLOCK_READ_START_TOKEN) {
+    case SDCARD_SINGLE_BLOCK_READ_START_TOKEN:
+        return SDCARD_RECEIVE_SUCCESS;
+    default:
         return SDCARD_RECEIVE_ERROR;
     }
-    spiTransfer(sdcard.instance, NULL, buffer, count);
-    // Discard trailing CRC, we don't care
-    spiTransferByte(sdcard.instance, 0xFF);
-    spiTransferByte(sdcard.instance, 0xFF);
-    return SDCARD_RECEIVE_SUCCESS;
 }
 
 static bool sdcard_sendDataBlockFinish(void) {
-#if defined(USE_HAL_DRIVER) && !defined(STM32H7)
-    // Drain anything left in the Rx FIFO (we didn't read it during the write)
-    //This is necessary here as when using msc there is timing issue
-    while (LL_SPI_IsActiveFlag_RXNE(sdcard.instance)) {
-        sdcard.instance->DR;
-    }
-#endif
-    // Send a dummy CRC
-    spiTransferByte(sdcard.instance, 0x00);
-    spiTransferByte(sdcard.instance, 0x00);
-    uint8_t dataResponseToken = spiTransferByte(sdcard.instance, 0xFF);
+    uint16_t dummyCRC = 0;
+    uint8_t dataResponseToken;
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {(uint8_t *)&dummyCRC, NULL}, sizeof(dummyCRC), false, NULL},
+        {.u.buffers = {NULL, &dataResponseToken}, sizeof(dataResponseToken), false, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
     /*
      * Check if the card accepted the write (no CRC error / no address error)
      *
@@ -352,58 +473,26 @@ static bool sdcard_sendDataBlockFinish(void) {
 /**
  * Begin sending a buffer of SDCARD_BLOCK_SIZE bytes to the SD card.
  */
-static void sdcard_sendDataBlockBegin(const uint8_t *buffer, bool multiBlockWrite) {
-    // Card wants 8 dummy clock cycles between the write command's response and a data block beginning:
-    spiTransferByte(sdcard.instance, 0xFF);
-    spiTransferByte(sdcard.instance, multiBlockWrite ? SDCARD_MULTIPLE_BLOCK_WRITE_START_TOKEN : SDCARD_SINGLE_BLOCK_WRITE_START_TOKEN);
-    if (sdcard.useDMAForTx) {
-#if defined(USE_HAL_DRIVER) && !defined(STM32H7)
-        LL_DMA_InitTypeDef init;
-        LL_DMA_StructInit(&init);
-        init.Channel = dmaGetChannel(sdcard.dmaChannel);
-        init.Mode = LL_DMA_MODE_NORMAL;
-        init.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
-        init.PeriphOrM2MSrcAddress = (uint32_t)&sdcard.instance->DR;
-        init.Priority = LL_DMA_PRIORITY_LOW;
-        init.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-        init.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
-        init.MemoryOrM2MDstAddress = (uint32_t)buffer;
-        init.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
-        init.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-        init.NbData = SDCARD_BLOCK_SIZE;
-        LL_DMA_DeInit(sdcard.dma->dma, sdcard.dma->stream);
-        LL_DMA_Init(sdcard.dma->dma, sdcard.dma->stream, &init);
-        LL_DMA_EnableStream(sdcard.dma->dma, sdcard.dma->stream);
-        LL_SPI_EnableDMAReq_TX(sdcard.instance);
-#elif !defined(STM32H7)
-        DMA_InitTypeDef init;
-        DMA_StructInit(&init);
-#ifdef STM32F4
-        init.DMA_Channel = dmaGetChannel(sdcard.dmaChannel);
-        init.DMA_Memory0BaseAddr = (uint32_t) buffer;
-        init.DMA_DIR = DMA_DIR_MemoryToPeripheral;
-#else
-        init.DMA_M2M = DMA_M2M_Disable;
-        init.DMA_MemoryBaseAddr = (uint32_t) buffer;
-        init.DMA_DIR = DMA_DIR_PeripheralDST;
-#endif
-        init.DMA_PeripheralBaseAddr = (uint32_t) &sdcard.instance->DR;
-        init.DMA_Priority = DMA_Priority_Low;
-        init.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
-        init.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
-        init.DMA_MemoryInc = DMA_MemoryInc_Enable;
-        init.DMA_MemoryDataSize = DMA_MemoryDataSize_Byte;
-        init.DMA_BufferSize = SDCARD_BLOCK_SIZE;
-        init.DMA_Mode = DMA_Mode_Normal;
-        DMA_DeInit(sdcard.dma->ref);
-        DMA_Init(sdcard.dma->ref, &init);
-        DMA_Cmd(sdcard.dma->ref, ENABLE);
-        SPI_I2S_DMACmd(sdcard.instance, SPI_I2S_DMAReq_Tx, ENABLE);
-#endif
-    } else {
-        // Send the first chunk now
-        spiTransfer(sdcard.instance, buffer, NULL, SDCARD_NON_DMA_CHUNK_SIZE);
-    }
+static void sdcard_sendDataBlockBegin(uint8_t *buffer, bool multiBlockWrite) {
+    static uint8_t token;
+
+    token = multiBlockWrite ? SDCARD_MULTIPLE_BLOCK_WRITE_START_TOKEN : SDCARD_SINGLE_BLOCK_WRITE_START_TOKEN;
+
+    // Note that this does not release the CS at the end of the transaction
+    static busSegment_t segments[] = {
+        // Write a single 0xff
+        {.u.buffers = {NULL, NULL}, 1, false, NULL},
+        {.u.buffers = {&token, NULL}, sizeof(token), false, NULL},
+        {.u.buffers = {NULL, NULL}, 0, false, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    segments[2].u.buffers.txData = buffer;
+    segments[2].len = spiUseDMA(&sdcard.dev) ? SDCARD_BLOCK_SIZE : SDCARD_NON_DMA_CHUNK_SIZE;
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Don't block pending completion of SPI access
 }
 
 static bool sdcard_receiveCID(void) {
@@ -429,7 +518,6 @@ static bool sdcard_receiveCID(void) {
 static bool sdcard_fetchCSD(void) {
     uint32_t readBlockLen, blockCount, blockCountMult;
     uint64_t capacityBytes;
-    sdcard_select();
     /* The CSD command's data block should always arrive within 8 idle clock cycles (SD card spec). This is because
      * the information about card latency is stored in the CSD register itself, so we can't use that yet!
      */
@@ -466,20 +554,10 @@ static bool sdcard_fetchCSD(void) {
  * Returns true if the card has finished its init process.
  */
 static bool sdcard_checkInitDone(void) {
-    sdcard_select();
     uint8_t status = sdcard_sendAppCommand(SDCARD_ACOMMAND_SEND_OP_COND, sdcard.version == 2 ? 1 << 30 /* We support high capacity cards */ : 0);
     sdcard_deselect();
     // When card init is complete, the idle bit in the response becomes zero.
     return status == 0x00;
-}
-
-// sdcard_init() can be called from both boot init and the USB MSC passthrough path -- a
-// stream already held by this same owner must be re-claimable.
-static bool sdcardDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
-    if (dmaGetOwner(identifier) == owner && dmaGetResourceIndex(identifier) == resourceIndex) {
-        return true;
-    }
-    return dmaAllocate(identifier, owner, resourceIndex);
 }
 
 /**
@@ -491,32 +569,16 @@ void sdcard_init(const sdcardConfig_t *config) {
         sdcard.state = SDCARD_STATE_NOT_PRESENT;
         return;
     }
-    sdcard.instance = spiInstanceByDevice(config->device);
-#if defined(STM32H7)
-    sdcard.useDMAForTx = false;
-#else
-    sdcard.useDMAForTx = config->useDma;
-#endif
-    if (sdcard.useDMAForTx) {
-        if (sdcardDmaClaim(config->dmaIdentifier, OWNER_SDCARD, 0)) {
-#if defined(STM32F4) || defined(STM32F7)
-            sdcard.dmaChannel = config->dmaChannel;
-#endif
-            sdcard.dma = dmaGetDescriptorByIdentifier(config->dmaIdentifier);
-            dmaEnable(config->dmaIdentifier);
-        } else {
-            // Stream already owned by another peripheral -- fall back to polled SPI
-            // rather than losing the card (and blackbox logging) entirely.
-            sdcard.useDMAForTx = false;
-        }
-    }
+    spiSetBusInstance(&sdcard.dev, config->device);
     if (config->chipSelectTag) {
-        sdcard.chipSelectPin = IOGetByTag(config->chipSelectTag);
-        IOInit(sdcard.chipSelectPin, OWNER_SDCARD_CS, 0);
-        IOConfigGPIO(sdcard.chipSelectPin, SPI_IO_CS_CFG);
+        sdcard.dev.busType_u.spi.csnPin = IOGetByTag(config->chipSelectTag);
+        IOInit(sdcard.dev.busType_u.spi.csnPin, OWNER_SDCARD_CS, 0);
+        IOConfigGPIO(sdcard.dev.busType_u.spi.csnPin, SPI_IO_CS_CFG);
     } else {
-        sdcard.chipSelectPin = IO_NONE;
+        sdcard.dev.busType_u.spi.csnPin = IO_NONE;
     }
+    // Set the callback argument when calling back to this driver for DMA completion
+    sdcard.dev.callbackArg = (uint32_t)&sdcard;
     if (config->cardDetectTag) {
         sdcard.cardDetectPin = IOGetByTag(config->cardDetectTag);
         sdcard.detectionInverted = config->cardDetectInverted;
@@ -525,15 +587,23 @@ void sdcard_init(const sdcardConfig_t *config) {
         sdcard.detectionInverted = false;
     }
     // Max frequency is initially 400kHz
-    spiSetDivisor(sdcard.instance, SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER);
+    spiSetClkDivisor(&sdcard.dev, SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER);
     // SDCard wants 1ms minimum delay after power is applied to it
     delay(1000);
     // Transmit at least 74 dummy clock cycles with CS high so the SD card can start up
-    SET_CS_HIGH;
-    spiTransfer(sdcard.instance, NULL, NULL, SDCARD_INIT_NUM_DUMMY_BYTES);
+    IOHi(sdcard.dev.busType_u.spi.csnPin);
+
+    // Note that CS is not asserted for this transaction
+    busSegment_t segments[] = {
+        {.u.buffers = {NULL, NULL}, SDCARD_INIT_NUM_DUMMY_BYTES, true, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
     // Wait for that transmission to finish before we enable the SDCard, so it receives the required number of cycles:
     int time = 100000;
-    while (spiIsBusBusy(sdcard.instance)) {
+    while (spiIsBusy(&sdcard.dev)) {
         if (time-- == 0) {
             sdcard.state = SDCARD_STATE_NOT_PRESENT;
             sdcard.failureCount++;
@@ -546,7 +616,6 @@ void sdcard_init(const sdcardConfig_t *config) {
 }
 
 static bool sdcard_setBlockLength(uint32_t blockLen) {
-    sdcard_select();
     uint8_t status = sdcard_sendCommand(SDCARD_COMMAND_SET_BLOCKLEN, blockLen);
     sdcard_deselect();
     return status == 0;
@@ -570,12 +639,24 @@ static bool sdcard_isReady(void) {
  *
  */
 static sdcardOperationStatus_e sdcard_endWriteBlocks(void) {
+    uint8_t token = SDCARD_MULTIPLE_BLOCK_WRITE_STOP_TOKEN;
     sdcard.multiWriteBlocksRemain = 0;
-    // 8 dummy clocks to guarantee N_WR clocks between the last card response and this token
-    spiTransferByte(sdcard.instance, 0xFF);
-    spiTransferByte(sdcard.instance, SDCARD_MULTIPLE_BLOCK_WRITE_STOP_TOKEN);
+
+    // Note that this does not release the CS at the end of the transaction
+    busSegment_t segments[] = {
+        // 8 dummy clocks to guarantee N_WR clocks between the last card response and this token
+        {.u.buffers = {NULL, NULL}, 1, false, NULL},
+        {.u.buffers = {&token, NULL}, sizeof(token), false, NULL},
+        {.u.link = {NULL, NULL}, 0, true, NULL},
+    };
+
+    spiSequence(&sdcard.dev, &segments[0]);
+
+    // Block pending completion of SPI access
+    spiWait(&sdcard.dev);
+
     // Card may choose to raise a busy (non-0xFF) signal after at most N_BR (1 byte) delay
-    if (sdcard_waitForNonIdleByte(1) == 0xFF) {
+    if (sdcard_waitForNonIdleByte(1) == SDCARD_IDLE_TOKEN) {
         sdcard.state = SDCARD_STATE_READY;
         return SDCARD_OPERATION_SUCCESS;
     } else {
@@ -603,7 +684,6 @@ bool sdcard_poll(void) {
 doMore:
     switch (sdcard.state) {
     case SDCARD_STATE_RESET:
-        sdcard_select();
         initStatus = sdcard_sendCommand(SDCARD_COMMAND_GO_IDLE_STATE, 0);
         sdcard_deselect();
         if (initStatus == SDCARD_R1_STATUS_BIT_IDLE) {
@@ -633,7 +713,6 @@ doMore:
             }
             // Now fetch the CSD and CID registers
             if (sdcard_fetchCSD()) {
-                sdcard_select();
                 uint8_t status = sdcard_sendCommand(SDCARD_COMMAND_SEND_CID, 0);
                 if (status == 0) {
                     // Keep the card selected to receive the response block
@@ -658,7 +737,7 @@ doMore:
                 goto doMore;
             }
             // Now we're done with init and we can switch to the full speed clock (<25MHz)
-            spiSetDivisor(sdcard.instance, SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER);
+            spiSetClkDivisor(&sdcard.dev, SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER);
             sdcard.multiWriteBlocksRemain = 0;
             sdcard.state = SDCARD_STATE_READY;
             goto doMore;
@@ -666,45 +745,10 @@ doMore:
         break;
     case SDCARD_STATE_SENDING_WRITE:
         // Have we finished sending the write yet?
-        sendComplete = false;
-#if defined(USE_HAL_DRIVER) && !defined(STM32H7)
-        if (sdcard.useDMAForTx && DMA_GET_FLAG_STATUS(sdcard.dma, DMA_IT_TCIF)) {
-            //Clear both flags after transfer
-            DMA_CLEAR_FLAG(sdcard.dma, DMA_IT_TCIF);
-            DMA_CLEAR_FLAG(sdcard.dma, DMA_IT_HTIF);
-            // Drain anything left in the Rx FIFO (we didn't read it during the write)
-            while (LL_SPI_IsActiveFlag_RXNE(sdcard.instance)) {
-                sdcard.instance->DR;
-            }
-            // Wait for the final bit to be transmitted
-            while (spiIsBusBusy(sdcard.instance)) {
-            }
-            LL_SPI_DisableDMAReq_TX(sdcard.instance);
-            sendComplete = true;
-        }
-#elif !defined(STM32H7)
-#ifdef STM32F4
-        if (sdcard.useDMAForTx && DMA_GetFlagStatus(sdcard.dma->ref, sdcard.dma->completeFlag) == SET) {
-            DMA_ClearFlag(sdcard.dma->ref, sdcard.dma->completeFlag);
-#else
-        if (sdcard.useDMAForTx && DMA_GetFlagStatus(sdcard.dma->completeFlag) == SET) {
-            DMA_ClearFlag(sdcard.dma->completeFlag);
-#endif
-            DMA_Cmd(sdcard.dma->ref, DISABLE);
-            // Drain anything left in the Rx FIFO (we didn't read it during the write)
-            while (SPI_I2S_GetFlagStatus(sdcard.instance, SPI_I2S_FLAG_RXNE) == SET) {
-                sdcard.instance->DR;
-            }
-            // Wait for the final bit to be transmitted
-            while (spiIsBusBusy(sdcard.instance)) {
-            }
-            SPI_I2S_DMACmd(sdcard.instance, SPI_I2S_DMAReq_Tx, DISABLE);
-            sendComplete = true;
-        }
-#endif
-        if (!sdcard.useDMAForTx) {
+        sendComplete = !spiIsBusy(&sdcard.dev);
+        if (!spiUseDMA(&sdcard.dev)) {
             // Send another chunk
-            spiTransfer(sdcard.instance, sdcard.pendingOperation.buffer + SDCARD_NON_DMA_CHUNK_SIZE * sdcard.pendingOperation.chunkIndex, NULL, SDCARD_NON_DMA_CHUNK_SIZE);
+            spiReadWriteBuf(&sdcard.dev, sdcard.pendingOperation.buffer + SDCARD_NON_DMA_CHUNK_SIZE * sdcard.pendingOperation.chunkIndex, NULL, SDCARD_NON_DMA_CHUNK_SIZE);
             sdcard.pendingOperation.chunkIndex++;
             sendComplete = sdcard.pendingOperation.chunkIndex == SDCARD_BLOCK_SIZE / SDCARD_NON_DMA_CHUNK_SIZE;
         }
@@ -873,7 +917,6 @@ doMore:
         break;
     case SDCARD_STATE_READY:
         // We're not continuing a multi-block write so we need to send a single-block write command
-        sdcard_select();
         // Standard size cards use byte addressing, high capacity cards use block addressing
         status = sdcard_sendCommand(SDCARD_COMMAND_WRITE_BLOCK, sdcard.highCapacity ? blockIndex : blockIndex * SDCARD_BLOCK_SIZE);
         if (status != 0) {
@@ -921,7 +964,6 @@ sdcardOperationStatus_e sdcard_beginWriteBlocks(uint32_t blockIndex, uint32_t bl
             return SDCARD_OPERATION_BUSY;
         }
     }
-    sdcard_select();
     if (
         sdcard_sendAppCommand(SDCARD_ACOMMAND_SET_WR_BLOCK_ERASE_COUNT, blockCount) == 0
         && sdcard_sendCommand(SDCARD_COMMAND_WRITE_MULTIPLE_BLOCK, sdcard.highCapacity ? blockIndex : blockIndex * SDCARD_BLOCK_SIZE) == 0
@@ -963,7 +1005,6 @@ bool sdcard_readBlock(uint32_t blockIndex, uint8_t *buffer, sdcard_operationComp
 #ifdef SDCARD_PROFILING
     sdcard.pendingOperation.profileStartTime = micros();
 #endif
-    sdcard_select();
     // Standard size cards use byte addressing, high capacity cards use block addressing
     uint8_t status = sdcard_sendCommand(SDCARD_COMMAND_READ_SINGLE_BLOCK, sdcard.highCapacity ? blockIndex : blockIndex * SDCARD_BLOCK_SIZE);
     if (status == 0) {

--- a/src/main/drivers/sdcard.c
+++ b/src/main/drivers/sdcard.c
@@ -285,7 +285,10 @@ static uint8_t sdcard_sendCommand(uint8_t commandCode, uint32_t commandArgument)
     };
 
     uint8_t idleByte;
-    uint8_t cmdResponse;
+    // Stays at this sentinel if the pre-command idle-wait aborts, which skips the command and
+    // reply segments below entirely -- reachable for SDCARD_COMMAND_GO_IDLE_STATE, the one
+    // command sent regardless of idle-wait outcome.
+    uint8_t cmdResponse = SDCARD_IDLE_TOKEN;
 
     // Note that this does not release the CS at the end of the transaction
     busSegment_t segments[] = {

--- a/src/main/drivers/sdcard_standard.h
+++ b/src/main/drivers/sdcard_standard.h
@@ -201,6 +201,8 @@ typedef struct sdcardCSD_t {
 #define SDCARD_MULTIPLE_BLOCK_WRITE_START_TOKEN 0xFC
 #define SDCARD_MULTIPLE_BLOCK_WRITE_STOP_TOKEN  0xFD
 
+#define SDCARD_IDLE_TOKEN                       0xFF
+
 #define SDCARD_BLOCK_SIZE 512
 
 // Idle bit is set to 1 only when idle during intialization phase:

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -1032,10 +1032,6 @@ const clivalue_t valueTable[] = {
     { "ledstrip_grb_rgb",           VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_RGB_GRB }, PG_LED_STRIP_CONFIG, offsetof(ledStripConfig_t, ledstrip_grb_rgb) },
 #endif
 
-// PG_SDCARD_CONFIG
-#ifdef USE_SDCARD
-    { "sdcard_dma",                 VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SDCARD_CONFIG, offsetof(sdcardConfig_t, useDma) },
-#endif
 #ifdef USE_SDCARD_SDIO
     { "sdio_clk_bypass",            VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SDIO_CONFIG, offsetof(sdioConfig_t, clockBypass) },
     { "sdio_use_cache",             VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SDIO_CONFIG, offsetof(sdioConfig_t, useCache) },

--- a/src/main/pg/sdcard.c
+++ b/src/main/pg/sdcard.c
@@ -33,10 +33,9 @@
 #include "drivers/io.h"
 #include "drivers/dma.h"
 
-PG_REGISTER_WITH_RESET_FN(sdcardConfig_t, sdcardConfig, PG_SDCARD_CONFIG, 0);
+PG_REGISTER_WITH_RESET_FN(sdcardConfig_t, sdcardConfig, PG_SDCARD_CONFIG, 1);
 
 void pgResetFn_sdcardConfig(sdcardConfig_t *config) {
-    config->useDma = false;
 #ifdef SDCARD_SPI_INSTANCE
     config->enabled = 1;
     config->device = spiDeviceByInstance(SDCARD_SPI_INSTANCE);
@@ -67,10 +66,6 @@ void pgResetFn_sdcardConfig(sdcardConfig_t *config) {
     config->dmaIdentifier = (uint8_t)dmaGetIdentifier(SDCARD_DMA_CHANNEL_TX);
 #elif defined(SDIO_DMA)
     config->dmaIdentifier = (uint8_t)dmaGetIdentifier(SDIO_DMA);
-    config->useDma = true;
-#endif
-#if defined(SDCARD_DMA_CHANNEL)
-    config->dmaChannel = SDCARD_DMA_CHANNEL;
 #endif
 }
 #endif

--- a/src/main/pg/sdcard.h
+++ b/src/main/pg/sdcard.h
@@ -24,14 +24,14 @@
 #include "drivers/io.h"
 
 typedef struct sdcardConfig_s {
-    uint8_t useDma;
     uint8_t enabled;
     uint8_t device;
     ioTag_t cardDetectTag;
     ioTag_t chipSelectTag;
     uint8_t cardDetectInverted;
+    // SDIO mode only (drivers/sdcard_sdio_baremetal.c) -- the SPI-mode driver resolves its own
+    // DMA at the bus level via spiInitBusDMA(), no config-level identifier needed.
     uint8_t dmaIdentifier;
-    uint8_t dmaChannel;
 } sdcardConfig_t;
 
 PG_DECLARE(sdcardConfig_t, sdcardConfig);

--- a/src/main/target/MLTEMPF4/config.c
+++ b/src/main/target/MLTEMPF4/config.c
@@ -25,12 +25,9 @@
 
 #ifdef USE_TARGET_CONFIG
 
-#include "pg/sdcard.h"
-
 #include "telemetry/telemetry.h"
 
 void targetConfiguration(void) {
-    sdcardConfigMutable()->useDma = true;
     telemetryConfigMutable()->halfDuplex = 0;
 }
 #endif

--- a/src/main/target/MLTYPHF4/config.c
+++ b/src/main/target/MLTYPHF4/config.c
@@ -25,12 +25,9 @@
 
 #ifdef USE_TARGET_CONFIG
 
-#include "pg/sdcard.h"
-
 #include "telemetry/telemetry.h"
 
 void targetConfiguration(void) {
-    sdcardConfigMutable()->useDma = true;
     telemetryConfigMutable()->halfDuplex = 0;
 }
 #endif

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -21,6 +21,8 @@ include $(ROOT)/make/system-id.mk
 #   <test_name>_SRC
 #   <test_name>_DEFINES
 #   <test_name>_INCLUDE_DIRS
+#   <test_name>_CFLAGS
+#   <test_name>_LDFLAGS
 
 
 alignsensor_unittest_SRC := \
@@ -350,6 +352,35 @@ serial_uart_dma_claim_unittest_DEFINES := \
 
 sdcard_dma_claim_unittest_DEFINES := \
 		STM32F4
+
+
+sdcard_unittest_SRC := \
+		$(USER_DIR)/drivers/sdcard.c \
+		$(USER_DIR)/drivers/sdcard_standard.c
+
+sdcard_unittest_DEFINES := \
+		STM32F4 \
+		USE_SDCARD \
+		SDCARD_SPI_INITIALIZATION_CLOCK_DIVIDER=256 \
+		SDCARD_SPI_FULL_SPEED_CLOCK_DIVIDER=4 \
+		GPIO_Mode_IN=0 \
+		GPIO_Mode_OUT=1 \
+		GPIO_PuPd_NOPULL=0 \
+		GPIO_PuPd_UP=1 \
+		GPIO_OType_PP=0 \
+		GPIO_Speed_50MHz=0
+
+# extDevice_t.callbackArg is uint32_t (matches every 32-bit MCU target); the host test build is
+# 64-bit, so the driver's dev.callbackArg <-> sdcard_t* round-trip needs a lossless cast here:
+# -fno-pie/-no-pie keeps static addresses under 4GB so the uint32_t round-trip stays exact,
+# matching what's always true on the real 32-bit target.
+sdcard_unittest_CFLAGS := \
+		-Wno-int-to-pointer-cast \
+		-Wno-pointer-to-int-cast \
+		-fno-pie
+
+sdcard_unittest_LDFLAGS := \
+		-no-pie
 
 
 flight_failsafe_unittest_SRC := \
@@ -768,7 +799,7 @@ $$1_OBJS = $$(patsubst $$(TEST_DIR)%,$$(OBJECT_DIR)/$1%, $$(patsubst $$(USER_DIR
 $(OBJECT_DIR)/$1/%.c.o: $(USER_DIR)/%.c
 	@echo "compiling $$<" "$(STDOUT)"
 	$(V1) mkdir -p $$(dir $$@)
-	$(V1) $(CC) $(C_FLAGS) $(TEST_CFLAGS) \
+	$(V1) $(CC) $(C_FLAGS) $(TEST_CFLAGS) $($1_CFLAGS) \
                 $(foreach def,$($1_INCLUDE_DIRS),-I $(def)) \
                 $(foreach def,$($1_DEFINES),-D $(def)) \
                 -c $$< -o $$@
@@ -776,7 +807,7 @@ $(OBJECT_DIR)/$1/%.c.o: $(USER_DIR)/%.c
 $(OBJECT_DIR)/$1/%.c.o: $(TEST_DIR)/%.c
 	@echo "compiling test c file: $$<" "$(STDOUT)"
 	$(V1) mkdir -p $$(dir $$@)
-	$(V1) $(CC) $(C_FLAGS) $(TEST_CFLAGS) \
+	$(V1) $(CC) $(C_FLAGS) $(TEST_CFLAGS) $($1_CFLAGS) \
                 $(foreach def,$($1_INCLUDE_DIRS),-I $(def)) \
                 $(foreach def,$($1_DEFINES),-D $(def)) \
                 -c $$< -o $$@
@@ -784,7 +815,7 @@ $(OBJECT_DIR)/$1/%.c.o: $(TEST_DIR)/%.c
 $(OBJECT_DIR)/$1/$1.o: $(TEST_DIR)/$1.cc
 	@echo "compiling $$<" "$(STDOUT)"
 	$(V1) mkdir -p $$(dir $$@)
-	$(V1) $(CXX) $(CXX_FLAGS) $(TEST_CFLAGS)  \
+	$(V1) $(CXX) $(CXX_FLAGS) $(TEST_CFLAGS) $($1_CFLAGS) \
                 $(foreach def,$($1_INCLUDE_DIRS),-I $(def)) \
                 $(foreach def,$($1_DEFINES),-D $(def)) \
                 -c $$< -o $$@
@@ -796,7 +827,7 @@ $(OBJECT_DIR)/$1/$1 : $$($$1_OBJS) \
 
 	@echo "linking $$@" "$(STDOUT)"
 	$(V1) mkdir -p $(dir $$@)
-	$(V1) $(CXX) $(CXX_FLAGS) $(LDFLAGS) $$^ -o $$@
+	$(V1) $(CXX) $(CXX_FLAGS) $(LDFLAGS) $($1_LDFLAGS) $$^ -o $$@
 
 test_$1: $(OBJECT_DIR)/$1/$1
 	$(V1) $$< $$(EXEC_OPTS) "$(STDOUT)" && echo "running $$@: PASS"

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -691,6 +691,14 @@ endif
 TEST_SRC = $(sort $(wildcard $(TEST_DIR)/*.cc))
 TESTS = $(TEST_SRC:$(TEST_DIR)/%.cc=%)
 
+# sdcard_unittest relies on a uint32_t<->pointer round-trip that is only lossless when the
+# process image sits under 4GB (forced via -fno-pie/-no-pie on Linux/ELF). macOS's ld64 does not
+# honor that flag the same way and offers no equivalent guarantee, so the test cannot run
+# reliably there; excluded rather than risk a silent wrong-pointer segfault.
+ifdef MACOSX
+TESTS := $(filter-out sdcard_unittest, $(TESTS))
+endif
+
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
 GTEST_HEADERS = $(GTEST_DIR)/inc/gtest/*.h

--- a/src/test/unit/sdcard_dma_claim_unittest.cc
+++ b/src/test/unit/sdcard_dma_claim_unittest.cc
@@ -28,26 +28,21 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
-// Mirrors sdcardDmaClaim() (drivers/sdcard.c) and sdioDmaClaim() (drivers/sdio_f4xx.c,
-// drivers/sdio_f7xx.c -- byte-identical body, confirmed by direct read) rather than compiling
-// those files. Real-compile was investigated, not assumed disproportionate: sdcard.c's
-// SDCARD_STATE_SENDING_WRITE completion path (STM32F4 branch) needs a real DMA_Stream_TypeDef
-// with ->ref/->completeFlag fields, a two-arg DMA_GetFlagStatus()/DMA_ClearFlag() pair distinct
-// from the one-arg mock already in test/unit/platform.h, DMA_Cmd(), SPI_I2S_GetFlagStatus(),
-// LL_SPI_DisableDMAReq_TX(), and direct ->DR register access -- none of which the file's own
-// DMA-claim logic uses, but all of which must still link since the whole .c compiles as one
-// translation unit. sdio_f4xx.c/f7xx.c need the same class of surface an order of magnitude
-// larger (118 direct SDIO->/RCC-> field accesses, real GPIO AF config, NVIC). Both are the
-// same disproportionate-mocking case bus_spi_ll.c/bus_spi_stdperiph.c already were in
-// feat/dma-ll-unittest-infra (20+ mocks needed for functions that weren't even the test
-// target). Follows the same mirror-with-fake-DMA-state convention already established for
-// uartDmaClaim() in serial_uart_dma_claim_unittest.cc.
+// Mirrors sdioDmaClaim() (drivers/sdio_f4xx.c, drivers/sdio_f7xx.c -- byte-identical body,
+// confirmed by direct read) rather than compiling those files: they need 118 direct
+// SDIO->/RCC-> field accesses, real GPIO AF config, and NVIC -- the same disproportionate-
+// mocking case bus_spi_ll.c/bus_spi_stdperiph.c already were in feat/dma-ll-unittest-infra
+// (20+ mocks needed for functions that weren't even the test target). Follows the same
+// mirror-with-fake-DMA-state convention already established for uartDmaClaim() in
+// serial_uart_dma_claim_unittest.cc.
 //
-// sdcard_init() (SPI mode) can be called from both fc_init.c (boot) and
-// usbd_storage_sd_spi.c (USB MSC passthrough). SD_Initialize_LL() (SDIO mode) can be called
-// from both sdcard_sdio_baremetal.c (boot) and usbd_storage_sdio.c (USB MSC passthrough). In
-// both cases the second call is a legitimate reopen of the same OWNER_SDCARD claim, not a
-// conflict, and must not be misidentified as one now that the caller-side return check exists.
+// SD_Initialize_LL() (SDIO mode) can be called from both sdcard_sdio_baremetal.c (boot) and
+// usbd_storage_sdio.c (USB MSC passthrough). The second call is a legitimate reopen of the
+// same OWNER_SDCARD claim, not a conflict, and must not be misidentified as one now that the
+// caller-side return check exists.
+//
+// sdcard.c's SPI-mode driver has no DMA claim of its own -- DMA ownership for that path is
+// resolved once at the bus level by spiInitBusDMA(), covered by bus_spi_unittest.cc.
 namespace {
 
 resourceOwner_e fakeOwner = OWNER_FREE;
@@ -75,13 +70,6 @@ bool fakeDmaAllocate(dmaIdentifier_e, resourceOwner_e owner, uint8_t resourceInd
     return true;
 }
 
-bool sdcardDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
-    if (fakeDmaGetOwner(identifier) == owner && fakeDmaGetResourceIndex(identifier) == resourceIndex) {
-        return true;
-    }
-    return fakeDmaAllocate(identifier, owner, resourceIndex);
-}
-
 bool sdioDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t resourceIndex) {
     if (fakeDmaGetOwner(identifier) == owner && fakeDmaGetResourceIndex(identifier) == resourceIndex) {
         return true;
@@ -92,39 +80,6 @@ bool sdioDmaClaim(dmaIdentifier_e identifier, resourceOwner_e owner, uint8_t res
 const dmaIdentifier_e kStream = DMA1_ST3_HANDLER;
 
 }  // namespace
-
-// sdcardDmaClaim() -- SPI-mode (drivers/sdcard.c), real callers always pass OWNER_SDCARD / index 0.
-
-TEST(SdcardDmaClaimUnittest, FirstClaimOnFreeStreamSucceeds) {
-    resetFakeDmaState();
-    EXPECT_TRUE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
-    EXPECT_EQ(fakeOwner, OWNER_SDCARD);
-}
-
-TEST(SdcardDmaClaimUnittest, UsbMscReopenBySameOwnerAndIndexSucceeds) {
-    resetFakeDmaState();
-    fakeOwner = OWNER_SDCARD;
-    fakeResourceIndex = 0;
-    // sdcard_init() called again from usbd_storage_sd_spi.c after fc_init.c already claimed it.
-    EXPECT_TRUE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
-}
-
-TEST(SdcardDmaClaimUnittest, ConflictWithForeignOwnerFails) {
-    resetFakeDmaState();
-    fakeOwner = OWNER_SPI_SDI;
-    fakeResourceIndex = 0;
-    EXPECT_FALSE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
-    // failed claim must not disturb the existing owner's bookkeeping.
-    EXPECT_EQ(fakeOwner, OWNER_SPI_SDI);
-}
-
-TEST(SdcardDmaClaimUnittest, SameOwnerDifferentResourceIndexFails) {
-    resetFakeDmaState();
-    fakeOwner = OWNER_SDCARD;
-    fakeResourceIndex = 1;
-    // spec-level guard: same owner enum alone is not sufficient, index must match too.
-    EXPECT_FALSE(sdcardDmaClaim(kStream, OWNER_SDCARD, 0));
-}
 
 // sdioDmaClaim() -- SDIO-mode (drivers/sdio_f4xx.c, drivers/sdio_f7xx.c), same real callers
 // always pass OWNER_SDCARD / index 0.

--- a/src/test/unit/sdcard_unittest.cc
+++ b/src/test/unit/sdcard_unittest.cc
@@ -311,3 +311,20 @@ TEST(SdcardUnittest, SilentBusNeverReachesReadyAndEscalatesToNotPresent) {
     EXPECT_FALSE(sdcard_isFunctional());
     EXPECT_FALSE(sdcard_isInitialized());
 }
+
+TEST(SdcardUnittest, PersistentlyBusyBusBeforeCmd0DoesNotAdvancePastReset) {
+    resetSdcardTestState();
+    // 8 non-idle bytes exhausts the idle-wait budget before CMD0's command and R1-reply
+    // segments ever run: sdcard_sendCommand()'s BUS_ABORT-before-transmission path still lets
+    // SDCARD_COMMAND_GO_IDLE_STATE fall through to `return cmdResponse`, so this must not
+    // return a stale/undefined byte that could be misread as SDCARD_R1_STATUS_BIT_IDLE.
+    static const uint8_t busyPreamble[8] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    scriptBytes(busyPreamble, sizeof(busyPreamble));
+
+    sdcard_init(&testConfig);
+    ASSERT_TRUE(sdcard_isFunctional());
+
+    EXPECT_FALSE(sdcard_poll());
+    EXPECT_FALSE(sdcard_isInitialized());
+    EXPECT_TRUE(sdcard_isFunctional()); // one failed attempt is not yet NOT_PRESENT
+}

--- a/src/test/unit/sdcard_unittest.cc
+++ b/src/test/unit/sdcard_unittest.cc
@@ -1,0 +1,313 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+
+extern "C" {
+
+#include "platform.h"
+
+#if !defined(UNUSED)
+#define UNUSED(x) (void)(x)
+#endif
+
+#include "drivers/bus.h"
+#include "drivers/bus_spi.h"
+#include "drivers/io.h"
+#include "drivers/time.h"
+
+#include "pg/sdcard.h"
+
+#include "drivers/sdcard.h"
+#include "drivers/sdcard_standard.h"
+
+// Real driver under test calls into this fake bus_spi.h/io.h/time.h surface instead of
+// bus_spi.c: sdcard.c only ever reaches the SPI bus through spiSequence()'s segment API, so
+// scripting responses at that one boundary is enough to drive the real command/data-block state
+// machine -- same technique bus_spi_unittest.cc uses one layer down (fake DMA registration
+// instead of fake bus_spi.h calls) to let its own target file link and run host-side.
+
+static timeMs_t fakeMillis;
+
+timeMs_t millis(void) {
+    return fakeMillis;
+}
+
+timeUs_t micros(void) {
+    return fakeMillis * 1000;
+}
+
+void delay(timeMs_t ms) {
+    fakeMillis += ms;
+}
+
+void delayMicroseconds(timeUs_t us) {
+    UNUSED(us);
+}
+
+static void resetFakeMillis(void) {
+    fakeMillis = 0;
+}
+
+static void testAdvanceMillis(timeMs_t delta) {
+    fakeMillis += delta;
+}
+
+IO_t IOGetByTag(ioTag_t tag) {
+    UNUSED(tag);
+    return (IO_t)1;
+}
+
+void IOInit(IO_t io, resourceOwner_e owner, uint8_t index) {
+    UNUSED(io); UNUSED(owner); UNUSED(index);
+}
+
+void IOConfigGPIO(IO_t io, ioConfig_t cfg) {
+    UNUSED(io); UNUSED(cfg);
+}
+
+void IOHi(IO_t io) {
+    UNUSED(io);
+}
+
+void IOLo(IO_t io) {
+    UNUSED(io);
+}
+
+bool IORead(IO_t io) {
+    UNUSED(io);
+    return true;
+}
+
+// Scripted card-response byte stream. sdcard.c's own idleCount-bounded retries (not a loop cap
+// here) guarantee spiSequence() below always terminates.
+static uint8_t responseBytes[128];
+static int responseLen;
+static int responseIndex;
+
+static void resetResponseScript(void) {
+    responseLen = 0;
+    responseIndex = 0;
+}
+
+static void scriptBytes(const uint8_t *bytes, int count) {
+    for (int i = 0; i < count; i++) {
+        responseBytes[responseLen++] = bytes[i];
+    }
+}
+
+// Once the script is exhausted, behave like a silent bus that never leaves the idle state --
+// matches a card that has stopped responding, and is what drives the adversarial test's
+// escalation to SDCARD_STATE_NOT_PRESENT rather than a hang.
+static uint8_t popResponseByte(void) {
+    if (responseIndex < responseLen) {
+        return responseBytes[responseIndex++];
+    }
+    return SDCARD_IDLE_TOKEN;
+}
+
+static busDevice_t fakeBus;
+
+bool spiSetBusInstance(extDevice_t *dev, uint32_t device) {
+    UNUSED(device);
+    dev->bus = &fakeBus;
+    return true;
+}
+
+void spiSetClkDivisor(const extDevice_t *dev, uint16_t divisor) {
+    UNUSED(dev); UNUSED(divisor);
+}
+
+uint16_t spiCalculateDivider(uint32_t freq) {
+    UNUSED(freq);
+    return 2;
+}
+
+// Mirrors the polled segment loop in bus_spi_ll.c: read segments pull from the scripted
+// response queue, write-only/filler segments don't touch it, and BUS_BUSY/BUS_ABORT/BUS_READY
+// are honored exactly as the real bus does.
+void spiSequence(const extDevice_t *dev, busSegment_t *segments) {
+    busDevice_t *bus = dev->bus;
+    bus->curSegment = segments;
+
+    while (bus->curSegment->len) {
+        busSegment_t *segment = (busSegment_t *)bus->curSegment;
+
+        if (segment->u.buffers.rxData) {
+            for (int i = 0; i < segment->len; i++) {
+                segment->u.buffers.rxData[i] = popResponseByte();
+            }
+        }
+
+        bool segmentComplete = true;
+        if (segment->callback) {
+            switch (segment->callback(dev->callbackArg)) {
+            case BUS_BUSY:
+                segmentComplete = false;
+                break;
+            case BUS_ABORT:
+                return;
+            case BUS_READY:
+            default:
+                break;
+            }
+        }
+
+        if (segmentComplete) {
+            bus->curSegment = segment + 1;
+        }
+    }
+}
+
+void spiWait(const extDevice_t *dev) {
+    UNUSED(dev);
+}
+
+void spiRelease(const extDevice_t *dev) {
+    UNUSED(dev);
+}
+
+bool spiIsBusy(const extDevice_t *dev) {
+    UNUSED(dev);
+    // spiSequence() above always runs a segment chain to completion synchronously.
+    return false;
+}
+
+bool spiUseDMA(const extDevice_t *dev) {
+    UNUSED(dev);
+    return false;
+}
+
+void spiReadWriteBuf(const extDevice_t *dev, uint8_t *txData, uint8_t *rxData, int len) {
+    UNUSED(dev); UNUSED(txData);
+    if (rxData) {
+        for (int i = 0; i < len; i++) {
+            rxData[i] = popResponseByte();
+        }
+    }
+}
+
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+sdcardConfig_t testConfig;
+
+void resetSdcardTestState() {
+    resetFakeMillis();
+    resetResponseScript();
+    memset(&fakeBus, 0, sizeof(fakeBus));
+    memset(&testConfig, 0, sizeof(testConfig));
+    testConfig.enabled = 1;
+    testConfig.device = 0;
+    testConfig.chipSelectTag = 0;
+    testConfig.cardDetectTag = 0; // no detect pin -> sdcard_isInserted() always true
+}
+
+// CMD0/CMD8/ACMD41/CMD58/CMD9/CMD10 init sequence for a version-2 (SDHC) card, scripted
+// against the SD physical layer spec's R1/R7/data-token wire format -- not copied from any
+// driver output. Each command's [idle-wait byte, R1 reply byte] pair precedes its data phase.
+void scriptSuccessfulHighCapacityInit(void) {
+    static const uint8_t cmd0[] = {0xFF, 0x01};                          // GO_IDLE_STATE -> idle
+    static const uint8_t cmd8[] = {0xFF, 0x01};                          // SEND_IF_COND -> idle
+    static const uint8_t ifCondReply[] = {0x00, 0x00, 0x01, 0xAB};       // echoed voltage + check pattern
+    static const uint8_t cmd55[] = {0xFF, 0x01};                         // APP_CMD (response ignored)
+    static const uint8_t cmd41[] = {0xFF, 0x00};                         // ACMD41 -> init done
+    static const uint8_t cmd58[] = {0xFF, 0x00};                         // READ_OCR -> ok
+    static const uint8_t ocr[] = {0x40, 0x00, 0x00, 0x00};               // bit 30 set: high capacity
+    static const uint8_t cmd9[] = {0xFF, 0x00};                          // SEND_CSD -> ok
+    static const uint8_t csdToken[] = {0xFE};
+    // CSD v2: bits[0:1]=01 (structure v2), CSIZE(bits 58:79)=0 -> (0+1)*1024 = 1024 blocks,
+    // bit 127 (TRAILER, LSB of last byte) = 1. All other fields unused by sdcard_fetchCSD().
+    static const uint8_t csd[16] = {0x40, 0, 0, 0, 0, 0, 0, 0x00, 0x00, 0x00, 0, 0, 0, 0, 0, 0x01};
+    static const uint8_t csdCrc[] = {0x00, 0x00};
+    static const uint8_t cmd10[] = {0xFF, 0x00};                         // SEND_CID -> ok
+    static const uint8_t cidToken[] = {0xFE};
+    static const uint8_t cid[16] = {
+        0x03,                         // manufacturerID
+        0x54, 0x4D,                   // oemID = "TM"
+        0x53, 0x44, 0x54, 0x53, 0x54, // productName = "SDTST"
+        0x10,                         // revision 1.0
+        0x12, 0x34, 0x56, 0x78,       // productSerial
+        0xA1, 0x86,                   // productionYear=2024, productionMonth=6
+        0x00,                         // CRC (unused)
+    };
+    static const uint8_t cidCrc[] = {0x00, 0x00};
+
+    scriptBytes(cmd0, sizeof(cmd0));
+    scriptBytes(cmd8, sizeof(cmd8));
+    scriptBytes(ifCondReply, sizeof(ifCondReply));
+    scriptBytes(cmd55, sizeof(cmd55));
+    scriptBytes(cmd41, sizeof(cmd41));
+    scriptBytes(cmd58, sizeof(cmd58));
+    scriptBytes(ocr, sizeof(ocr));
+    scriptBytes(cmd9, sizeof(cmd9));
+    scriptBytes(csdToken, sizeof(csdToken));
+    scriptBytes(csd, sizeof(csd));
+    scriptBytes(csdCrc, sizeof(csdCrc));
+    scriptBytes(cmd10, sizeof(cmd10));
+    scriptBytes(cidToken, sizeof(cidToken));
+    scriptBytes(cid, sizeof(cid));
+    scriptBytes(cidCrc, sizeof(cidCrc));
+}
+
+} // namespace
+
+TEST(SdcardUnittest, HighCapacityCardReachesReadyInOnePoll) {
+    resetSdcardTestState();
+    scriptSuccessfulHighCapacityInit();
+
+    sdcard_init(&testConfig);
+    ASSERT_TRUE(sdcard_isFunctional());
+
+    EXPECT_TRUE(sdcard_poll());
+    EXPECT_TRUE(sdcard_isInitialized());
+
+    const sdcardMetadata_t *metadata = sdcard_getMetadata();
+    EXPECT_EQ(1024u, metadata->numBlocks);
+    EXPECT_EQ(0x03, metadata->manufacturerID);
+    EXPECT_EQ(0x544D, metadata->oemID);
+    EXPECT_EQ(2024, metadata->productionYear);
+    EXPECT_EQ(6, metadata->productionMonth);
+}
+
+TEST(SdcardUnittest, SilentBusNeverReachesReadyAndEscalatesToNotPresent) {
+    resetSdcardTestState();
+    // Empty script: popResponseByte() always returns SDCARD_IDLE_TOKEN, so every reply-wait
+    // times out after SDCARD_MAXIMUM_BYTE_DELAY_FOR_CMD_REPLY retries without ever reporting
+    // the R1 idle-status bit sdcard_poll() needs to advance past SDCARD_STATE_RESET.
+
+    sdcard_init(&testConfig);
+    ASSERT_TRUE(sdcard_isFunctional());
+
+    // SDCARD_MAX_CONSECUTIVE_FAILURES resets, each gated by SDCARD_TIMEOUT_INIT_MILLIS.
+    for (int attempt = 0; attempt < 8; attempt++) {
+        EXPECT_FALSE(sdcard_poll());
+        EXPECT_FALSE(sdcard_isInitialized());
+        testAdvanceMillis(250);
+    }
+    sdcard_poll();
+
+    EXPECT_FALSE(sdcard_isFunctional());
+    EXPECT_FALSE(sdcard_isInitialized());
+}


### PR DESCRIPTION
AI Generated pull-request

## Summary

- Migrates `src/main/drivers/sdcard.c` (SPI mode) off the legacy polled SPI API onto `extDevice_t`/`busSegment_t`/`spiSequence()` — the mechanism every other EF driver (`accgyro_mpu.c`, `flash_m25p16.c`, `flash_w25n.c`) already uses. DMA ownership for this path is now resolved once at the bus level by `spiInitBusDMA()`, not by a per-driver claim.
- Deletes the EF-only `sdcardDmaClaim()` ownership-check wrapper and its ~45-line hand-rolled `LL_DMA_Init`/`DMA_Init` write path entirely.
- Removes the now-dead `useDma`/`dmaChannel` config fields and the `sdcard_dma` CLI setting (`PG_SDCARD_CONFIG` version bumped 0→1). `dmaIdentifier` is kept — it is still read by the independent SDIO-mode driver (`sdcard_sdio_baremetal.c`), which this migration does not touch.
- Deliberately keeps EF's single-file (non-vtable) driver structure and per-target raw SPI clock divisors, rather than adopting BF's 3-file vtable split — the gap this closes is the transfer mechanism, not file layout.
- Ports master's fix (not 4.5-maintenance's) for one BF-branch-register item: master removed `sdcardSpi_init()`'s forced SPI mode 3 (CPOL=1/CPHA=1); the SD-card SPI spec wants mode 0. EF's legacy code never forced mode 3 either, so this is a do-not-regress carry-forward, not a behavior change.
- Preserves EF's bounded init-timeout busy-wait (BF's equivalent is an unbounded `spiWait()`) so a board with no card fitted fails fast instead of hanging — verified on real hardware, see Test plan.
- Adds `src/test/unit/sdcard_unittest.cc`: deleting the raw-DMA code is what makes `sdcard.c` host-compilable for the first time (its old F4 completion path needed a two-arg `DMA_GetFlagStatus`/`DMA_ClearFlag` pair the host stubs don't provide). The new test compiles the real driver against a scripted-SPI-response fake bus layer and drives the actual SD command/data-block state machine to `SDCARD_STATE_READY` for a high-capacity card, plus an adversarial silent-bus case that must escalate to `SDCARD_STATE_NOT_PRESENT` rather than hang. Mutation-verified.
- Adds two new opt-in Makefile hooks (`<test>_CFLAGS`, `<test>_LDFLAGS`) needed to host-compile a driver that round-trips a pointer through `extDevice_t`'s `uint32_t callbackArg` — lossless on the real 32-bit MCU target, so the test forces `-fno-pie`/`-no-pie` to keep the 64-bit host build's addresses under 4GB.
- Trims `sdcard_dma_claim_unittest.cc` to its still-valid SDIO half; the SPI-mode `sdcardDmaClaim()` half it mirrored no longer exists.

## Known follow-up (not fixed in this PR)

Removing `useDma`/`dmaChannel` from `sdcardConfig_t` orphans the `SDCARD_DMA_CHANNEL` `#define` in ~66 target `target.h` files (its only reader was the code this PR deletes). Harmless — it's dead config text, not a compile or runtime issue — but a mechanical 66-file cleanup is out of proportion to this PR's scope. Flagging here rather than filing separately unless requested.

## Test plan

- [x] `make clean_test && make test` — 49/49 test binaries pass, including the new `sdcard_unittest` (2 tests, mutation-verified) and the trimmed `sdcard_dma_claim_unittest` (4 SDIO tests)
- [x] Bench targets — `HELIOSPRING TUNERCF405 SKYSTARSF405AIO PYRODRONEF7 FOXEERF722V4 FOXEERF405 APEXF7 TMOTORF7 MATEKF411 NBDHMBF4PRO ALIENWHOOPF7 CRAZYFLIE2 WORMFC SITL` — 14/14 succeeded
- [x] Full `USE_SDCARD` fleet sweep (71 targets — the only ones this change can affect; none of the bench targets above exercise the SPI-mode code path) — confirmed on independent build infrastructure: `71 succeeded, 0 failed`
- [x] Real-hardware no-card boot test on FOXEERF722V4, via a local (not committed) `USE_SDCARD_SPI` enable on its otherwise-unused SPI3/PC13 — flashed and confirmed: board boots cleanly, gyro/accel functional, `sd_info` reports `SD card: Startup failed` (correct result with no card-detect pin wired: `sdcard_isInserted()` is always true by design, so the driver correctly escalates to `SDCARD_STATE_NOT_PRESENT` rather than hanging), `resource` shows `SDCARD_CS 1 C13` claimed with no conflicts. This is exactly the regression class this PR's bounded-timeout preservation guards against: BF's equivalent `spiWait()` is unbounded, EF's original had a bounded fallback, this PR keeps EF's bound, and it fails fast as designed instead of hanging boot.
- [ ] Real SD-card positive-path verification — no board in this fleet has a card fitted; out of scope for this PR, flagged as a known gap




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved SD card SPI transfer handling for more consistent initialization and data access.
  - Simplified SD card configuration by removing obsolete SPI DMA options; SDIO-specific DMA settings remain available.
  - Improved handling of unresponsive cards so they are detected as unavailable instead of remaining stuck.

- **Documentation**
  - Clarified bus callback behavior for both polled and DMA-based transfers.

- **Tests**
  - Added coverage for high-capacity card initialization and repeated communication failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->