### PR TITLE
fix(target): correct PYRODRONEF7 voltage meter scale

### DIFF
--- a/src/main/target/PYRODRONEF7/target.h
+++ b/src/main/target/PYRODRONEF7/target.h
@@ -124,7 +124,7 @@
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define CURRENT_METER_ADC_PIN   PC1
 #define VBAT_ADC_PIN            PC2
-#define DEFAULT_VOLTAGE_METER_SCALE                 160
+#define DEFAULT_VOLTAGE_METER_SCALE                 109
 #define RSSI_ADC_PIN            PC3
 #define DEFAULT_CURRENT_METER_SCALE 250                     // 3.3/120A  = 25mv/A
 

--- a/src/main/target/PYRODRONEF7/target.h
+++ b/src/main/target/PYRODRONEF7/target.h
@@ -124,7 +124,7 @@
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define CURRENT_METER_ADC_PIN   PC1
 #define VBAT_ADC_PIN            PC2
-#define DEFAULT_VOLTAGE_METER_SCALE                 109
+#define DEFAULT_VOLTAGE_METER_SCALE                 110
 #define RSSI_ADC_PIN            PC3
 #define DEFAULT_CURRENT_METER_SCALE 250                     // 3.3/120A  = 25mv/A
 


### PR DESCRIPTION
AI Generated pull-request

## Summary
- master's `DEFAULT_VOLTAGE_METER_SCALE` for PYRODRONEF7 is wrongly 160, matching Betaflight's own config-submodule default for this board — not an EF-introduced divergence.
- Confirmed wrong on real hardware (unsoldered FC, AIKON 32 ESC, 6S LiPo), tested on Betaflight 4.5.5 with `force_battery_cell_count = 6`: at scale 160, displayed voltage read 33.34V while a balance-lead LiPo voltage checker showed 22.9V — a ~45.6% overread.
- Corrected to 110, divider (10) and multiplier (1) unchanged. Re-tested at scale 110 on the same 6S pack: displayed voltage read 22.92V against the checker's 22.9V — within 0.02V, confirming 110 as correct.
- `DEFAULT_CURRENT_METER_SCALE` (250) is untouched — not verified against hardware in this pass.

## Test plan
- [x] Build passes: PYRODRONEF7
- [x] Bench-verified: PYRODRONEF7, unsoldered FC + AIKON 32 ESC + 6S LiPo, voltage checked against a balance-lead LiPo voltage checker/buzzer (not a real-aircraft flight test, no multimeter used)
- [x] Cross-checked against Betaflight 4.5.5 on the same hardware with `force_battery_cell_count = 6`: scale 160 read 33.34V (checker 22.9V), scale 110 read 22.92V (checker 22.9V)