### PR TITLE
fix(drivers): refuse escserial TX-pin fallback for SIMONK/BLHELI/CASTLE

### DIFF
--- a/src/main/drivers/serial_escserial.c
+++ b/src/main/drivers/serial_escserial.c
@@ -558,6 +558,14 @@ static void resetBuffers(escSerial_t *escSerial) {
 static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSerialPortIndex_e portIndex, serialReceiveCallbackPtr callback, uint16_t output, uint32_t baud, portOptions_e options, uint8_t mode) {
     escSerial_t *escSerial = &(escSerialPorts[portIndex]);
     if (mode != PROTOCOL_KISSALL) {
+        // SIMONK/BLHELI/CASTLE need a fixed-baud periodic tick (TX) and a free-running
+        // edge-capture timebase (RX) on the timer channel at the same time; a shared
+        // channel can only run one of those, so RX's setup always destroys TX's.
+        // Refuse rather than open a connection that can never actually transmit.
+        if ((mode == PROTOCOL_SIMONK || mode == PROTOCOL_BLHELI || mode == PROTOCOL_CASTLE)
+            && escSerialConfig()->ioTag == IO_TAG_NONE) {
+            return NULL;
+        }
         const ioTag_t tag = motorConfig->ioTags[output];
         const timerHardware_t *timerHardware = timerAllocate(tag, OWNER_MOTOR, 0);
         if (timerHardware == NULL) {
@@ -586,7 +594,9 @@ static serialPort_t *openEscSerial(const motorDevConfig_t *motorConfig, escSeria
 #endif
             timerConfigure(escSerial->txTimerHardware, 0xffff, 1);
         } else {
-            // No separate TX pin configured - use RX pin for both TX and RX (fallback mode)
+            // No separate TX pin configured - use RX pin for both TX and RX (fallback mode).
+            // Safe here: PROTOCOL_KISS is the only mode left that reaches this without a
+            // dedicated TX pin, and it never configures the RX side of the shared channel.
             escSerial->txTimerHardware = escSerial->rxTimerHardware;
 #ifdef USE_HAL_DRIVER
             escSerial->txTimerHandle = escSerial->rxTimerHandle;


### PR DESCRIPTION
AI Generated pull-request

Follow-up to #1426 (spawned by #1408/#1427). Addresses one of the two open items — the TX/RX timer-channel clobber for SIMONK/BLHELI/CASTLE when no dedicated `ESCSERIAL_TIMER_TX_PIN` is configured.

**Root cause (deeper than the issue's original framing).** When `escSerialConfig()->ioTag == IO_TAG_NONE`, `openEscSerial()` aliases `txTimerHardware = rxTimerHardware` — TX and RX share one physical timer channel. For SIMONK/BLHELI/CASTLE, `serialTimerTxConfigBL()`/`escSerialTimerTxConfig()` configure that channel for a fixed-baud periodic tick (drives bit output), then `serialTimerRxConfigBL()`/`escSerialTimerRxConfig()` immediately `TIM_DeInit()` the same channel and reconfigure it as a free-running 0xFFFF timebase for edge-pulse-width capture. RX's setup always wins — it overwrites both the `timerChConfigCallbacks()` slot and the `ARR`/prescaler TX depends on. `openEscSerial()` returns a non-NULL port ("opens"), but the TX periodic tick never runs again, so it can never transmit. This is not fixable by combining callbacks — the two roles need incompatible timebases on the same counter, a hardware constraint, not just a software slot conflict.

`PROTOCOL_KISS`/`PROTOCOL_KISSALL` are unaffected — TX-only, no RX config touches the shared channel.

**Fix.** `openEscSerial()` now returns `NULL` before touching any hardware when SIMONK/BLHELI/CASTLE would hit this fallback, so `escprog`'s existing "Error starting ESC connection" path reports a clean, diagnosable failure instead of a connection that silently can't transmit.

**Behavior change on real hardware.** HELIOSPRING and the STM32F7X2 generic target (flashed on FOXEERF722V4) have no dedicated TX pin and were both used to hardware-verify #1427's `escprog bl` fallback path — that testing confirmed the connection "opens" but explicitly did not verify actual ESC communication (no ESC connected). With this PR, `escprog bl`/`sk`/`cc` (Castle) on those targets will now report a clean error instead. This is intentional — the prior "opens" state was never functionally correct.

**Not in scope here — real fix would need a separate timer channel entirely decoupled from the RX pin, purely as a periodic-tick interrupt source for TX (TX already bit-bangs the GPIO directly, so it doesn't need to own a real output pin, just an interrupt). That needs a new "find any free timer channel" allocator and likely a new resource-owner type — no upstream reference exists to check against. Left as a follow-up if wanted; commented on #1426 with both directions.**

The other open item in #1426 (motor-timer ownership conflict, no `timerAllocate()` release path) is unrelated to this file's timer-channel-sharing problem and is not touched here — no reference implementation exists on any branch (present-both with BF, tracked via BF #15655).

## Test plan
- [x] `make clean_test && make test` — 49/49 test binaries pass, 0 failures
- [x] `CCACHE_DISABLE=1 make -j<n>` — HELIOSPRING, TUNERCF405, SKYSTARSF405AIO, PYRODRONEF7, FOXEERF722V4, FOXEERF405, APEXF7, TMOTORF7, STM32F7X2, NERO, SITL — 11/11 succeeded, zero compiler warnings
- [x] Hardware re-verification on HELIOSPRING/FOXEERF722V4 that `escprog bl` now reports a clean CLI error (not a hang or crash) for targets with no dedicated TX pin — confirmed on both real HELIOSPRING (F4) and STM32F7X2/FOXEERF722V4 (F7/HAL) at commit `7acdd94a4`: `escprog bl 0` returns `###ERROR### Error starting ESC connection` cleanly, no hang
- [x] Post-failure sanity check on STM32F7X2/FOXEERF722V4: `diff` (full config dump) ran cleanly immediately after the failed `escprog bl 0` attempt — confirms the early `NULL` return leaves CLI and resource/timer state uncorrupted

## Review summary

| Check | Result |
|---|---|
| CodeRabbit local CLI | 0 findings |
| CodeRabbit GitHub bot | Formal review APPROVED, 0 findings; analyze ping confirmed guard placement (before any hardware touch) and exhaustive mode coverage |
| opencode (2nd opinion, pi hit daily rate limit) | PASS, no correctness issues |
| Codacy | SUCCESS, clean |
| CI | 11 build groups + test×2 + sitl all SUCCESS |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported SimonK, BLHeli, and Castle connections when no dedicated transmit pin is configured.
  * Retained shared-channel operation only for KISS mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

