### PR TITLE
fix(cli): exclude gyroregisters command on IMUF9001 targets

### DIFF
--- a/src/main/interface/cli.c
+++ b/src/main/interface/cli.c
@@ -2650,7 +2650,7 @@ static void cliGpsPassthrough(char *cmdline) {
 }
 #endif
 
-#if defined(USE_GYRO_REGISTER_DUMP) && !defined(SIMULATOR_BUILD)
+#if defined(USE_GYRO_REGISTER_DUMP) && !defined(SIMULATOR_BUILD) && !defined(USE_GYRO_IMUF9001)
 static void cliPrintGyroRegisters(uint8_t whichSensor) {
     cliPrintLinef("# WHO_AM_I    0x%X", gyroReadRegister(whichSensor, MPU_RA_WHO_AM_I));
     cliPrintLinef("# CONFIG      0x%X", gyroReadRegister(whichSensor, MPU_RA_CONFIG));
@@ -4585,7 +4585,7 @@ const clicmd_t cmdTable[] = {
 #ifdef USE_GPS
     CLI_COMMAND_DEF("gpspassthrough", "passthrough gps to serial", NULL, cliGpsPassthrough),
 #endif
-#if defined(USE_GYRO_REGISTER_DUMP) && !defined(SIMULATOR_BUILD)
+#if defined(USE_GYRO_REGISTER_DUMP) && !defined(SIMULATOR_BUILD) && !defined(USE_GYRO_IMUF9001)
     CLI_COMMAND_DEF("gyroregisters", "dump gyro config registers contents", NULL, cliDumpGyroRegisters),
 #endif
 #ifdef USE_GYRO_IMUF9001


### PR DESCRIPTION
AI Generated pull-request

## Summary
`gyroregisters` (`cliDumpGyroRegisters`/`cliPrintGyroRegisters`, `src/main/interface/cli.c`)
calls `gyroReadRegister()`, which issues a standard MPU-style single-byte SPI register-read
transaction. IMUF9001-based targets (HELIOSPRING, STRIXF10, MODE2FLUX) don't speak that
protocol — their real comms path is a custom packet protocol over `imufSendReceiveSpi()`.
Sending the wrong protocol returns whatever happens to be on the MISO line at that instant,
different on every call.

Fix: gate the command's static functions and its `CLI_COMMAND_DEF` registration with
`!defined(USE_GYRO_IMUF9001)`, matching the existing `reportimuferrors` gate immediately
below it in the same table. On IMUF9001 targets the command no longer exists, so the CLI's
normal unknown-command response applies instead of printing a fake register value.

Closes #1322.

## Test plan
- [x] Unit tests: `make test` — 100% pass
- [x] Build: HELIOSPRING, STRIXF10, MODE2FLUX (all 3 affected IMUF9001 targets) — succeed, zero warnings
- [x] Build: FOXEERF722V4, STELLARH7DEV (standard SPI-gyro regression targets) — succeed, zero warnings
- [x] Build: SITL — succeeds
- [x] Confirmed via `strings` on the built ELF: `gyroregisters` string absent from HELIOSPRING binary, present in FOXEERF722V4 binary
- [ ] Hardware verification: not required — command is removed at compile time, no runtime behavior change on any target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - The `gyroregisters` CLI command is no longer available in builds using the IMUF9001 gyro.
  - Other supported configurations continue to include the command when gyro register dumping is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->